### PR TITLE
Rename `ExpressionField` to `CELField`

### DIFF
--- a/internal/resourcegroup/builder.go
+++ b/internal/resourcegroup/builder.go
@@ -137,8 +137,8 @@ func (b *GraphBuilder) NewResourceGroup(rg *v1alpha1.ResourceGroup) (*ResourceGr
 		for _, celExpression := range celExpressions {
 			resourceVariables = append(resourceVariables, &ResourceVariable{
 				// Assume variables are static, we'll validate them later
-				Kind:            ResourceVariableKindStatic,
-				ExpressionField: celExpression,
+				Kind:     ResourceVariableKindStatic,
+				CELField: celExpression,
 			})
 		}
 
@@ -227,7 +227,7 @@ func (b *GraphBuilder) NewResourceGroup(rg *v1alpha1.ResourceGroup) (*ResourceGr
 	instanceRuntimeVariables := []*RuntimeVariable{}
 	for _, variable := range instance.Variables {
 		instanceRuntimeVariables = append(instanceRuntimeVariables, &RuntimeVariable{
-			Expression:   variable.ExpressionField.Expressions[0],
+			Expression:   variable.CELField.Expressions[0],
 			Kind:         variable.Kind,
 			Dependencies: allResources,
 			Resolved:     false,
@@ -468,8 +468,8 @@ func (b *GraphBuilder) buildInstanceResource(
 		path := ".status" + statusVariable.Path
 		statusVariable.Path = path
 		instanceVariables = append(instanceVariables, &ResourceVariable{
-			Kind:            ResourceVariableKindDynamic,
-			ExpressionField: statusVariable,
+			Kind:     ResourceVariableKindDynamic,
+			CELField: statusVariable,
 		})
 	}
 
@@ -508,7 +508,7 @@ func (b *GraphBuilder) buildInstanceSpecSchema(definition *v1alpha1.Definition) 
 	return instanceSchema, nil
 }
 
-func (b *GraphBuilder) buildStatusSchema(definition *v1alpha1.Definition, resources map[string]*Resource) (*extv1.JSONSchemaProps, []parser.ExpressionField, error) {
+func (b *GraphBuilder) buildStatusSchema(definition *v1alpha1.Definition, resources map[string]*Resource) (*extv1.JSONSchemaProps, []parser.CELField, error) {
 	// The instance resource has a schema defined using the "SimpleSchema" format.
 	unstructuredStatus := map[string]interface{}{}
 	err := yaml.UnmarshalStrict(definition.Status.Raw, &unstructuredStatus)

--- a/internal/resourcegroup/resource_variables.go
+++ b/internal/resourcegroup/resource_variables.go
@@ -23,6 +23,6 @@ const (
 )
 
 type ResourceVariable struct {
-	parser.ExpressionField
+	parser.CELField
 	Kind ResourceVariableKind
 }

--- a/internal/resourcegroup/runtime.go
+++ b/internal/resourcegroup/runtime.go
@@ -215,9 +215,9 @@ func (rt *RuntimeResourceGroup) ResolveResource(resource string) error {
 	}
 
 	rs := resolver.NewResolver(rt.Resources[resource].Object, exprValues)
-	exprFields := make([]parser.ExpressionField, len(rt.ResourceGroup.Resources[resource].Variables))
+	exprFields := make([]parser.CELField, len(rt.ResourceGroup.Resources[resource].Variables))
 	for i, v := range rt.ResourceGroup.Resources[resource].Variables {
-		exprFields[i] = v.ExpressionField
+		exprFields[i] = v.CELField
 	}
 	summary := rs.Resolve(exprFields)
 	if summary.Errors != nil {

--- a/internal/typesystem/parser/cel_field.go
+++ b/internal/typesystem/parser/cel_field.go
@@ -1,0 +1,40 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package parser
+
+import "k8s.io/kube-openapi/pkg/validation/spec"
+
+// CELField represents a field that contains CEL expressions in it. It
+// contains the path of the field in the resource, the CEL expressions
+// and the expected type of the field. The field may contain multiple
+// expressions.
+type CELField struct {
+	// Path is the path of the field in the resource (JSONPath-like)
+	// example: spec.template.spec.containers[0].env[0].value
+	// Since the object's we're dealing with are mainly made up of maps,
+	// arrays and native types, we can use a string to represent the path.
+	Path string
+	// Expressions is a list of CEL expressions in the field.
+	Expressions []string
+	// ExpectedType is the expected type of the field.
+	ExpectedType string
+	// ExpectedSchema is the expected schema of the field if it is a complex type.
+	// This is only set if the field is a OneShotCEL expression, and the schema
+	// is expected to be a complex type (object or array).
+	ExpectedSchema *spec.Schema
+	// StandaloneExpression is true if the field contains a single CEL expression
+	// that is not part of a larger string. example: "${foo}" is a standalone expression
+	// but not "hello-${foo}" or "${foo}${bar}"
+	StandaloneExpression bool
+}

--- a/internal/typesystem/parser/parser_test.go
+++ b/internal/typesystem/parser/parser_test.go
@@ -81,16 +81,16 @@ func TestParseResource(t *testing.T) {
 			},
 		}
 
-		expectedExpressions := []ExpressionField{
-			{Path: ".stringField", Expressions: []string{"string.value"}, ExpectedType: "string", OneShotCEL: true},
-			{Path: ".intField", Expressions: []string{"int.value"}, ExpectedType: "integer", OneShotCEL: true},
-			{Path: ".boolField", Expressions: []string{"bool.value"}, ExpectedType: "boolean", OneShotCEL: true},
-			{Path: ".nestedObject.nestedString", Expressions: []string{"nested.string"}, ExpectedType: "string", OneShotCEL: true},
-			{Path: ".nestedObject.nestedStringMultiple", Expressions: []string{"nested.string1", "nested.string2"}, ExpectedType: "string", OneShotCEL: false},
-			{Path: ".simpleArray[0]", Expressions: []string{"array[0]"}, ExpectedType: "string", OneShotCEL: true},
-			{Path: ".simpleArray[1]", Expressions: []string{"array[1]"}, ExpectedType: "string", OneShotCEL: true},
-			{Path: ".mapField.key1", Expressions: []string{"map.key1"}, ExpectedType: "string", OneShotCEL: true},
-			{Path: ".mapField.key2", Expressions: []string{"map.key2"}, ExpectedType: "string", OneShotCEL: true},
+		expectedExpressions := []CELField{
+			{Path: ".stringField", Expressions: []string{"string.value"}, ExpectedType: "string", StandaloneExpression: true},
+			{Path: ".intField", Expressions: []string{"int.value"}, ExpectedType: "integer", StandaloneExpression: true},
+			{Path: ".boolField", Expressions: []string{"bool.value"}, ExpectedType: "boolean", StandaloneExpression: true},
+			{Path: ".nestedObject.nestedString", Expressions: []string{"nested.string"}, ExpectedType: "string", StandaloneExpression: true},
+			{Path: ".nestedObject.nestedStringMultiple", Expressions: []string{"nested.string1", "nested.string2"}, ExpectedType: "string", StandaloneExpression: false},
+			{Path: ".simpleArray[0]", Expressions: []string{"array[0]"}, ExpectedType: "string", StandaloneExpression: true},
+			{Path: ".simpleArray[1]", Expressions: []string{"array[1]"}, ExpectedType: "string", StandaloneExpression: true},
+			{Path: ".mapField.key1", Expressions: []string{"map.key1"}, ExpectedType: "string", StandaloneExpression: true},
+			{Path: ".mapField.key2", Expressions: []string{"map.key2"}, ExpectedType: "string", StandaloneExpression: true},
 		}
 
 		expressions, err := ParseResource(resource, schema)
@@ -418,13 +418,13 @@ func TestParseWithExpectedSchema(t *testing.T) {
 		t.Fatalf("ParseResource() error = %v", err)
 	}
 
-	expectedExpressions := map[string]ExpressionField{
-		".stringField":                               {Path: ".stringField", Expressions: []string{"string.value"}, ExpectedType: "string", ExpectedSchema: &stringFieldSchema, OneShotCEL: true},
-		".objectField":                               {Path: ".objectField", Expressions: []string{"object.value"}, ExpectedType: "object", ExpectedSchema: &objectFieldSchema, OneShotCEL: true},
-		".nestedObjectField.nestedString":            {Path: ".nestedObjectField.nestedString", Expressions: []string{"nested.string"}, ExpectedType: "string", ExpectedSchema: &nestedObjectNestedStringSchema, OneShotCEL: true},
-		".nestedObjectField.nestedObject.deepNested": {Path: ".nestedObjectField.nestedObject.deepNested", Expressions: []string{"deep.nested"}, ExpectedType: "string", ExpectedSchema: &deepNestedSchema, OneShotCEL: true},
-		".arrayField[0]":                             {Path: ".arrayField[0]", Expressions: []string{"array[0]"}, ExpectedType: "object", ExpectedSchema: arrayFieldSchema.Items.Schema, OneShotCEL: true},
-		".arrayField[1].objectInArray":               {Path: ".arrayField[1].objectInArray", Expressions: []string{"object.in.array"}, ExpectedType: "string", ExpectedSchema: &objectInArraySchema, OneShotCEL: true},
+	expectedExpressions := map[string]CELField{
+		".stringField":                               {Path: ".stringField", Expressions: []string{"string.value"}, ExpectedType: "string", ExpectedSchema: &stringFieldSchema, StandaloneExpression: true},
+		".objectField":                               {Path: ".objectField", Expressions: []string{"object.value"}, ExpectedType: "object", ExpectedSchema: &objectFieldSchema, StandaloneExpression: true},
+		".nestedObjectField.nestedString":            {Path: ".nestedObjectField.nestedString", Expressions: []string{"nested.string"}, ExpectedType: "string", ExpectedSchema: &nestedObjectNestedStringSchema, StandaloneExpression: true},
+		".nestedObjectField.nestedObject.deepNested": {Path: ".nestedObjectField.nestedObject.deepNested", Expressions: []string{"deep.nested"}, ExpectedType: "string", ExpectedSchema: &deepNestedSchema, StandaloneExpression: true},
+		".arrayField[0]":                             {Path: ".arrayField[0]", Expressions: []string{"array[0]"}, ExpectedType: "object", ExpectedSchema: arrayFieldSchema.Items.Schema, StandaloneExpression: true},
+		".arrayField[1].objectInArray":               {Path: ".arrayField[1].objectInArray", Expressions: []string{"object.in.array"}, ExpectedType: "string", ExpectedSchema: &objectInArraySchema, StandaloneExpression: true},
 	}
 
 	if len(expressions) != len(expectedExpressions) {
@@ -444,8 +444,8 @@ func TestParseWithExpectedSchema(t *testing.T) {
 		if expr.ExpectedType != expected.ExpectedType {
 			t.Errorf("Path %s: expected type %s, got %s", expr.Path, expected.ExpectedType, expr.ExpectedType)
 		}
-		if expr.OneShotCEL != expected.OneShotCEL {
-			t.Errorf("Path %s: expected OneShotCEL %v, got %v", expr.Path, expected.OneShotCEL, expr.OneShotCEL)
+		if expr.StandaloneExpression != expected.StandaloneExpression {
+			t.Errorf("Path %s: expected OneShotCEL %v, got %v", expr.Path, expected.StandaloneExpression, expr.StandaloneExpression)
 		}
 		if !reflect.DeepEqual(expr.ExpectedSchema, expected.ExpectedSchema) {
 			t.Errorf("Path %s: schema mismatch", expr.Path)

--- a/internal/typesystem/parser/schemaless.go
+++ b/internal/typesystem/parser/schemaless.go
@@ -20,15 +20,15 @@ import (
 
 // ParseSchemalessResource extracts CEL expressions without a schema, this is useful
 // when the schema is not available. e.g RGI statuses
-func ParseSchemalessResource(resource map[string]interface{}) ([]ExpressionField, error) {
+func ParseSchemalessResource(resource map[string]interface{}) ([]CELField, error) {
 	return parseSchemalessResource(resource, "")
 }
 
 // parseSchemalessResource is a helper function that recursively
 // extracts expressions from a resource. It uses a depth first search to traverse
 // the resource and extract expressions from string fields
-func parseSchemalessResource(resource interface{}, path string) ([]ExpressionField, error) {
-	var expressionsFields []ExpressionField
+func parseSchemalessResource(resource interface{}, path string) ([]CELField, error) {
+	var expressionsFields []CELField
 	switch field := resource.(type) {
 	case map[string]interface{}:
 		for field, value := range field {
@@ -54,11 +54,11 @@ func parseSchemalessResource(resource interface{}, path string) ([]ExpressionFie
 			return nil, err
 		}
 		if ok {
-			expressionsFields = append(expressionsFields, ExpressionField{
-				Expressions:  []string{strings.Trim(field, "${}")},
-				ExpectedType: "any",
-				Path:         path,
-				OneShotCEL:   true,
+			expressionsFields = append(expressionsFields, CELField{
+				Expressions:          []string{strings.Trim(field, "${}")},
+				ExpectedType:         "any",
+				Path:                 path,
+				StandaloneExpression: true,
 			})
 		} else {
 			expressions, err := extractExpressions(field)
@@ -66,7 +66,7 @@ func parseSchemalessResource(resource interface{}, path string) ([]ExpressionFie
 				return nil, err
 			}
 			if len(expressions) > 0 {
-				expressionsFields = append(expressionsFields, ExpressionField{
+				expressionsFields = append(expressionsFields, CELField{
 					Expressions:  expressions,
 					ExpectedType: "any",
 					Path:         path,

--- a/internal/typesystem/parser/schemaless_test.go
+++ b/internal/typesystem/parser/schemaless_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 )
 
-func compareExpressionFields(a, b []ExpressionField) bool {
+func compareExpressionFields(a, b []CELField) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -30,7 +30,7 @@ func compareExpressionFields(a, b []ExpressionField) bool {
 		if !equalStrings(a[i].Expressions, b[i].Expressions) ||
 			a[i].ExpectedType != b[i].ExpectedType ||
 			a[i].Path != b[i].Path ||
-			a[i].OneShotCEL != b[i].OneShotCEL {
+			a[i].StandaloneExpression != b[i].StandaloneExpression {
 			return false
 		}
 	}
@@ -41,7 +41,7 @@ func TestParseSchemalessResource(t *testing.T) {
 	tests := []struct {
 		name     string
 		resource map[string]interface{}
-		want     []ExpressionField
+		want     []CELField
 		wantErr  bool
 	}{
 		{
@@ -49,12 +49,12 @@ func TestParseSchemalessResource(t *testing.T) {
 			resource: map[string]interface{}{
 				"field": "${resource.value}",
 			},
-			want: []ExpressionField{
+			want: []CELField{
 				{
-					Expressions:  []string{"resource.value"},
-					ExpectedType: "any",
-					Path:         ".field",
-					OneShotCEL:   true,
+					Expressions:          []string{"resource.value"},
+					ExpectedType:         "any",
+					Path:                 ".field",
+					StandaloneExpression: true,
 				},
 			},
 			wantErr: false,
@@ -66,12 +66,12 @@ func TestParseSchemalessResource(t *testing.T) {
 					"inner": "${nested.value}",
 				},
 			},
-			want: []ExpressionField{
+			want: []CELField{
 				{
-					Expressions:  []string{"nested.value"},
-					ExpectedType: "any",
-					Path:         ".outer.inner",
-					OneShotCEL:   true,
+					Expressions:          []string{"nested.value"},
+					ExpectedType:         "any",
+					Path:                 ".outer.inner",
+					StandaloneExpression: true,
 				},
 			},
 			wantErr: false,
@@ -84,18 +84,18 @@ func TestParseSchemalessResource(t *testing.T) {
 					"${array[1]}",
 				},
 			},
-			want: []ExpressionField{
+			want: []CELField{
 				{
-					Expressions:  []string{"array[0]"},
-					ExpectedType: "any",
-					Path:         ".array[0]",
-					OneShotCEL:   true,
+					Expressions:          []string{"array[0]"},
+					ExpectedType:         "any",
+					Path:                 ".array[0]",
+					StandaloneExpression: true,
 				},
 				{
-					Expressions:  []string{"array[1]"},
-					ExpectedType: "any",
-					Path:         ".array[1]",
-					OneShotCEL:   true,
+					Expressions:          []string{"array[1]"},
+					ExpectedType:         "any",
+					Path:                 ".array[1]",
+					StandaloneExpression: true,
 				},
 			},
 			wantErr: false,
@@ -105,7 +105,7 @@ func TestParseSchemalessResource(t *testing.T) {
 			resource: map[string]interface{}{
 				"field": "Start ${expr1} middle ${expr2} end",
 			},
-			want: []ExpressionField{
+			want: []CELField{
 				{
 					Expressions:  []string{"expr1", "expr2"},
 					ExpectedType: "any",
@@ -127,18 +127,18 @@ func TestParseSchemalessResource(t *testing.T) {
 					},
 				},
 			},
-			want: []ExpressionField{
+			want: []CELField{
 				{
-					Expressions:  []string{"string.value"},
-					ExpectedType: "any",
-					Path:         ".string",
-					OneShotCEL:   true,
+					Expressions:          []string{"string.value"},
+					ExpectedType:         "any",
+					Path:                 ".string",
+					StandaloneExpression: true,
 				},
 				{
-					Expressions:  []string{"array.value"},
-					ExpectedType: "any",
-					Path:         ".nested.array[0]",
-					OneShotCEL:   true,
+					Expressions:          []string{"array.value"},
+					ExpectedType:         "any",
+					Path:                 ".nested.array[0]",
+					StandaloneExpression: true,
 				},
 			},
 			wantErr: false,
@@ -146,7 +146,7 @@ func TestParseSchemalessResource(t *testing.T) {
 		{
 			name:     "Empty resource",
 			resource: map[string]interface{}{},
-			want:     []ExpressionField{},
+			want:     []CELField{},
 			wantErr:  false,
 		},
 		{
@@ -177,7 +177,7 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 	tests := []struct {
 		name     string
 		resource map[string]interface{}
-		want     []ExpressionField
+		want     []CELField
 		wantErr  bool
 	}{
 		{
@@ -191,12 +191,12 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 					},
 				},
 			},
-			want: []ExpressionField{
+			want: []CELField{
 				{
-					Expressions:  []string{"deeply.nested.value"},
-					ExpectedType: "any",
-					Path:         ".level1.level2.level3.level4",
-					OneShotCEL:   true,
+					Expressions:          []string{"deeply.nested.value"},
+					ExpectedType:         "any",
+					Path:                 ".level1.level2.level3.level4",
+					StandaloneExpression: true,
 				},
 			},
 			wantErr: false,
@@ -213,18 +213,18 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 					},
 				},
 			},
-			want: []ExpressionField{
+			want: []CELField{
 				{
-					Expressions:  []string{"expr1"},
-					ExpectedType: "any",
-					Path:         ".array[0]",
-					OneShotCEL:   true,
+					Expressions:          []string{"expr1"},
+					ExpectedType:         "any",
+					Path:                 ".array[0]",
+					StandaloneExpression: true,
 				},
 				{
-					Expressions:  []string{"expr2"},
-					ExpectedType: "any",
-					Path:         ".array[3].nested",
-					OneShotCEL:   true,
+					Expressions:          []string{"expr2"},
+					ExpectedType:         "any",
+					Path:                 ".array[3].nested",
+					StandaloneExpression: true,
 				},
 			},
 			wantErr: false,
@@ -235,18 +235,18 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 				"empty1": "${}",
 				"empty2": "${    }",
 			},
-			want: []ExpressionField{
+			want: []CELField{
 				{
-					Expressions:  []string{""},
-					ExpectedType: "any",
-					Path:         ".empty1",
-					OneShotCEL:   true,
+					Expressions:          []string{""},
+					ExpectedType:         "any",
+					Path:                 ".empty1",
+					StandaloneExpression: true,
 				},
 				{
-					Expressions:  []string{"    "},
-					ExpectedType: "any",
-					Path:         ".empty2",
-					OneShotCEL:   true,
+					Expressions:          []string{"    "},
+					ExpectedType:         "any",
+					Path:                 ".empty2",
+					StandaloneExpression: true,
 				},
 			},
 			wantErr: false,
@@ -258,7 +258,7 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 				"incomplete2": "incomplete}",
 				"incomplete3": "$not_an_expression",
 			},
-			want:    []ExpressionField{},
+			want:    []CELField{},
 			wantErr: false,
 		},
 		{
@@ -285,18 +285,18 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 					},
 				},
 			},
-			want: []ExpressionField{
+			want: []CELField{
 				{
-					Expressions:  []string{"string.value"},
-					ExpectedType: "any",
-					Path:         ".string",
-					OneShotCEL:   true,
+					Expressions:          []string{"string.value"},
+					ExpectedType:         "any",
+					Path:                 ".string",
+					StandaloneExpression: true,
 				},
 				{
-					Expressions:  []string{"array.value"},
-					ExpectedType: "any",
-					Path:         ".nested.array[0]",
-					OneShotCEL:   true,
+					Expressions:          []string{"array.value"},
+					ExpectedType:         "any",
+					Path:                 ".nested.array[0]",
+					StandaloneExpression: true,
 				},
 				{
 					Expressions:  []string{"expr1", "expr2"},
@@ -304,22 +304,22 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 					Path:         ".complex.field",
 				},
 				{
-					Expressions:  []string{"nested.value"},
-					ExpectedType: "any",
-					Path:         ".complex.nested.inner",
-					OneShotCEL:   true,
+					Expressions:          []string{"nested.value"},
+					ExpectedType:         "any",
+					Path:                 ".complex.nested.inner",
+					StandaloneExpression: true,
 				},
 				{
-					Expressions:  []string{"expr4"},
-					ExpectedType: "any",
-					Path:         ".complex.array[1]",
-					OneShotCEL:   true,
+					Expressions:          []string{"expr4"},
+					ExpectedType:         "any",
+					Path:                 ".complex.array[1]",
+					StandaloneExpression: true,
 				},
 				{
-					Expressions:  []string{"expr5"},
-					ExpectedType: "any",
-					Path:         ".complex.array[2]",
-					OneShotCEL:   true,
+					Expressions:          []string{"expr5"},
+					ExpectedType:         "any",
+					Path:                 ".complex.array[2]",
+					StandaloneExpression: true,
 				},
 			},
 		},

--- a/internal/typesystem/resolver/resolver.go
+++ b/internal/typesystem/resolver/resolver.go
@@ -59,7 +59,7 @@ func NewResolver(resource map[string]interface{}, data map[string]interface{}) *
 
 // Resolve processes all the given ExpressionFields and resolves their CEL expressions.
 // It returns a ResolutionSummary containing information about the resolution process.
-func (r *Resolver) Resolve(expressions []parser.ExpressionField) ResolutionSummary {
+func (r *Resolver) Resolve(expressions []parser.CELField) ResolutionSummary {
 	summary := ResolutionSummary{
 		TotalExpressions: len(expressions),
 		Results:          make([]ResolutionResult, 0, len(expressions)),
@@ -82,7 +82,7 @@ func (r *Resolver) Resolve(expressions []parser.ExpressionField) ResolutionSumma
 // resolveField handles the resolution of a single ExpressionField (one field) in
 // the resource. It returns a ResolutionResult containing information about the
 // resolution process
-func (r *Resolver) resolveField(field parser.ExpressionField) ResolutionResult {
+func (r *Resolver) resolveField(field parser.CELField) ResolutionResult {
 	result := ResolutionResult{
 		Path:     field.Path,
 		Original: fmt.Sprintf("%v", field.Expressions),
@@ -96,7 +96,7 @@ func (r *Resolver) resolveField(field parser.ExpressionField) ResolutionResult {
 		return result
 	}
 
-	if field.OneShotCEL {
+	if field.StandaloneExpression {
 		resolvedValue, ok := r.data[strings.Trim(field.Expressions[0], "${}")]
 		if !ok {
 			result.Error = fmt.Errorf("no data provided for expression: %s", field.Expressions[0])


### PR DESCRIPTION
This commit renames the ExpressionField to `CELField` throught
the code base to better reflect its purpose in handling CEL expressions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
