### PR TITLE
add additional printer columns for ResourceGroup CRD

### DIFF
--- a/internal/resourcegroup/builder_schema.go
+++ b/internal/resourcegroup/builder_schema.go
@@ -358,6 +358,38 @@ var (
 			},
 		},
 	}
+	// additionalPrinterColumns specifies additional columns returned in Table output.
+	// See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details.
+	// Sample output for `kubectl get clusters`
+	//
+	// NAME            STATE    SYNCED   AGE
+	// testcluster29   ACTIVE   True     22d
+	defaultAdditionalPrinterColumns = []extv1.CustomResourceColumnDefinition{
+		// ResourceGroup instance state
+		{
+			Name:        "State",
+			Description: "The state of a ResourceGroup instance",
+			Priority:    0,
+			Type:        "string",
+			JSONPath:    ".status.state",
+		},
+		// ResourceGroup instance AllResourcesReady condition
+		{
+			Name:        "Synced",
+			Description: "Whether a ResourceGroup instance have all it's subresources ready",
+			Priority:    0,
+			Type:        "string",
+			JSONPath:    ".status.conditions[?(@.type==\"InstanceSynced\")].status",
+		},
+		// ResourceGroup instance age
+		{
+			Name:        "Age",
+			Description: "Age of the resource",
+			Priority:    0,
+			Type:        "date",
+			JSONPath:    ".metadata.creationTimestamp",
+		},
+	}
 )
 
 func JSONSchemaPropsToSpecSchema(jsonSchemaProps *apiextensions.JSONSchemaProps) (*spec.Schema, error) {
@@ -541,6 +573,7 @@ func newCRD(apiVersion, kind string, schema *extv1.JSONSchemaProps, ownerReferen
 					Subresources: &extv1.CustomResourceSubresources{
 						Status: &extv1.CustomResourceSubresourceStatus{},
 					},
+					AdditionalPrinterColumns: defaultAdditionalPrinterColumns,
 				},
 			},
 		},


### PR DESCRIPTION
This commit adds additional printer columns to the ResourceGroup
instance CRDs, which will be displayed when listing ResourceGroup
instances using `kubectl get` command. The additional columns are:

- `State`: The current state of the ResourceGroup instance. Found in
  `.status.state`
- Synced: Whether all subresources of the ResourceGroup are ready.
  Found in `status.conditions[?(@.type==\"InstanceSynced\")].status`
- Age: The age of the ResourceGroup instance. Found in
  `.metadata.creationTimestamp`


Sample kubectl output:
```bash
➜  ~ k get eksclusters
NAME            STATE    SYNCED   AGE
testcluster29   ACTIVE   True     22d
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
