### PR TITLE
Refactor `parser` and add comprehensive edge case tests for it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Dockerfile.cross
 
 symphony-controller
 symphony-chart*
+cover.htlm
 .read
 .snapshots
 .alpackages


### PR DESCRIPTION
This patch refactors the `parser.Parse*` functions, by split the validation
logic from the extraction logic. Now we use helper functions for schema validation
and type checking. Allowing reading to distinguish recursive walk logic, from
other mechanics used for parsing.

- Refactor `parseResource` function to use type specific parsing functions
- Introduce `TestParserEdgeCases` to cover various type mimatches and
  error conditions..
- Add `TestParseWithExpectedSchema` to validate schema extraction from
  objects


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
