### PR TITLE
Add example deploying ACK controllers with symphony

### DIFF
--- a/examples/ack-controller/README.md
+++ b/examples/ack-controller/README.md
@@ -1,0 +1,18 @@
+# Steps to deploy ack-controllers to cluster
+
+## Deploying Controllers
+### Prerequisites
+Create IRSA for IAM controller
+See [ACK Docs] (https://aws-controllers-k8s.github.io/community/docs/user-docs/irsa/)
+
+### Deployment order:
+1. IAM
+2. EC2
+3. EKS
+
+### Steps
+For these EKS and EC2 controllers we are using the IAM controller to create
+the necessary roles for the service account
+1. Deploy Controller CRD Group
+2. Deploy Controller ResourceGroup
+3. Deploy Controller Instance (don't forget to include required fields) 

--- a/examples/ack-controller/ec2-controller/ec2-controller-instance.yaml
+++ b/examples/ack-controller/ec2-controller/ec2-controller-instance.yaml
@@ -1,0 +1,22 @@
+apiVersion: x.symphony.k8s.aws/v1alpha1
+kind: EC2controller
+metadata:
+  name: my-symphony-ec2-controller
+  namespace: default
+spec:
+  name: ec2-controller
+  namespace: default
+  values:
+    aws:
+      accountID: "399481058530"
+    deployment: {}
+    iamRole:
+      oidcProvider: oidc.eks.us-west-2.amazonaws.com/id/50B8942190FBD3A2EF2BF6AB7D27B06B
+    image:
+      resources:
+        requests: {}
+        limits: {}
+    log:
+      enabled: true
+      level: debug
+    serviceAccount: {}

--- a/examples/ack-controller/ec2-controller/ec2-controller.yaml
+++ b/examples/ack-controller/ec2-controller/ec2-controller.yaml
@@ -1,0 +1,527 @@
+apiVersion: x.symphony.k8s.aws/v1alpha1
+kind: ResourceGroup
+metadata:
+  name: ec2controller.x.symphony.k8s.aws
+spec:
+  apiVersion: v1alpha1
+  kind: EC2Controller
+  definition:
+    spec:
+      name: string | default=ec2-controller
+      namespace: string | default=default
+      values:
+        aws:
+          accountID: string | required=true
+          region: string | default=us-west-2
+        deployment:
+          containerPort: integer | default=8080
+          replicas: integer | default=1
+        iamRole:
+          maxSessionDuration: integer | default=3600
+          oidcProvider: string | required=true
+          roleDescription: string | default=IRSA role for ACK EC2 controller deployement on EKS cluster using Symphony Resource group
+        image:
+          deletePolicy: string | default=delete
+          repository: string | default=public.ecr.aws/aws-controllers-k8s/ec2-controller
+          tag: string | default=1.2.27
+          resources:
+            requests:
+              memory: string | default=64Mi
+              cpu: string | default=50m
+            limits:
+              memory: string | default=128Mi
+              cpu: string | default=100m
+        log:
+          enabled: boolean | default=false
+          level: string | default=info
+        serviceAccount:
+          name: string | default=ec2-controller-sa
+  resources:
+  - name: ec2CRDGroup
+    definition:
+      apiVersion: x.symphony.k8s.aws/v1alpha1
+      kind: EC2CRDGroup
+      metadata:
+        name: ${spec.name}-crd-group
+      spec:
+        name: ${spec.name}-crd-group
+  - name: ec2ControllerIamRole
+    definition:
+      apiVersion: iam.services.k8s.aws/v1alpha1
+      kind: Role
+      metadata:
+        name: ${spec.name}-iam-role
+        namespace: ${spec.namespace}
+      spec:
+        name: ${spec.name}-iam-role
+        description: ${spec.values.iamRole.roleDescription}
+        maxSessionDuration: ${spec.values.iamRole.maxSessionDuration}
+        policies:
+        - arn:aws:iam::aws:policy/AmazonEC2FullAccess
+        assumeRolePolicyDocument: >
+          {
+            "Version": "2012-10-17",
+            "Statement": [{
+              "Effect": "Allow",
+              "Principal": {"Federated": "arn:aws:iam::${spec.values.aws.accountID}:oidc-provider/${spec.values.iamRole.oidcProvider}"},
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": {
+                  "StringEquals": {"${spec.values.iamRole.oidcProvider}:sub": "system:serviceaccount:${spec.namespace}:${spec.values.serviceAccount.name}"}
+              }
+            }]
+          }
+  - name: serviceAccount
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ${spec.values.serviceAccount.name}
+        namespace: ${spec.namespace}
+        annotations:
+          eks.amazonaws.com/role-arn: ${ec2ControllerIamRole.status.ackResourceMetadata.arn}
+  - name: deployment
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ${spec.name}-deployment
+        namespace: ${spec.namespace}
+        labels:
+          app.kubernetes.io.name: ${spec.name}-deployment
+          app.kubernetes.io.instance: ${spec.name}
+      spec:
+        replicas: ${spec.values.deployment.replicas}
+        selector:
+          matchLabels:
+            app.kubernetes.io.name: ${spec.name}-deployment
+            app.kubernetes.io.instance: ${spec.name}
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io.name: ${spec.name}-deployment
+              app.kubernetes.io.instance: ${spec.name}
+          spec:
+            serviceAccountName: ${serviceAccount.metadata.name}
+            containers:
+            - command:
+              - ./bin/controller
+              args:
+              - --aws-region
+              - ${spec.values.aws.region}
+              - --enable-development-logging=${spec.values.log.enabled}
+              - --log-level
+              - ${spec.values.log.level}
+              - --deletion-policy
+              - ${spec.values.image.deletePolicy}
+              - --watch-namespace
+              - ${spec.namespace}
+              image: ${spec.values.image.repository}:${spec.values.image.tag}
+              name: controller
+              ports:
+                - name: http
+                  containerPort: ${spec.values.deployment.containerPort}
+              resources:
+                requests:
+                  memory: ${spec.values.image.resources.requests.memory}
+                  cpu: ${spec.values.image.resources.requests.cpu}
+                limits:
+                    memory: ${spec.values.image.resources.limits.memory}
+                    cpu: ${spec.values.image.resources.limits.cpu}
+              env:
+              - name: ACK_SYSTEM_NAMESPACE
+                value: ${spec.namespace}
+              - name: AWS_REGION
+                value: ${spec.values.aws.region}
+              - name: DELETE_POLICY
+                value: ${spec.values.image.deletePolicy}
+              - name: ACK_LOG_LEVEL
+                value: ${spec.values.log.level}              
+              ports:
+              - containerPort: 80
+  - name: clusterRoleBinding
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: ${spec.name}-clusterrolebinding
+      roleRef:
+        kind: ClusterRole
+        apiGroup: rbac.authorization.k8s.io
+        name: ${clusterRole.metadata.name}
+      subjects:
+      - kind: ServiceAccount
+        name: ${serviceAccount.metadata.name}
+        namespace: ${serviceAccount.metadata.namespace}
+  - name: clusterRole
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ${spec.name}-clusterrole
+      rules:
+      - apiGroups:
+        - ""
+        resources:
+        - configmaps
+        verbs:
+        - get
+        - list
+        - patch
+        - watch
+      - apiGroups:
+        - ""
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ""
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - patch
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - dhcpoptions
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - dhcpoptions/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - elasticipaddresses
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - elasticipaddresses/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - flowlogs
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - flowlogs/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - instances
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - instances/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - internetgateways
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - internetgateways/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - natgateways
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - natgateways/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - networkacls
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - networkacls/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - routetables
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - routetables/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - securitygroups
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - securitygroups/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - subnets
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - subnets/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - transitgateways
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - transitgateways/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - vpcendpoints
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - vpcendpoints/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - vpcendpointserviceconfigurations
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - vpcendpointserviceconfigurations/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - vpcpeeringconnections
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - vpcpeeringconnections/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - vpcs
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - vpcs/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - services.k8s.aws
+        resources:
+        - adoptedresources
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - services.k8s.aws
+        resources:
+        - adoptedresources/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - services.k8s.aws
+        resources:
+        - fieldexports
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - services.k8s.aws
+        resources:
+        - fieldexports/status
+        verbs:
+        - get
+        - patch
+        - update

--- a/examples/ack-controller/ec2-controller/ec2-crd-group.yaml
+++ b/examples/ack-controller/ec2-controller/ec2-crd-group.yaml
@@ -1,0 +1,5125 @@
+apiVersion: x.symphony.k8s.aws/v1alpha1
+kind: ResourceGroup
+metadata:
+  name: ec2crdgroup.x.symphony.k8s.aws
+spec:
+  apiVersion: v1alpha1
+  kind: EC2CRDGroup
+  definition:
+    spec:
+      name: string | default=ec2CRDGroup
+  resources:
+  - name: dhcpOptionsCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: dhcpoptions.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: DHCPOptions
+          listKind: DHCPOptionsList
+          plural: dhcpoptions
+          singular: dhcpoptions
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .status.dhcpOptionsID
+            name: ID
+            type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: DHCPOptions is the Schema for the DHCPOptions API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    DhcpOptionsSpec defines the desired state of DhcpOptions.
+
+
+                    Describes a set of DHCP options.
+                  properties:
+                    dhcpConfigurations:
+                      description: A DHCP configuration option.
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    vpc:
+                      items:
+                        type: string
+                      type: array
+                    vpcRefs:
+                      items:
+                        description: "AWSResourceReferenceWrapper provides a wrapper around
+                          *AWSResourceReference\ntype to provide more user friendly syntax
+                          for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                          \ name: my-api"
+                        properties:
+                          from:
+                            description: |-
+                              AWSResourceReference provides all the values necessary to reference another
+                              k8s resource for finding the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                  required:
+                  - dhcpConfigurations
+                  type: object
+                status:
+                  description: DHCPOptionsStatus defines the observed state of DHCPOptions
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    dhcpOptionsID:
+                      description: The ID of the set of DHCP options.
+                      type: string
+                    ownerID:
+                      description: The ID of the Amazon Web Services account that owns the
+                        DHCP options set.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: elasticIPAddressCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: elasticipaddresses.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: ElasticIPAddress
+          listKind: ElasticIPAddressList
+          plural: elasticipaddresses
+          singular: elasticipaddress
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .status.allocationID
+            name: ALLOCATION-ID
+            type: string
+          - jsonPath: .status.publicIP
+            name: PUBLIC-IP
+            type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: ElasticIPAddress is the Schema for the ElasticIPAddresses API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: ElasticIPAddressSpec defines the desired state of ElasticIPAddress.
+                  properties:
+                    address:
+                      description: |-
+                        [EC2-VPC] The Elastic IP address to recover or an IPv4 address from an address
+                        pool.
+                      type: string
+                    customerOwnedIPv4Pool:
+                      description: |-
+                        The ID of a customer-owned address pool. Use this parameter to let Amazon
+                        EC2 select an address from the address pool. Alternatively, specify a specific
+                        address from the address pool.
+                      type: string
+                    networkBorderGroup:
+                      description: |-
+                        A unique set of Availability Zones, Local Zones, or Wavelength Zones from
+                        which Amazon Web Services advertises IP addresses. Use this parameter to
+                        limit the IP address to this location. IP addresses cannot move between network
+                        border groups.
+
+
+                        Use DescribeAvailabilityZones (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html)
+                        to view the network border groups.
+
+
+                        You cannot use a network border group with EC2 Classic. If you attempt this
+                        operation on EC2 Classic, you receive an InvalidParameterCombination error.
+                      type: string
+                    publicIPv4Pool:
+                      description: |-
+                        The ID of an address pool that you own. Use this parameter to let Amazon
+                        EC2 select an address from the address pool. To specify a specific address
+                        from the address pool, use the Address parameter instead.
+                      type: string
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                status:
+                  description: ElasticIPAddressStatus defines the observed state of ElasticIPAddress
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    allocationID:
+                      description: |-
+                        [EC2-VPC] The ID that Amazon Web Services assigns to represent the allocation
+                        of the Elastic IP address for use with instances in a VPC.
+                      type: string
+                    carrierIP:
+                      description: |-
+                        The carrier IP address. This option is only available for network interfaces
+                        which reside in a subnet in a Wavelength Zone (for example an EC2 instance).
+                      type: string
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    customerOwnedIP:
+                      description: The customer-owned IP address.
+                      type: string
+                    publicIP:
+                      description: The Elastic IP address.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: flowLogsCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: flowlogs.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: FlowLog
+          listKind: FlowLogList
+          plural: flowlogs
+          singular: flowlog
+        scope: Namespaced
+        versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: FlowLog is the Schema for the FlowLogs API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    FlowLogSpec defines the desired state of FlowLog.
+
+
+                    Describes a flow log.
+                  properties:
+                    deliverLogsPermissionARN:
+                      description: |-
+                        The ARN for the IAM role that permits Amazon EC2 to publish flow logs to
+                        a CloudWatch Logs log group in your account.
+
+
+                        If you specify LogDestinationType as s3, do not specify DeliverLogsPermissionArn
+                        or LogGroupName.
+                      type: string
+                    destinationOptions:
+                      description: The destination options.
+                      properties:
+                        fileFormat:
+                          type: string
+                        hiveCompatiblePartitions:
+                          type: boolean
+                        perHourPartition:
+                          type: boolean
+                      type: object
+                    logDestination:
+                      description: |-
+                        The destination to which the flow log data is to be published. Flow log data
+                        can be published to a CloudWatch Logs log group or an Amazon S3 bucket. The
+                        value specified for this parameter depends on the value specified for LogDestinationType.
+
+
+                        If LogDestinationType is not specified or cloud-watch-logs, specify the Amazon
+                        Resource Name (ARN) of the CloudWatch Logs log group. For example, to publish
+                        to a log group called my-logs, specify arn:aws:logs:us-east-1:123456789012:log-group:my-logs.
+                        Alternatively, use LogGroupName instead.
+
+
+                        If LogDestinationType is s3, specify the ARN of the Amazon S3 bucket. You
+                        can also specify a subfolder in the bucket. To specify a subfolder in the
+                        bucket, use the following ARN format: bucket_ARN/subfolder_name/. For example,
+                        to specify a subfolder named my-logs in a bucket named my-bucket, use the
+                        following ARN: arn:aws:s3:::my-bucket/my-logs/. You cannot use AWSLogs as
+                        a subfolder name. This is a reserved term.
+                      type: string
+                    logDestinationType:
+                      description: |-
+                        The type of destination to which the flow log data is to be published. Flow
+                        log data can be published to CloudWatch Logs or Amazon S3. To publish flow
+                        log data to CloudWatch Logs, specify cloud-watch-logs. To publish flow log
+                        data to Amazon S3, specify s3.
+
+
+                        If you specify LogDestinationType as s3, do not specify DeliverLogsPermissionArn
+                        or LogGroupName.
+
+
+                        Default: cloud-watch-logs
+                      type: string
+                    logFormat:
+                      description: |-
+                        The fields to include in the flow log record, in the order in which they
+                        should appear. For a list of available fields, see Flow log records (https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html#flow-log-records).
+                        If you omit this parameter, the flow log is created using the default format.
+                        If you specify this parameter, you must specify at least one field.
+
+
+                        Specify the fields using the $\{field-id} format, separated by spaces. For
+                        the CLI, surround this parameter value with single quotes on Linux or double
+                        quotes on Windows.
+                      type: string
+                    logGroupName:
+                      description: |-
+                        The name of a new or existing CloudWatch Logs log group where Amazon EC2
+                        publishes your flow logs.
+
+
+                        If you specify LogDestinationType as s3, do not specify DeliverLogsPermissionArn
+                        or LogGroupName.
+                      type: string
+                    maxAggregationInterval:
+                      description: |-
+                        The maximum interval of time during which a flow of packets is captured and
+                        aggregated into a flow log record. You can specify 60 seconds (1 minute)
+                        or 600 seconds (10 minutes).
+
+
+                        When a network interface is attached to a Nitro-based instance (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances),
+                        the aggregation interval is always 60 seconds or less, regardless of the
+                        value that you specify.
+
+
+                        Default: 600
+                      format: int64
+                      type: integer
+                    resourceID:
+                      type: string
+                    resourceType:
+                      description: |-
+                        The type of resource for which to create the flow log. For example, if you
+                        specified a VPC ID for the ResourceId property, specify VPC for this property.
+                      type: string
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    trafficType:
+                      description: |-
+                        The type of traffic to log. You can log traffic that the resource accepts
+                        or rejects, or all traffic.
+                      type: string
+                  required:
+                  - resourceID
+                  - resourceType
+                  type: object
+                status:
+                  description: FlowLogStatus defines the observed state of FlowLog
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    clientToken:
+                      description: |-
+                        Unique, case-sensitive identifier that you provide to ensure the idempotency
+                        of the request.
+                      type: string
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    flowLogID:
+                      type: string
+                    unsuccessful:
+                      description: Information about the flow logs that could not be created
+                        successfully.
+                      items:
+                        description: Information about items that were not successfully
+                          processed in a batch call.
+                        properties:
+                          error:
+                            description: |-
+                              Information about the error that occurred. For more information about errors,
+                              see Error codes (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html).
+                            properties:
+                              code:
+                                type: string
+                              message:
+                                type: string
+                            type: object
+                          resourceID:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: instanceCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: instances.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: Instance
+          listKind: InstanceList
+          plural: instances
+          singular: instance
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .status.instanceID
+            name: ID
+            type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: Instance is the Schema for the Instances API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    InstanceSpec defines the desired state of Instance.
+
+
+                    Describes an instance.
+                  properties:
+                    blockDeviceMappings:
+                      description: |-
+                        The block device mapping, which defines the EBS volumes and instance store
+                        volumes to attach to the instance at launch. For more information, see Block
+                        device mappings (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html)
+                        in the Amazon EC2 User Guide.
+                      items:
+                        description: |-
+                          Describes a block device mapping, which defines the EBS volumes and instance
+                          store volumes to attach to an instance at launch.
+                        properties:
+                          deviceName:
+                            type: string
+                          ebs:
+                            description: Describes a block device for an EBS volume.
+                            properties:
+                              deleteOnTermination:
+                                type: boolean
+                              encrypted:
+                                type: boolean
+                              iops:
+                                format: int64
+                                type: integer
+                              kmsKeyID:
+                                type: string
+                              outpostARN:
+                                type: string
+                              snapshotID:
+                                type: string
+                              throughput:
+                                format: int64
+                                type: integer
+                              volumeSize:
+                                format: int64
+                                type: integer
+                              volumeType:
+                                type: string
+                            type: object
+                          noDevice:
+                            type: string
+                          virtualName:
+                            type: string
+                        type: object
+                      type: array
+                    capacityReservationSpecification:
+                      description: |-
+                        Information about the Capacity Reservation targeting option. If you do not
+                        specify this parameter, the instance's Capacity Reservation preference defaults
+                        to open, which enables it to run in any open Capacity Reservation that has
+                        matching attributes (instance type, platform, Availability Zone).
+                      properties:
+                        capacityReservationPreference:
+                          type: string
+                        capacityReservationTarget:
+                          description: Describes a target Capacity Reservation or Capacity
+                            Reservation group.
+                          properties:
+                            capacityReservationID:
+                              type: string
+                            capacityReservationResourceGroupARN:
+                              type: string
+                          type: object
+                      type: object
+                    cpuOptions:
+                      description: |-
+                        The CPU options for the instance. For more information, see Optimize CPU
+                        options (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-optimize-cpu.html)
+                        in the Amazon EC2 User Guide.
+                      properties:
+                        coreCount:
+                          format: int64
+                          type: integer
+                        threadsPerCore:
+                          format: int64
+                          type: integer
+                      type: object
+                    creditSpecification:
+                      description: |-
+                        The credit option for CPU usage of the burstable performance instance. Valid
+                        values are standard and unlimited. To change this attribute after launch,
+                        use ModifyInstanceCreditSpecification (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyInstanceCreditSpecification.html).
+                        For more information, see Burstable performance instances (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html)
+                        in the Amazon EC2 User Guide.
+
+
+                        Default: standard (T2 instances) or unlimited (T3/T3a/T4g instances)
+
+
+                        For T3 instances with host tenancy, only standard is supported.
+                      properties:
+                        cpuCredits:
+                          type: string
+                      type: object
+                    disableAPIStop:
+                      description: |-
+                        Indicates whether an instance is enabled for stop protection. For more information,
+                        see Stop protection (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Stop_Start.html#Using_StopProtection).
+                      type: boolean
+                    disableAPITermination:
+                      description: |-
+                        If you set this parameter to true, you can't terminate the instance using
+                        the Amazon EC2 console, CLI, or API; otherwise, you can. To change this attribute
+                        after launch, use ModifyInstanceAttribute (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyInstanceAttribute.html).
+                        Alternatively, if you set InstanceInitiatedShutdownBehavior to terminate,
+                        you can terminate the instance by running the shutdown command from the instance.
+
+
+                        Default: false
+                      type: boolean
+                    ebsOptimized:
+                      description: |-
+                        Indicates whether the instance is optimized for Amazon EBS I/O. This optimization
+                        provides dedicated throughput to Amazon EBS and an optimized configuration
+                        stack to provide optimal Amazon EBS I/O performance. This optimization isn't
+                        available with all instance types. Additional usage charges apply when using
+                        an EBS-optimized instance.
+
+
+                        Default: false
+                      type: boolean
+                    elasticGPUSpecification:
+                      description: |-
+                        An elastic GPU to associate with the instance. An Elastic GPU is a GPU resource
+                        that you can attach to your Windows instance to accelerate the graphics performance
+                        of your applications. For more information, see Amazon EC2 Elastic GPUs (https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/elastic-graphics.html)
+                        in the Amazon EC2 User Guide.
+                      items:
+                        description: A specification for an Elastic Graphics accelerator.
+                        properties:
+                          type_:
+                            type: string
+                        type: object
+                      type: array
+                    elasticInferenceAccelerators:
+                      description: |-
+                        An elastic inference accelerator to associate with the instance. Elastic
+                        inference accelerators are a resource you can attach to your Amazon EC2 instances
+                        to accelerate your Deep Learning (DL) inference workloads.
+
+
+                        You cannot specify accelerators from different generations in the same request.
+                      items:
+                        description: Describes an elastic inference accelerator.
+                        properties:
+                          count:
+                            format: int64
+                            type: integer
+                          type_:
+                            type: string
+                        type: object
+                      type: array
+                    enclaveOptions:
+                      description: |-
+                        Indicates whether the instance is enabled for Amazon Web Services Nitro Enclaves.
+                        For more information, see What is Amazon Web Services Nitro Enclaves? (https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave.html)
+                        in the Amazon Web Services Nitro Enclaves User Guide.
+
+
+                        You can't enable Amazon Web Services Nitro Enclaves and hibernation on the
+                        same instance.
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    hibernationOptions:
+                      description: |-
+                        Indicates whether an instance is enabled for hibernation. For more information,
+                        see Hibernate your instance (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Hibernate.html)
+                        in the Amazon EC2 User Guide.
+
+
+                        You can't enable hibernation and Amazon Web Services Nitro Enclaves on the
+                        same instance.
+                      properties:
+                        configured:
+                          type: boolean
+                      type: object
+                    iamInstanceProfile:
+                      description: The name or Amazon Resource Name (ARN) of an IAM instance
+                        profile.
+                      properties:
+                        arn:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    imageID:
+                      description: |-
+                        The ID of the AMI. An AMI ID is required to launch an instance and must be
+                        specified here or in a launch template.
+                      type: string
+                    instanceInitiatedShutdownBehavior:
+                      description: |-
+                        Indicates whether an instance stops or terminates when you initiate shutdown
+                        from the instance (using the operating system command for system shutdown).
+
+
+                        Default: stop
+                      type: string
+                    instanceMarketOptions:
+                      description: |-
+                        The market (purchasing) option for the instances.
+
+
+                        For RunInstances, persistent Spot Instance requests are only supported when
+                        InstanceInterruptionBehavior is set to either hibernate or stop.
+                      properties:
+                        marketType:
+                          type: string
+                        spotOptions:
+                          description: The options for Spot Instances.
+                          properties:
+                            blockDurationMinutes:
+                              format: int64
+                              type: integer
+                            instanceInterruptionBehavior:
+                              type: string
+                            maxPrice:
+                              type: string
+                            spotInstanceType:
+                              type: string
+                            validUntil:
+                              format: date-time
+                              type: string
+                          type: object
+                      type: object
+                    instanceType:
+                      description: |-
+                        The instance type. For more information, see Instance types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html)
+                        in the Amazon EC2 User Guide.
+
+
+                        Default: m1.small
+                      type: string
+                    ipv6AddressCount:
+                      description: |-
+                        [EC2-VPC] The number of IPv6 addresses to associate with the primary network
+                        interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet.
+                        You cannot specify this option and the option to assign specific IPv6 addresses
+                        in the same request. You can specify this option if you've specified a minimum
+                        number of instances to launch.
+
+
+                        You cannot specify this option and the network interfaces option in the same
+                        request.
+                      format: int64
+                      type: integer
+                    ipv6Addresses:
+                      description: |-
+                        [EC2-VPC] The IPv6 addresses from the range of the subnet to associate with
+                        the primary network interface. You cannot specify this option and the option
+                        to assign a number of IPv6 addresses in the same request. You cannot specify
+                        this option if you've specified a minimum number of instances to launch.
+
+
+                        You cannot specify this option and the network interfaces option in the same
+                        request.
+                      items:
+                        description: Describes an IPv6 address.
+                        properties:
+                          ipv6Address:
+                            type: string
+                        type: object
+                      type: array
+                    kernelID:
+                      description: |-
+                        The ID of the kernel.
+
+
+                        We recommend that you use PV-GRUB instead of kernels and RAM disks. For more
+                        information, see PV-GRUB (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/UserProvidedkernels.html)
+                        in the Amazon EC2 User Guide.
+                      type: string
+                    keyName:
+                      description: |-
+                        The name of the key pair. You can create a key pair using CreateKeyPair (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateKeyPair.html)
+                        or ImportKeyPair (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ImportKeyPair.html).
+
+
+                        If you do not specify a key pair, you can't connect to the instance unless
+                        you choose an AMI that is configured to allow users another way to log in.
+                      type: string
+                    launchTemplate:
+                      description: |-
+                        The launch template to use to launch the instances. Any parameters that you
+                        specify in RunInstances override the same parameters in the launch template.
+                        You can specify either the name or ID of a launch template, but not both.
+                      properties:
+                        launchTemplateID:
+                          type: string
+                        launchTemplateName:
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                    licenseSpecifications:
+                      description: The license configurations.
+                      items:
+                        description: Describes a license configuration.
+                        properties:
+                          licenseConfigurationARN:
+                            type: string
+                        type: object
+                      type: array
+                    maintenanceOptions:
+                      description: The maintenance and recovery options for the instance.
+                      properties:
+                        autoRecovery:
+                          type: string
+                      type: object
+                    maxCount:
+                      description: |-
+                        The maximum number of instances to launch. If you specify more instances
+                        than Amazon EC2 can launch in the target Availability Zone, Amazon EC2 launches
+                        the largest possible number of instances above MinCount.
+
+
+                        Constraints: Between 1 and the maximum number you're allowed for the specified
+                        instance type. For more information about the default limits, and how to
+                        request an increase, see How many instances can I run in Amazon EC2 (http://aws.amazon.com/ec2/faqs/#How_many_instances_can_I_run_in_Amazon_EC2)
+                        in the Amazon EC2 FAQ.
+                      format: int64
+                      type: integer
+                    metadataOptions:
+                      description: |-
+                        The metadata options for the instance. For more information, see Instance
+                        metadata and user data (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
+                      properties:
+                        httpEndpoint:
+                          type: string
+                        httpProtocolIPv6:
+                          type: string
+                        httpPutResponseHopLimit:
+                          format: int64
+                          type: integer
+                        httpTokens:
+                          type: string
+                        instanceMetadataTags:
+                          type: string
+                      type: object
+                    minCount:
+                      description: |-
+                        The minimum number of instances to launch. If you specify a minimum that
+                        is more instances than Amazon EC2 can launch in the target Availability Zone,
+                        Amazon EC2 launches no instances.
+
+
+                        Constraints: Between 1 and the maximum number you're allowed for the specified
+                        instance type. For more information about the default limits, and how to
+                        request an increase, see How many instances can I run in Amazon EC2 (http://aws.amazon.com/ec2/faqs/#How_many_instances_can_I_run_in_Amazon_EC2)
+                        in the Amazon EC2 General FAQ.
+                      format: int64
+                      type: integer
+                    monitoring:
+                      description: Specifies whether detailed monitoring is enabled for
+                        the instance.
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    networkInterfaces:
+                      description: |-
+                        The network interfaces to associate with the instance. If you specify a network
+                        interface, you must specify any security groups and subnets as part of the
+                        network interface.
+                      items:
+                        description: Describes a network interface.
+                        properties:
+                          associateCarrierIPAddress:
+                            type: boolean
+                          associatePublicIPAddress:
+                            type: boolean
+                          deleteOnTermination:
+                            type: boolean
+                          description:
+                            type: string
+                          deviceIndex:
+                            format: int64
+                            type: integer
+                          interfaceType:
+                            type: string
+                          ipv4PrefixCount:
+                            format: int64
+                            type: integer
+                          ipv4Prefixes:
+                            items:
+                              description: Describes the IPv4 prefix option for a network
+                                interface.
+                              properties:
+                                ipv4Prefix:
+                                  type: string
+                              type: object
+                            type: array
+                          ipv6AddressCount:
+                            format: int64
+                            type: integer
+                          ipv6Addresses:
+                            items:
+                              description: Describes an IPv6 address.
+                              properties:
+                                ipv6Address:
+                                  type: string
+                              type: object
+                            type: array
+                          ipv6PrefixCount:
+                            format: int64
+                            type: integer
+                          ipv6Prefixes:
+                            items:
+                              description: Describes the IPv4 prefix option for a network
+                                interface.
+                              properties:
+                                ipv6Prefix:
+                                  type: string
+                              type: object
+                            type: array
+                          networkCardIndex:
+                            format: int64
+                            type: integer
+                          networkInterfaceID:
+                            type: string
+                          privateIPAddress:
+                            type: string
+                          privateIPAddresses:
+                            items:
+                              description: Describes a secondary private IPv4 address for
+                                a network interface.
+                              properties:
+                                primary:
+                                  type: boolean
+                                privateIPAddress:
+                                  type: string
+                              type: object
+                            type: array
+                          secondaryPrivateIPAddressCount:
+                            format: int64
+                            type: integer
+                          subnetID:
+                            type: string
+                        type: object
+                      type: array
+                    placement:
+                      description: The placement for the instance.
+                      properties:
+                        affinity:
+                          type: string
+                        availabilityZone:
+                          type: string
+                        groupName:
+                          type: string
+                        hostID:
+                          type: string
+                        hostResourceGroupARN:
+                          type: string
+                        partitionNumber:
+                          format: int64
+                          type: integer
+                        spreadDomain:
+                          type: string
+                        tenancy:
+                          type: string
+                      type: object
+                    privateDNSNameOptions:
+                      description: |-
+                        The options for the instance hostname. The default values are inherited from
+                        the subnet.
+                      properties:
+                        enableResourceNameDNSAAAARecord:
+                          type: boolean
+                        enableResourceNameDNSARecord:
+                          type: boolean
+                        hostnameType:
+                          type: string
+                      type: object
+                    privateIPAddress:
+                      description: |-
+                        [EC2-VPC] The primary IPv4 address. You must specify a value from the IPv4
+                        address range of the subnet.
+
+
+                        Only one private IP address can be designated as primary. You can't specify
+                        this option if you've specified the option to designate a private IP address
+                        as the primary IP address in a network interface specification. You cannot
+                        specify this option if you're launching more than one instance in the request.
+
+
+                        You cannot specify this option and the network interfaces option in the same
+                        request.
+                      type: string
+                    ramDiskID:
+                      description: |-
+                        The ID of the RAM disk to select. Some kernels require additional drivers
+                        at launch. Check the kernel requirements for information about whether you
+                        need to specify a RAM disk. To find kernel requirements, go to the Amazon
+                        Web Services Resource Center and search for the kernel ID.
+
+
+                        We recommend that you use PV-GRUB instead of kernels and RAM disks. For more
+                        information, see PV-GRUB (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/UserProvidedkernels.html)
+                        in the Amazon EC2 User Guide.
+                      type: string
+                    securityGroupIDs:
+                      description: |-
+                        The IDs of the security groups. You can create a security group using CreateSecurityGroup
+                        (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSecurityGroup.html).
+
+
+                        If you specify a network interface, you must specify any security groups
+                        as part of the network interface.
+                      items:
+                        type: string
+                      type: array
+                    securityGroups:
+                      description: |-
+                        [EC2-Classic, default VPC] The names of the security groups. For a nondefault
+                        VPC, you must use security group IDs instead.
+
+
+                        If you specify a network interface, you must specify any security groups
+                        as part of the network interface.
+
+
+                        Default: Amazon EC2 uses the default security group.
+                      items:
+                        type: string
+                      type: array
+                    subnetID:
+                      description: |-
+                        [EC2-VPC] The ID of the subnet to launch the instance into.
+
+
+                        If you specify a network interface, you must specify any subnets as part
+                        of the network interface.
+                      type: string
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    userData:
+                      description: |-
+                        The user data script to make available to the instance. For more information,
+                        see Run commands on your Linux instance at launch (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html)
+                        and Run commands on your Windows instance at launch (https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-windows-user-data.html).
+                        If you are using a command line tool, base64-encoding is performed for you,
+                        and you can load the text from a file. Otherwise, you must provide base64-encoded
+                        text. User data is limited to 16 KB.
+                      type: string
+                  type: object
+                status:
+                  description: InstanceStatus defines the observed state of Instance
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    amiLaunchIndex:
+                      description: |-
+                        The AMI launch index, which can be used to find this instance in the launch
+                        group.
+                      format: int64
+                      type: integer
+                    architecture:
+                      description: The architecture of the image.
+                      type: string
+                    bootMode:
+                      description: |-
+                        The boot mode of the instance. For more information, see Boot modes (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ami-boot.html)
+                        in the Amazon EC2 User Guide.
+                      type: string
+                    capacityReservationID:
+                      description: The ID of the Capacity Reservation.
+                      type: string
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    elasticGPUAssociations:
+                      description: The Elastic GPU associated with the instance.
+                      items:
+                        description: Describes the association between an instance and an
+                          Elastic Graphics accelerator.
+                        properties:
+                          elasticGPUAssociationID:
+                            type: string
+                          elasticGPUAssociationState:
+                            type: string
+                          elasticGPUAssociationTime:
+                            type: string
+                          elasticGPUID:
+                            type: string
+                        type: object
+                      type: array
+                    elasticInferenceAcceleratorAssociations:
+                      description: The elastic inference accelerator associated with the
+                        instance.
+                      items:
+                        description: Describes the association between an instance and an
+                          elastic inference accelerator.
+                        properties:
+                          elasticInferenceAcceleratorARN:
+                            type: string
+                          elasticInferenceAcceleratorAssociationID:
+                            type: string
+                          elasticInferenceAcceleratorAssociationState:
+                            type: string
+                          elasticInferenceAcceleratorAssociationTime:
+                            format: date-time
+                            type: string
+                        type: object
+                      type: array
+                    enaSupport:
+                      description: Specifies whether enhanced networking with ENA is enabled.
+                      type: boolean
+                    hypervisor:
+                      description: |-
+                        The hypervisor type of the instance. The value xen is used for both Xen and
+                        Nitro hypervisors.
+                      type: string
+                    instanceID:
+                      description: The ID of the instance.
+                      type: string
+                    instanceLifecycle:
+                      description: Indicates whether this is a Spot Instance or a Scheduled
+                        Instance.
+                      type: string
+                    ipv6Address:
+                      description: The IPv6 address assigned to the instance.
+                      type: string
+                    launchTime:
+                      description: The time the instance was launched.
+                      format: date-time
+                      type: string
+                    licenses:
+                      description: The license configurations for the instance.
+                      items:
+                        description: Describes a license configuration.
+                        properties:
+                          licenseConfigurationARN:
+                            type: string
+                        type: object
+                      type: array
+                    outpostARN:
+                      description: The Amazon Resource Name (ARN) of the Outpost.
+                      type: string
+                    platform:
+                      description: The value is Windows for Windows instances; otherwise
+                        blank.
+                      type: string
+                    platformDetails:
+                      description: |-
+                        The platform details value for the instance. For more information, see AMI
+                        billing information fields (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/billing-info-fields.html)
+                        in the Amazon EC2 User Guide.
+                      type: string
+                    privateDNSName:
+                      description: |-
+                        (IPv4 only) The private DNS hostname name assigned to the instance. This
+                        DNS hostname can only be used inside the Amazon EC2 network. This name is
+                        not available until the instance enters the running state.
+
+
+                        [EC2-VPC] The Amazon-provided DNS server resolves Amazon-provided private
+                        DNS hostnames if you've enabled DNS resolution and DNS hostnames in your
+                        VPC. If you are not using the Amazon-provided DNS server in your VPC, your
+                        custom domain name servers must resolve the hostname as appropriate.
+                      type: string
+                    productCodes:
+                      description: The product codes attached to this instance, if applicable.
+                      items:
+                        description: Describes a product code.
+                        properties:
+                          productCodeID:
+                            type: string
+                          productCodeType:
+                            type: string
+                        type: object
+                      type: array
+                    publicDNSName:
+                      description: |-
+                        (IPv4 only) The public DNS name assigned to the instance. This name is not
+                        available until the instance enters the running state. For EC2-VPC, this
+                        name is only available if you've enabled DNS hostnames for your VPC.
+                      type: string
+                    publicIPAddress:
+                      description: |-
+                        The public IPv4 address, or the Carrier IP address assigned to the instance,
+                        if applicable.
+
+
+                        A Carrier IP address only applies to an instance launched in a subnet associated
+                        with a Wavelength Zone.
+                      type: string
+                    rootDeviceName:
+                      description: The device name of the root device volume (for example,
+                        /dev/sda1).
+                      type: string
+                    rootDeviceType:
+                      description: |-
+                        The root device type used by the AMI. The AMI can use an EBS volume or an
+                        instance store volume.
+                      type: string
+                    sourceDestCheck:
+                      description: Indicates whether source/destination checking is enabled.
+                      type: boolean
+                    spotInstanceRequestID:
+                      description: If the request is a Spot Instance request, the ID of
+                        the request.
+                      type: string
+                    sriovNetSupport:
+                      description: |-
+                        Specifies whether enhanced networking with the Intel 82599 Virtual Function
+                        interface is enabled.
+                      type: string
+                    state:
+                      description: The current state of the instance.
+                      properties:
+                        code:
+                          format: int64
+                          type: integer
+                        name:
+                          type: string
+                      type: object
+                    stateReason:
+                      description: The reason for the most recent state transition.
+                      properties:
+                        code:
+                          type: string
+                        message:
+                          type: string
+                      type: object
+                    stateTransitionReason:
+                      description: The reason for the most recent state transition. This
+                        might be an empty string.
+                      type: string
+                    tpmSupport:
+                      description: |-
+                        If the instance is configured for NitroTPM support, the value is v2.0. For
+                        more information, see NitroTPM (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nitrotpm.html)
+                        in the Amazon EC2 User Guide.
+                      type: string
+                    usageOperation:
+                      description: |-
+                        The usage operation value for the instance. For more information, see AMI
+                        billing information fields (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/billing-info-fields.html)
+                        in the Amazon EC2 User Guide.
+                      type: string
+                    usageOperationUpdateTime:
+                      description: The time that the usage operation was last updated.
+                      format: date-time
+                      type: string
+                    virtualizationType:
+                      description: The virtualization type of the instance.
+                      type: string
+                    vpcID:
+                      description: '[EC2-VPC] The ID of the VPC in which the instance is
+                        running.'
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: internetGatewayCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: internetgateways.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: InternetGateway
+          listKind: InternetGatewayList
+          plural: internetgateways
+          singular: internetgateway
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .status.internetGatewayID
+            name: ID
+            type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: InternetGateway is the Schema for the InternetGateways API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    InternetGatewaySpec defines the desired state of InternetGateway.
+
+
+                    Describes an internet gateway.
+                  properties:
+                    routeTableRefs:
+                      items:
+                        description: "AWSResourceReferenceWrapper provides a wrapper around
+                          *AWSResourceReference\ntype to provide more user friendly syntax
+                          for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                          \ name: my-api"
+                        properties:
+                          from:
+                            description: |-
+                              AWSResourceReference provides all the values necessary to reference another
+                              k8s resource for finding the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                    routeTables:
+                      items:
+                        type: string
+                      type: array
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    vpc:
+                      description: The ID of the VPC.
+                      type: string
+                    vpcRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                status:
+                  description: InternetGatewayStatus defines the observed state of InternetGateway
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    attachments:
+                      description: Any VPCs attached to the internet gateway.
+                      items:
+                        description: |-
+                          Describes the attachment of a VPC to an internet gateway or an egress-only
+                          internet gateway.
+                        properties:
+                          state:
+                            type: string
+                          vpcID:
+                            type: string
+                        type: object
+                      type: array
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    internetGatewayID:
+                      description: The ID of the internet gateway.
+                      type: string
+                    ownerID:
+                      description: The ID of the Amazon Web Services account that owns the
+                        internet gateway.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: natGatewayCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: natgateways.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: NATGateway
+          listKind: NATGatewayList
+          plural: natgateways
+          singular: natgateway
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .status.natGatewayID
+            name: ID
+            type: string
+          - jsonPath: .status.state
+            name: state
+            type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: NATGateway is the Schema for the NATGateways API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    NatGatewaySpec defines the desired state of NatGateway.
+
+
+                    Describes a NAT gateway.
+                  properties:
+                    allocationID:
+                      description: |-
+                        [Public NAT gateways only] The allocation ID of an Elastic IP address to
+                        associate with the NAT gateway. You cannot specify an Elastic IP address
+                        with a private NAT gateway. If the Elastic IP address is associated with
+                        another resource, you must first disassociate it.
+                      type: string
+                    allocationRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    connectivityType:
+                      description: |-
+                        Indicates whether the NAT gateway supports public or private connectivity.
+                        The default is public connectivity.
+                      type: string
+                    subnetID:
+                      description: The subnet in which to create the NAT gateway.
+                      type: string
+                    subnetRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                status:
+                  description: NATGatewayStatus defines the observed state of NATGateway
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    createTime:
+                      description: The date and time the NAT gateway was created.
+                      format: date-time
+                      type: string
+                    deleteTime:
+                      description: The date and time the NAT gateway was deleted, if applicable.
+                      format: date-time
+                      type: string
+                    failureCode:
+                      description: |-
+                        If the NAT gateway could not be created, specifies the error code for the
+                        failure. (InsufficientFreeAddressesInSubnet | Gateway.NotAttached | InvalidAllocationID.NotFound
+                        | Resource.AlreadyAssociated | InternalError | InvalidSubnetID.NotFound)
+                      type: string
+                    failureMessage:
+                      description: |-
+                        If the NAT gateway could not be created, specifies the error message for
+                        the failure, that corresponds to the error code.
+
+
+                          * For InsufficientFreeAddressesInSubnet: "Subnet has insufficient free
+                          addresses to create this NAT gateway"
+
+
+                          * For Gateway.NotAttached: "Network vpc-xxxxxxxx has no Internet gateway
+                          attached"
+
+
+                          * For InvalidAllocationID.NotFound: "Elastic IP address eipalloc-xxxxxxxx
+                          could not be associated with this NAT gateway"
+
+
+                          * For Resource.AlreadyAssociated: "Elastic IP address eipalloc-xxxxxxxx
+                          is already associated"
+
+
+                          * For InternalError: "Network interface eni-xxxxxxxx, created and used
+                          internally by this NAT gateway is in an invalid state. Please try again."
+
+
+                          * For InvalidSubnetID.NotFound: "The specified subnet subnet-xxxxxxxx
+                          does not exist or could not be found."
+                      type: string
+                    natGatewayAddresses:
+                      description: |-
+                        Information about the IP addresses and network interface associated with
+                        the NAT gateway.
+                      items:
+                        description: Describes the IP addresses and network interface associated
+                          with a NAT gateway.
+                        properties:
+                          allocationID:
+                            type: string
+                          networkInterfaceID:
+                            type: string
+                          privateIP:
+                            type: string
+                          publicIP:
+                            type: string
+                        type: object
+                      type: array
+                    natGatewayID:
+                      description: The ID of the NAT gateway.
+                      type: string
+                    provisionedBandwidth:
+                      description: |-
+                        Reserved. If you need to sustain traffic greater than the documented limits
+                        (https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html),
+                        contact us through the Support Center (https://console.aws.amazon.com/support/home?).
+                      properties:
+                        provisionTime:
+                          format: date-time
+                          type: string
+                        provisioned:
+                          type: string
+                        requestTime:
+                          format: date-time
+                          type: string
+                        requested:
+                          type: string
+                        status:
+                          type: string
+                      type: object
+                    state:
+                      description: |-
+                        The state of the NAT gateway.
+
+
+                          * pending: The NAT gateway is being created and is not ready to process
+                          traffic.
+
+
+                          * failed: The NAT gateway could not be created. Check the failureCode
+                          and failureMessage fields for the reason.
+
+
+                          * available: The NAT gateway is able to process traffic. This status remains
+                          until you delete the NAT gateway, and does not indicate the health of
+                          the NAT gateway.
+
+
+                          * deleting: The NAT gateway is in the process of being terminated and
+                          may still be processing traffic.
+
+
+                          * deleted: The NAT gateway has been terminated and is no longer processing
+                          traffic.
+                      type: string
+                    vpcID:
+                      description: The ID of the VPC in which the NAT gateway is located.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: networkAclCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: networkacls.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: NetworkACL
+          listKind: NetworkACLList
+          plural: networkacls
+          singular: networkacl
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .status.id
+            name: ID
+            type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: NetworkACL is the Schema for the NetworkACLS API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    NetworkAclSpec defines the desired state of NetworkAcl.
+
+
+                    Describes a network ACL.
+                  properties:
+                    associations:
+                      items:
+                        description: Describes an association between a network ACL and
+                          a subnet.
+                        properties:
+                          networkACLAssociationID:
+                            type: string
+                          networkACLID:
+                            type: string
+                          subnetID:
+                            type: string
+                          subnetRef:
+                            description: Reference field for SubnetID
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    entries:
+                      items:
+                        description: Describes an entry in a network ACL.
+                        properties:
+                          cidrBlock:
+                            type: string
+                          egress:
+                            type: boolean
+                          icmpTypeCode:
+                            description: Describes the ICMP type and code.
+                            properties:
+                              code:
+                                format: int64
+                                type: integer
+                              type_:
+                                format: int64
+                                type: integer
+                            type: object
+                          ipv6CIDRBlock:
+                            type: string
+                          portRange:
+                            description: Describes a range of ports.
+                            properties:
+                              from:
+                                format: int64
+                                type: integer
+                              to:
+                                format: int64
+                                type: integer
+                            type: object
+                          protocol:
+                            type: string
+                          ruleAction:
+                            type: string
+                          ruleNumber:
+                            format: int64
+                            type: integer
+                        type: object
+                      type: array
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    vpcID:
+                      description: The ID of the VPC.
+                      type: string
+                    vpcRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                status:
+                  description: NetworkACLStatus defines the observed state of NetworkACL
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    id:
+                      description: The ID of the network ACL.
+                      type: string
+                    isDefault:
+                      description: Indicates whether this is the default network ACL for
+                        the VPC.
+                      type: boolean
+                    ownerID:
+                      description: The ID of the Amazon Web Services account that owns the
+                        network ACL.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: routeTableCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: routetables.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: RouteTable
+          listKind: RouteTableList
+          plural: routetables
+          singular: routetable
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .status.routeTableID
+            name: ID
+            type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: RouteTable is the Schema for the RouteTables API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    RouteTableSpec defines the desired state of RouteTable.
+
+
+                    Describes a route table.
+                  properties:
+                    routes:
+                      items:
+                        properties:
+                          carrierGatewayID:
+                            type: string
+                          coreNetworkARN:
+                            type: string
+                          destinationCIDRBlock:
+                            type: string
+                          destinationIPv6CIDRBlock:
+                            type: string
+                          destinationPrefixListID:
+                            type: string
+                          egressOnlyInternetGatewayID:
+                            type: string
+                          gatewayID:
+                            type: string
+                          gatewayRef:
+                            description: Reference field for GatewayID
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          instanceID:
+                            type: string
+                          localGatewayID:
+                            type: string
+                          natGatewayID:
+                            type: string
+                          natGatewayRef:
+                            description: Reference field for NATGatewayID
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          networkInterfaceID:
+                            type: string
+                          transitGatewayID:
+                            type: string
+                          transitGatewayRef:
+                            description: Reference field for TransitGatewayID
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          vpcEndpointID:
+                            type: string
+                          vpcEndpointRef:
+                            description: Reference field for VPCEndpointID
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          vpcPeeringConnectionID:
+                            type: string
+                          vpcPeeringConnectionRef:
+                            description: Reference field for VPCPeeringConnectionID
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    vpcID:
+                      description: The ID of the VPC.
+                      type: string
+                    vpcRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                status:
+                  description: RouteTableStatus defines the observed state of RouteTable
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    associations:
+                      description: The associations between the route table and one or more
+                        subnets or a gateway.
+                      items:
+                        description: Describes an association between a route table and
+                          a subnet or gateway.
+                        properties:
+                          associationState:
+                            description: |-
+                              Describes the state of an association between a route table and a subnet
+                              or gateway.
+                            properties:
+                              state:
+                                type: string
+                              statusMessage:
+                                type: string
+                            type: object
+                          gatewayID:
+                            type: string
+                          main:
+                            type: boolean
+                          routeTableAssociationID:
+                            type: string
+                          routeTableID:
+                            type: string
+                          subnetID:
+                            type: string
+                        type: object
+                      type: array
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    ownerID:
+                      description: The ID of the Amazon Web Services account that owns the
+                        route table.
+                      type: string
+                    propagatingVGWs:
+                      description: Any virtual private gateway (VGW) propagating routes.
+                      items:
+                        description: Describes a virtual private gateway propagating route.
+                        properties:
+                          gatewayID:
+                            type: string
+                        type: object
+                      type: array
+                    routeStatuses:
+                      description: The routes in the route table.
+                      items:
+                        description: Describes a route in a route table.
+                        properties:
+                          carrierGatewayID:
+                            type: string
+                          coreNetworkARN:
+                            type: string
+                          destinationCIDRBlock:
+                            type: string
+                          destinationIPv6CIDRBlock:
+                            type: string
+                          destinationPrefixListID:
+                            type: string
+                          egressOnlyInternetGatewayID:
+                            type: string
+                          gatewayID:
+                            type: string
+                          instanceID:
+                            type: string
+                          instanceOwnerID:
+                            type: string
+                          localGatewayID:
+                            type: string
+                          natGatewayID:
+                            type: string
+                          networkInterfaceID:
+                            type: string
+                          origin:
+                            type: string
+                          state:
+                            type: string
+                          transitGatewayID:
+                            type: string
+                          vpcPeeringConnectionID:
+                            type: string
+                        type: object
+                      type: array
+                    routeTableID:
+                      description: The ID of the route table.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: securityGroupCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: securitygroups.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: SecurityGroup
+          listKind: SecurityGroupList
+          plural: securitygroups
+          singular: securitygroup
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .status.id
+            name: ID
+            type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: SecurityGroup is the Schema for the SecurityGroups API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    SecurityGroupSpec defines the desired state of SecurityGroup.
+
+
+                    Describes a security group.
+                  properties:
+                    description:
+                      description: |-
+                        A description for the security group. This is informational only.
+
+
+                        Constraints: Up to 255 characters in length
+
+
+                        Constraints for EC2-Classic: ASCII characters
+
+
+                        Constraints for EC2-VPC: a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*
+                      type: string
+                    egressRules:
+                      items:
+                        description: Describes a set of permissions for a security group
+                          rule.
+                        properties:
+                          fromPort:
+                            format: int64
+                            type: integer
+                          ipProtocol:
+                            type: string
+                          ipRanges:
+                            items:
+                              description: Describes an IPv4 range.
+                              properties:
+                                cidrIP:
+                                  type: string
+                                description:
+                                  type: string
+                              type: object
+                            type: array
+                          ipv6Ranges:
+                            items:
+                              description: '[EC2-VPC only] Describes an IPv6 range.'
+                              properties:
+                                cidrIPv6:
+                                  type: string
+                                description:
+                                  type: string
+                              type: object
+                            type: array
+                          prefixListIDs:
+                            items:
+                              description: Describes a prefix list ID.
+                              properties:
+                                description:
+                                  type: string
+                                prefixListID:
+                                  type: string
+                              type: object
+                            type: array
+                          toPort:
+                            format: int64
+                            type: integer
+                          userIDGroupPairs:
+                            items:
+                              description: |-
+                                Describes a security group and Amazon Web Services account ID pair.
+
+
+                                We are retiring EC2-Classic on August 15, 2022. We recommend that you migrate
+                                from EC2-Classic to a VPC. For more information, see Migrate from EC2-Classic
+                                to a VPC (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-migrate.html)
+                                in the Amazon Elastic Compute Cloud User Guide.
+                              properties:
+                                description:
+                                  type: string
+                                groupID:
+                                  type: string
+                                groupName:
+                                  type: string
+                                groupRef:
+                                  description: Reference field for GroupID
+                                  properties:
+                                    from:
+                                      description: |-
+                                        AWSResourceReference provides all the values necessary to reference another
+                                        k8s resource for finding the identifier(Id/ARN/Name)
+                                      properties:
+                                        name:
+                                          type: string
+                                        namespace:
+                                          type: string
+                                      type: object
+                                  type: object
+                                peeringStatus:
+                                  type: string
+                                userID:
+                                  type: string
+                                vpcID:
+                                  type: string
+                                vpcPeeringConnectionID:
+                                  type: string
+                                vpcRef:
+                                  description: Reference field for VPCID
+                                  properties:
+                                    from:
+                                      description: |-
+                                        AWSResourceReference provides all the values necessary to reference another
+                                        k8s resource for finding the identifier(Id/ARN/Name)
+                                      properties:
+                                        name:
+                                          type: string
+                                        namespace:
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    ingressRules:
+                      items:
+                        description: Describes a set of permissions for a security group
+                          rule.
+                        properties:
+                          fromPort:
+                            format: int64
+                            type: integer
+                          ipProtocol:
+                            type: string
+                          ipRanges:
+                            items:
+                              description: Describes an IPv4 range.
+                              properties:
+                                cidrIP:
+                                  type: string
+                                description:
+                                  type: string
+                              type: object
+                            type: array
+                          ipv6Ranges:
+                            items:
+                              description: '[EC2-VPC only] Describes an IPv6 range.'
+                              properties:
+                                cidrIPv6:
+                                  type: string
+                                description:
+                                  type: string
+                              type: object
+                            type: array
+                          prefixListIDs:
+                            items:
+                              description: Describes a prefix list ID.
+                              properties:
+                                description:
+                                  type: string
+                                prefixListID:
+                                  type: string
+                              type: object
+                            type: array
+                          toPort:
+                            format: int64
+                            type: integer
+                          userIDGroupPairs:
+                            items:
+                              description: |-
+                                Describes a security group and Amazon Web Services account ID pair.
+
+
+                                We are retiring EC2-Classic on August 15, 2022. We recommend that you migrate
+                                from EC2-Classic to a VPC. For more information, see Migrate from EC2-Classic
+                                to a VPC (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-migrate.html)
+                                in the Amazon Elastic Compute Cloud User Guide.
+                              properties:
+                                description:
+                                  type: string
+                                groupID:
+                                  type: string
+                                groupName:
+                                  type: string
+                                groupRef:
+                                  description: Reference field for GroupID
+                                  properties:
+                                    from:
+                                      description: |-
+                                        AWSResourceReference provides all the values necessary to reference another
+                                        k8s resource for finding the identifier(Id/ARN/Name)
+                                      properties:
+                                        name:
+                                          type: string
+                                        namespace:
+                                          type: string
+                                      type: object
+                                  type: object
+                                peeringStatus:
+                                  type: string
+                                userID:
+                                  type: string
+                                vpcID:
+                                  type: string
+                                vpcPeeringConnectionID:
+                                  type: string
+                                vpcRef:
+                                  description: Reference field for VPCID
+                                  properties:
+                                    from:
+                                      description: |-
+                                        AWSResourceReference provides all the values necessary to reference another
+                                        k8s resource for finding the identifier(Id/ARN/Name)
+                                      properties:
+                                        name:
+                                          type: string
+                                        namespace:
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    name:
+                      description: |-
+                        The name of the security group.
+
+
+                        Constraints: Up to 255 characters in length. Cannot start with sg-.
+
+
+                        Constraints for EC2-Classic: ASCII characters
+
+
+                        Constraints for EC2-VPC: a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*
+                      type: string
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    vpcID:
+                      description: '[EC2-VPC] The ID of the VPC. Required for EC2-VPC.'
+                      type: string
+                    vpcRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - description
+                  - name
+                  type: object
+                status:
+                  description: SecurityGroupStatus defines the observed state of SecurityGroup
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    id:
+                      description: The ID of the security group.
+                      type: string
+                    rules:
+                      description: Information about security group rules.
+                      items:
+                        description: Describes a security group rule.
+                        properties:
+                          cidrIPv4:
+                            type: string
+                          cidrIPv6:
+                            type: string
+                          description:
+                            type: string
+                          fromPort:
+                            format: int64
+                            type: integer
+                          ipProtocol:
+                            type: string
+                          isEgress:
+                            type: boolean
+                          prefixListID:
+                            type: string
+                          securityGroupRuleID:
+                            type: string
+                          tags:
+                            items:
+                              description: Describes a tag.
+                              properties:
+                                key:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          toPort:
+                            format: int64
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: subnetCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: subnets.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: Subnet
+          listKind: SubnetList
+          plural: subnets
+          singular: subnet
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .status.subnetID
+            name: ID
+            type: string
+          - jsonPath: .status.state
+            name: state
+            type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: Subnet is the Schema for the Subnets API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    SubnetSpec defines the desired state of Subnet.
+
+
+                    Describes a subnet.
+                  properties:
+                    assignIPv6AddressOnCreation:
+                      type: boolean
+                    availabilityZone:
+                      description: |-
+                        The Availability Zone or Local Zone for the subnet.
+
+
+                        Default: Amazon Web Services selects one for you. If you create more than
+                        one subnet in your VPC, we do not necessarily select a different zone for
+                        each subnet.
+
+
+                        To create a subnet in a Local Zone, set this value to the Local Zone ID,
+                        for example us-west-2-lax-1a. For information about the Regions that support
+                        Local Zones, see Available Regions (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions)
+                        in the Amazon Elastic Compute Cloud User Guide.
+
+
+                        To create a subnet in an Outpost, set this value to the Availability Zone
+                        for the Outpost and specify the Outpost ARN.
+                      type: string
+                    availabilityZoneID:
+                      description: The AZ ID or the Local Zone ID of the subnet.
+                      type: string
+                    cidrBlock:
+                      description: |-
+                        The IPv4 network range for the subnet, in CIDR notation. For example, 10.0.0.0/24.
+                        We modify the specified CIDR block to its canonical form; for example, if
+                        you specify 100.68.0.18/18, we modify it to 100.68.0.0/18.
+
+
+                        This parameter is not supported for an IPv6 only subnet.
+                      type: string
+                    customerOwnedIPv4Pool:
+                      type: string
+                    enableDNS64:
+                      type: boolean
+                    enableResourceNameDNSAAAARecord:
+                      type: boolean
+                    enableResourceNameDNSARecord:
+                      type: boolean
+                    hostnameType:
+                      type: string
+                    ipv6CIDRBlock:
+                      description: |-
+                        The IPv6 network range for the subnet, in CIDR notation. The subnet size
+                        must use a /64 prefix length.
+
+
+                        This parameter is required for an IPv6 only subnet.
+                      type: string
+                    ipv6Native:
+                      description: Indicates whether to create an IPv6 only subnet.
+                      type: boolean
+                    mapPublicIPOnLaunch:
+                      type: boolean
+                    outpostARN:
+                      description: |-
+                        The Amazon Resource Name (ARN) of the Outpost. If you specify an Outpost
+                        ARN, you must also specify the Availability Zone of the Outpost subnet.
+                      type: string
+                    routeTableRefs:
+                      items:
+                        description: "AWSResourceReferenceWrapper provides a wrapper around
+                          *AWSResourceReference\ntype to provide more user friendly syntax
+                          for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                          \ name: my-api"
+                        properties:
+                          from:
+                            description: |-
+                              AWSResourceReference provides all the values necessary to reference another
+                              k8s resource for finding the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                    routeTables:
+                      items:
+                        type: string
+                      type: array
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    vpcID:
+                      description: The ID of the VPC.
+                      type: string
+                    vpcRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                status:
+                  description: SubnetStatus defines the observed state of Subnet
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    availableIPAddressCount:
+                      description: |-
+                        The number of unused private IPv4 addresses in the subnet. The IPv4 addresses
+                        for any stopped instances are considered unavailable.
+                      format: int64
+                      type: integer
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    defaultForAZ:
+                      description: Indicates whether this is the default subnet for the
+                        Availability Zone.
+                      type: boolean
+                    enableLniAtDeviceIndex:
+                      description: |-
+                        Indicates the device position for local network interfaces in this subnet.
+                        For example, 1 indicates local network interfaces in this subnet are the
+                        secondary network interface (eth1).
+                      format: int64
+                      type: integer
+                    ipv6CIDRBlockAssociationSet:
+                      description: Information about the IPv6 CIDR blocks associated with
+                        the subnet.
+                      items:
+                        description: Describes an association between a subnet and an IPv6
+                          CIDR block.
+                        properties:
+                          associationID:
+                            type: string
+                          ipv6CIDRBlock:
+                            type: string
+                          ipv6CIDRBlockState:
+                            description: Describes the state of a CIDR block.
+                            properties:
+                              state:
+                                type: string
+                              statusMessage:
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                    mapCustomerOwnedIPOnLaunch:
+                      description: |-
+                        Indicates whether a network interface created in this subnet (including a
+                        network interface created by RunInstances) receives a customer-owned IPv4
+                        address.
+                      type: boolean
+                    ownerID:
+                      description: The ID of the Amazon Web Services account that owns the
+                        subnet.
+                      type: string
+                    privateDNSNameOptionsOnLaunch:
+                      description: |-
+                        The type of hostnames to assign to instances in the subnet at launch. An
+                        instance hostname is based on the IPv4 address or ID of the instance.
+                      properties:
+                        enableResourceNameDNSAAAARecord:
+                          type: boolean
+                        enableResourceNameDNSARecord:
+                          type: boolean
+                        hostnameType:
+                          type: string
+                      type: object
+                    state:
+                      description: The current state of the subnet.
+                      type: string
+                    subnetID:
+                      description: The ID of the subnet.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: transitGatewayCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: transitgateways.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: TransitGateway
+          listKind: TransitGatewayList
+          plural: transitgateways
+          singular: transitgateway
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .status.transitGatewayID
+            name: ID
+            type: string
+          - jsonPath: .status.state
+            name: state
+            type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: TransitGateway is the Schema for the TransitGateways API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    TransitGatewaySpec defines the desired state of TransitGateway.
+
+
+                    Describes a transit gateway.
+                  properties:
+                    description:
+                      description: A description of the transit gateway.
+                      type: string
+                    options:
+                      description: The transit gateway options.
+                      properties:
+                        amazonSideASN:
+                          format: int64
+                          type: integer
+                        autoAcceptSharedAttachments:
+                          type: string
+                        defaultRouteTableAssociation:
+                          type: string
+                        defaultRouteTablePropagation:
+                          type: string
+                        dnsSupport:
+                          type: string
+                        multicastSupport:
+                          type: string
+                        transitGatewayCIDRBlocks:
+                          items:
+                            type: string
+                          type: array
+                        vpnECMPSupport:
+                          type: string
+                      type: object
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                status:
+                  description: TransitGatewayStatus defines the observed state of TransitGateway
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    creationTime:
+                      description: The creation time.
+                      format: date-time
+                      type: string
+                    ownerID:
+                      description: The ID of the Amazon Web Services account that owns the
+                        transit gateway.
+                      type: string
+                    state:
+                      description: The state of the transit gateway.
+                      type: string
+                    transitGatewayID:
+                      description: The ID of the transit gateway.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: vpcEndpointCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: vpcendpoints.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: VPCEndpoint
+          listKind: VPCEndpointList
+          plural: vpcendpoints
+          singular: vpcendpoint
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .status.vpcEndpointID
+            name: ID
+            type: string
+          - jsonPath: .status.state
+            name: state
+            type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: VPCEndpoint is the Schema for the VPCEndpoints API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    VpcEndpointSpec defines the desired state of VpcEndpoint.
+
+
+                    Describes a VPC endpoint.
+                  properties:
+                    dnsOptions:
+                      description: The DNS options for the endpoint.
+                      properties:
+                        dnsRecordIPType:
+                          type: string
+                      type: object
+                    ipAddressType:
+                      description: The IP address type for the endpoint.
+                      type: string
+                    policyDocument:
+                      description: |-
+                        (Interface and gateway endpoints) A policy to attach to the endpoint that
+                        controls access to the service. The policy must be in valid JSON format.
+                        If this parameter is not specified, we attach a default policy that allows
+                        full access to the service.
+                      type: string
+                    privateDNSEnabled:
+                      description: |-
+                        (Interface endpoint) Indicates whether to associate a private hosted zone
+                        with the specified VPC. The private hosted zone contains a record set for
+                        the default public DNS name for the service for the Region (for example,
+                        kinesis.us-east-1.amazonaws.com), which resolves to the private IP addresses
+                        of the endpoint network interfaces in the VPC. This enables you to make requests
+                        to the default public DNS name for the service instead of the public DNS
+                        names that are automatically generated by the VPC endpoint service.
+
+
+                        To use a private hosted zone, you must set the following VPC attributes to
+                        true: enableDnsHostnames and enableDnsSupport. Use ModifyVpcAttribute to
+                        set the VPC attributes.
+
+
+                        Default: true
+                      type: boolean
+                    routeTableIDs:
+                      description: (Gateway endpoint) One or more route table IDs.
+                      items:
+                        type: string
+                      type: array
+                    routeTableRefs:
+                      items:
+                        description: "AWSResourceReferenceWrapper provides a wrapper around
+                          *AWSResourceReference\ntype to provide more user friendly syntax
+                          for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                          \ name: my-api"
+                        properties:
+                          from:
+                            description: |-
+                              AWSResourceReference provides all the values necessary to reference another
+                              k8s resource for finding the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                    securityGroupIDs:
+                      description: |-
+                        (Interface endpoint) The ID of one or more security groups to associate with
+                        the endpoint network interface.
+                      items:
+                        type: string
+                      type: array
+                    securityGroupRefs:
+                      items:
+                        description: "AWSResourceReferenceWrapper provides a wrapper around
+                          *AWSResourceReference\ntype to provide more user friendly syntax
+                          for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                          \ name: my-api"
+                        properties:
+                          from:
+                            description: |-
+                              AWSResourceReference provides all the values necessary to reference another
+                              k8s resource for finding the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                    serviceName:
+                      description: |-
+                        The service name. To get a list of available services, use the DescribeVpcEndpointServices
+                        request, or get the name from the service provider.
+                      type: string
+                    subnetIDs:
+                      description: |-
+                        (Interface and Gateway Load Balancer endpoints) The ID of one or more subnets
+                        in which to create an endpoint network interface. For a Gateway Load Balancer
+                        endpoint, you can specify one subnet only.
+                      items:
+                        type: string
+                      type: array
+                    subnetRefs:
+                      items:
+                        description: "AWSResourceReferenceWrapper provides a wrapper around
+                          *AWSResourceReference\ntype to provide more user friendly syntax
+                          for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                          \ name: my-api"
+                        properties:
+                          from:
+                            description: |-
+                              AWSResourceReference provides all the values necessary to reference another
+                              k8s resource for finding the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    vpcEndpointType:
+                      description: |-
+                        The type of endpoint.
+
+
+                        Default: Gateway
+                      type: string
+                    vpcID:
+                      description: The ID of the VPC in which the endpoint will be used.
+                      type: string
+                    vpcRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - serviceName
+                  type: object
+                status:
+                  description: VPCEndpointStatus defines the observed state of VPCEndpoint
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    creationTimestamp:
+                      description: The date and time that the endpoint was created.
+                      format: date-time
+                      type: string
+                    dnsEntries:
+                      description: (Interface endpoint) The DNS entries for the endpoint.
+                      items:
+                        description: Describes a DNS entry.
+                        properties:
+                          dnsName:
+                            type: string
+                          hostedZoneID:
+                            type: string
+                        type: object
+                      type: array
+                    groups:
+                      description: |-
+                        (Interface endpoint) Information about the security groups that are associated
+                        with the network interface.
+                      items:
+                        description: Describes a security group.
+                        properties:
+                          groupID:
+                            type: string
+                          groupName:
+                            type: string
+                        type: object
+                      type: array
+                    lastError:
+                      description: The last error that occurred for endpoint.
+                      properties:
+                        code:
+                          type: string
+                        message:
+                          type: string
+                      type: object
+                    networkInterfaceIDs:
+                      description: (Interface endpoint) One or more network interfaces for
+                        the endpoint.
+                      items:
+                        type: string
+                      type: array
+                    ownerID:
+                      description: The ID of the Amazon Web Services account that owns the
+                        endpoint.
+                      type: string
+                    requesterManaged:
+                      description: Indicates whether the endpoint is being managed by its
+                        service.
+                      type: boolean
+                    state:
+                      description: The state of the endpoint.
+                      type: string
+                    vpcEndpointID:
+                      description: The ID of the endpoint.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: vpcEndpointServiceConfigurationCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: vpcendpointserviceconfigurations.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: VPCEndpointServiceConfiguration
+          listKind: VPCEndpointServiceConfigurationList
+          plural: vpcendpointserviceconfigurations
+          singular: vpcendpointserviceconfiguration
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .status.serviceID
+            name: ServiceID
+            type: string
+          - jsonPath: .status.serviceState
+            name: ServiceState
+            type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: VPCEndpointServiceConfiguration is the Schema for the VPCEndpointServiceConfigurations
+                API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: VpcEndpointServiceConfigurationSpec defines the desired state
+                    of VpcEndpointServiceConfiguration.
+                  properties:
+                    acceptanceRequired:
+                      description: |-
+                        Indicates whether requests from service consumers to create an endpoint to
+                        your service must be accepted manually.
+                      type: boolean
+                    allowedPrincipals:
+                      description: |-
+                        The Amazon Resource Names (ARN) of one or more principals. Permissions are
+                        granted to the principals in this list. To grant permissions to all principals,
+                        specify an asterisk (*).
+                      items:
+                        type: string
+                      type: array
+                    gatewayLoadBalancerARNs:
+                      description: The Amazon Resource Names (ARNs) of one or more Gateway
+                        Load Balancers.
+                      items:
+                        type: string
+                      type: array
+                    networkLoadBalancerARNs:
+                      description: |-
+                        The Amazon Resource Names (ARNs) of one or more Network Load Balancers for
+                        your service.
+                      items:
+                        type: string
+                      type: array
+                    privateDNSName:
+                      description: |-
+                        (Interface endpoint configuration) The private DNS name to assign to the
+                        VPC endpoint service.
+                      type: string
+                    supportedIPAddressTypes:
+                      description: The supported IP address types. The possible values are
+                        ipv4 and ipv6.
+                      items:
+                        type: string
+                      type: array
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                status:
+                  description: VPCEndpointServiceConfigurationStatus defines the observed
+                    state of VPCEndpointServiceConfiguration
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    availabilityZones:
+                      description: The Availability Zones in which the service is available.
+                      items:
+                        type: string
+                      type: array
+                    baseEndpointDNSNames:
+                      description: The DNS names for the service.
+                      items:
+                        type: string
+                      type: array
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    managesVPCEndpoints:
+                      description: |-
+                        Indicates whether the service manages its VPC endpoints. Management of the
+                        service VPC endpoints using the VPC endpoint API is restricted.
+                      type: boolean
+                    payerResponsibility:
+                      description: The payer responsibility.
+                      type: string
+                    privateDNSNameConfiguration:
+                      description: Information about the endpoint service private DNS name
+                        configuration.
+                      properties:
+                        name:
+                          type: string
+                        state:
+                          type: string
+                        type_:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    serviceID:
+                      description: The ID of the service.
+                      type: string
+                    serviceName:
+                      description: The name of the service.
+                      type: string
+                    serviceState:
+                      description: The service state.
+                      type: string
+                    serviceType:
+                      description: The type of service.
+                      items:
+                        description: Describes the type of service for a VPC endpoint.
+                        properties:
+                          serviceType:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: vpcPeeringConnectionCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: vpcpeeringconnections.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: VPCPeeringConnection
+          listKind: VPCPeeringConnectionList
+          plural: vpcpeeringconnections
+          singular: vpcpeeringconnection
+        scope: Namespaced
+        versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: VPCPeeringConnection is the Schema for the VPCPeeringConnections
+                API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    VpcPeeringConnectionSpec defines the desired state of VpcPeeringConnection.
+
+
+                    Describes a VPC peering connection.
+                  properties:
+                    acceptRequest:
+                      type: boolean
+                    accepterPeeringConnectionOptions:
+                      description: The VPC peering connection options for the accepter VPC.
+                      properties:
+                        allowDNSResolutionFromRemoteVPC:
+                          type: boolean
+                        allowEgressFromLocalClassicLinkToRemoteVPC:
+                          type: boolean
+                        allowEgressFromLocalVPCToRemoteClassicLink:
+                          type: boolean
+                      type: object
+                    peerOwnerID:
+                      description: |-
+                        The Amazon Web Services account ID of the owner of the accepter VPC.
+
+
+                        Default: Your Amazon Web Services account ID
+                      type: string
+                    peerRegion:
+                      description: |-
+                        The Region code for the accepter VPC, if the accepter VPC is located in a
+                        Region other than the Region in which you make the request.
+
+
+                        Default: The Region in which you make the request.
+                      type: string
+                    peerVPCID:
+                      description: |-
+                        The ID of the VPC with which you are creating the VPC peering connection.
+                        You must specify this parameter in the request.
+                      type: string
+                    peerVPCRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    requesterPeeringConnectionOptions:
+                      description: The VPC peering connection options for the requester
+                        VPC.
+                      properties:
+                        allowDNSResolutionFromRemoteVPC:
+                          type: boolean
+                        allowEgressFromLocalClassicLinkToRemoteVPC:
+                          type: boolean
+                        allowEgressFromLocalVPCToRemoteClassicLink:
+                          type: boolean
+                      type: object
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    vpcID:
+                      description: The ID of the requester VPC. You must specify this parameter
+                        in the request.
+                      type: string
+                    vpcRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                status:
+                  description: VPCPeeringConnectionStatus defines the observed state of
+                    VPCPeeringConnection
+                  properties:
+                    accepterVPCInfo:
+                      description: |-
+                        Information about the accepter VPC. CIDR block information is only returned
+                        when describing an active VPC peering connection.
+                      properties:
+                        cidrBlock:
+                          type: string
+                        cidrBlockSet:
+                          items:
+                            description: Describes an IPv4 CIDR block.
+                            properties:
+                              cidrBlock:
+                                type: string
+                            type: object
+                          type: array
+                        ipv6CIDRBlockSet:
+                          items:
+                            description: Describes an IPv6 CIDR block.
+                            properties:
+                              ipv6CIDRBlock:
+                                type: string
+                            type: object
+                          type: array
+                        ownerID:
+                          type: string
+                        peeringOptions:
+                          description: |-
+                            We are retiring EC2-Classic on August 15, 2022. We recommend that you migrate
+                            from EC2-Classic to a VPC. For more information, see Migrate from EC2-Classic
+                            to a VPC (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-migrate.html)
+                            in the Amazon Elastic Compute Cloud User Guide.
+
+
+                            Describes the VPC peering connection options.
+                          properties:
+                            allowDNSResolutionFromRemoteVPC:
+                              type: boolean
+                            allowEgressFromLocalClassicLinkToRemoteVPC:
+                              type: boolean
+                            allowEgressFromLocalVPCToRemoteClassicLink:
+                              type: boolean
+                          type: object
+                        region:
+                          type: string
+                        vpcID:
+                          type: string
+                      type: object
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    expirationTime:
+                      description: The time that an unaccepted VPC peering connection will
+                        expire.
+                      format: date-time
+                      type: string
+                    requesterVPCInfo:
+                      description: |-
+                        Information about the requester VPC. CIDR block information is only returned
+                        when describing an active VPC peering connection.
+                      properties:
+                        cidrBlock:
+                          type: string
+                        cidrBlockSet:
+                          items:
+                            description: Describes an IPv4 CIDR block.
+                            properties:
+                              cidrBlock:
+                                type: string
+                            type: object
+                          type: array
+                        ipv6CIDRBlockSet:
+                          items:
+                            description: Describes an IPv6 CIDR block.
+                            properties:
+                              ipv6CIDRBlock:
+                                type: string
+                            type: object
+                          type: array
+                        ownerID:
+                          type: string
+                        peeringOptions:
+                          description: |-
+                            We are retiring EC2-Classic on August 15, 2022. We recommend that you migrate
+                            from EC2-Classic to a VPC. For more information, see Migrate from EC2-Classic
+                            to a VPC (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-migrate.html)
+                            in the Amazon Elastic Compute Cloud User Guide.
+
+
+                            Describes the VPC peering connection options.
+                          properties:
+                            allowDNSResolutionFromRemoteVPC:
+                              type: boolean
+                            allowEgressFromLocalClassicLinkToRemoteVPC:
+                              type: boolean
+                            allowEgressFromLocalVPCToRemoteClassicLink:
+                              type: boolean
+                          type: object
+                        region:
+                          type: string
+                        vpcID:
+                          type: string
+                      type: object
+                    status:
+                      description: The status of the VPC peering connection.
+                      properties:
+                        code:
+                          type: string
+                        message:
+                          type: string
+                      type: object
+                    vpcPeeringConnectionID:
+                      description: The ID of the VPC peering connection.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: vpcCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: vpcs.ec2.services.k8s.aws
+      spec:
+        group: ec2.services.k8s.aws
+        names:
+          kind: VPC
+          listKind: VPCList
+          plural: vpcs
+          singular: vpc
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .status.vpcID
+            name: ID
+            type: string
+          - jsonPath: .status.state
+            name: state
+            type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: VPC is the Schema for the VPCS API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    VpcSpec defines the desired state of Vpc.
+
+
+                    Describes a VPC.
+                  properties:
+                    amazonProvidedIPv6CIDRBlock:
+                      description: |-
+                        Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for
+                        the VPC. You cannot specify the range of IP addresses, or the size of the
+                        CIDR block.
+                      type: boolean
+                    cidrBlocks:
+                      items:
+                        type: string
+                      type: array
+                    disallowSecurityGroupDefaultRules:
+                      type: boolean
+                    enableDNSHostnames:
+                      description: The attribute value. The valid values are true or false.
+                      type: boolean
+                    enableDNSSupport:
+                      description: The attribute value. The valid values are true or false.
+                      type: boolean
+                    instanceTenancy:
+                      description: |-
+                        The tenancy options for instances launched into the VPC. For default, instances
+                        are launched with shared tenancy by default. You can launch instances with
+                        any tenancy into a shared tenancy VPC. For dedicated, instances are launched
+                        as dedicated tenancy instances by default. You can only launch instances
+                        with a tenancy of dedicated or host into a dedicated tenancy VPC.
+
+
+                        Important: The host value cannot be used with this parameter. Use the default
+                        or dedicated values only.
+
+
+                        Default: default
+                      type: string
+                    ipv4IPAMPoolID:
+                      description: |-
+                        The ID of an IPv4 IPAM pool you want to use for allocating this VPC's CIDR.
+                        For more information, see What is IPAM? (https://docs.aws.amazon.com/vpc/latest/ipam/what-is-it-ipam.html)
+                        in the Amazon VPC IPAM User Guide.
+                      type: string
+                    ipv4NetmaskLength:
+                      description: |-
+                        The netmask length of the IPv4 CIDR you want to allocate to this VPC from
+                        an Amazon VPC IP Address Manager (IPAM) pool. For more information about
+                        IPAM, see What is IPAM? (https://docs.aws.amazon.com/vpc/latest/ipam/what-is-it-ipam.html)
+                        in the Amazon VPC IPAM User Guide.
+                      format: int64
+                      type: integer
+                    ipv6CIDRBlock:
+                      description: |-
+                        The IPv6 CIDR block from the IPv6 address pool. You must also specify Ipv6Pool
+                        in the request.
+
+
+                        To let Amazon choose the IPv6 CIDR block for you, omit this parameter.
+                      type: string
+                    ipv6CIDRBlockNetworkBorderGroup:
+                      description: |-
+                        The name of the location from which we advertise the IPV6 CIDR block. Use
+                        this parameter to limit the address to this location.
+
+
+                        You must set AmazonProvidedIpv6CidrBlock to true to use this parameter.
+                      type: string
+                    ipv6IPAMPoolID:
+                      description: |-
+                        The ID of an IPv6 IPAM pool which will be used to allocate this VPC an IPv6
+                        CIDR. IPAM is a VPC feature that you can use to automate your IP address
+                        management workflows including assigning, tracking, troubleshooting, and
+                        auditing IP addresses across Amazon Web Services Regions and accounts throughout
+                        your Amazon Web Services Organization. For more information, see What is
+                        IPAM? (https://docs.aws.amazon.com/vpc/latest/ipam/what-is-it-ipam.html)
+                        in the Amazon VPC IPAM User Guide.
+                      type: string
+                    ipv6NetmaskLength:
+                      description: |-
+                        The netmask length of the IPv6 CIDR you want to allocate to this VPC from
+                        an Amazon VPC IP Address Manager (IPAM) pool. For more information about
+                        IPAM, see What is IPAM? (https://docs.aws.amazon.com/vpc/latest/ipam/what-is-it-ipam.html)
+                        in the Amazon VPC IPAM User Guide.
+                      format: int64
+                      type: integer
+                    ipv6Pool:
+                      description: The ID of an IPv6 address pool from which to allocate
+                        the IPv6 CIDR block.
+                      type: string
+                    tags:
+                      description: |-
+                        The tags. The value parameter is required, but if you don't want the tag
+                        to have a value, specify the parameter with no value, and we set the value
+                        to an empty string.
+                      items:
+                        description: Describes a tag.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidrBlocks
+                  type: object
+                status:
+                  description: VPCStatus defines the observed state of VPC
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    cidrBlockAssociationSet:
+                      description: Information about the IPv4 CIDR blocks associated with
+                        the VPC.
+                      items:
+                        description: Describes an IPv4 CIDR block associated with a VPC.
+                        properties:
+                          associationID:
+                            type: string
+                          cidrBlock:
+                            type: string
+                          cidrBlockState:
+                            description: Describes the state of a CIDR block.
+                            properties:
+                              state:
+                                type: string
+                              statusMessage:
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    dhcpOptionsID:
+                      description: The ID of the set of DHCP options you've associated with
+                        the VPC.
+                      type: string
+                    ipv6CIDRBlockAssociationSet:
+                      description: Information about the IPv6 CIDR blocks associated with
+                        the VPC.
+                      items:
+                        description: Describes an IPv6 CIDR block associated with a VPC.
+                        properties:
+                          associationID:
+                            type: string
+                          ipv6CIDRBlock:
+                            type: string
+                          ipv6CIDRBlockState:
+                            description: Describes the state of a CIDR block.
+                            properties:
+                              state:
+                                type: string
+                              statusMessage:
+                                type: string
+                            type: object
+                          ipv6Pool:
+                            type: string
+                          networkBorderGroup:
+                            type: string
+                        type: object
+                      type: array
+                    isDefault:
+                      description: Indicates whether the VPC is the default VPC.
+                      type: boolean
+                    ownerID:
+                      description: The ID of the Amazon Web Services account that owns the
+                        VPC.
+                      type: string
+                    securityGroupDefaultRulesExist:
+                      type: boolean
+                    state:
+                      description: The current state of the VPC.
+                      type: string
+                    vpcID:
+                      description: The ID of the VPC.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: adoptedResourceCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: adoptedresources.services.k8s.aws
+      spec:
+        group: services.k8s.aws
+        names:
+          kind: AdoptedResource
+          listKind: AdoptedResourceList
+          plural: adoptedresources
+          singular: adoptedresource
+        scope: Namespaced
+        versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: AdoptedResource is the schema for the AdoptedResource API.
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: AdoptedResourceSpec defines the desired state of the AdoptedResource.
+                  properties:
+                    aws:
+                      description: AWSIdentifiers provide all unique ways to reference an
+                        AWS resource.
+                      properties:
+                        additionalKeys:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            AdditionalKeys represents any additional arbitrary identifiers used when
+                            describing the target resource.
+                          type: object
+                        arn:
+                          description: |-
+                            ARN is the AWS Resource Name for the resource. It is a globally
+                            unique identifier.
+                          type: string
+                        nameOrID:
+                          description: |-
+                            NameOrId is a user-supplied string identifier for the resource. It may
+                            or may not be globally unique, depending on the type of resource.
+                          type: string
+                      type: object
+                    kubernetes:
+                      description: |-
+                        ResourceWithMetadata provides the values necessary to create a
+                        Kubernetes resource and override any of its metadata values.
+                      properties:
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        metadata:
+                          description: |-
+                            ObjectMeta is metadata that all persisted resources must have, which includes all objects
+                            users must create.
+                            It is not possible to use `metav1.ObjectMeta` inside spec, as the controller-gen
+                            automatically converts this to an arbitrary string-string map.
+                            https://github.com/kubernetes-sigs/controller-tools/issues/385
+
+
+                            Active discussion about inclusion of this field in the spec is happening in this PR:
+                            https://github.com/kubernetes-sigs/controller-tools/pull/395
+
+
+                            Until this is allowed, or if it never is, we will produce a subset of the object meta
+                            that contains only the fields which the user is allowed to modify in the metadata.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Annotations is an unstructured key value map stored with a resource that may be
+                                set by external tools to store and retrieve arbitrary metadata. They are not
+                                queryable and should be preserved when modifying objects.
+                                More info: http://kubernetes.io/docs/user-guide/annotations
+                              type: object
+                            generateName:
+                              description: |-
+                                GenerateName is an optional prefix, used by the server, to generate a unique
+                                name ONLY IF the Name field has not been provided.
+                                If this field is used, the name returned to the client will be different
+                                than the name passed. This value will also be combined with a unique suffix.
+                                The provided value has the same validation rules as the Name field,
+                                and may be truncated by the length of the suffix required to make the value
+                                unique on the server.
+
+
+                                If this field is specified and the generated name exists, the server will
+                                NOT return a 409 - instead, it will either return 201 Created or 500 with Reason
+                                ServerTimeout indicating a unique name could not be found in the time allotted, and the client
+                                should retry (optionally after the time indicated in the Retry-After header).
+
+
+                                Applied only if Name is not specified.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                              type: string
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Map of string keys and values that can be used to organize and categorize
+                                (scope and select) objects. May match selectors of replication controllers
+                                and services.
+                                More info: http://kubernetes.io/docs/user-guide/labels
+                              type: object
+                            name:
+                              description: |-
+                                Name must be unique within a namespace. Is required when creating resources, although
+                                some resources may allow a client to request the generation of an appropriate name
+                                automatically. Name is primarily intended for creation idempotence and configuration
+                                definition.
+                                Cannot be updated.
+                                More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace defines the space within each name must be unique. An empty namespace is
+                                equivalent to the "default" namespace, but "default" is the canonical representation.
+                                Not all objects are required to be scoped to a namespace - the value of this field for
+                                those objects will be empty.
+
+
+                                Must be a DNS_LABEL.
+                                Cannot be updated.
+                                More info: http://kubernetes.io/docs/user-guide/namespaces
+                              type: string
+                            ownerReferences:
+                              description: |-
+                                List of objects depended by this object. If ALL objects in the list have
+                                been deleted, this object will be garbage collected. If this object is managed by a controller,
+                                then an entry in this list will point to this controller, with the controller field set to true.
+                                There cannot be more than one managing controller.
+                              items:
+                                description: |-
+                                  OwnerReference contains enough information to let you identify an owning
+                                  object. An owning object must be in the same namespace as the dependent, or
+                                  be cluster-scoped, so there is no namespace field.
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  blockOwnerDeletion:
+                                    description: |-
+                                      If true, AND if the owner has the "foregroundDeletion" finalizer, then
+                                      the owner cannot be deleted from the key-value store until this
+                                      reference is removed.
+                                      See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                      for how the garbage collector interacts with this field and enforces the foreground deletion.
+                                      Defaults to false.
+                                      To set this field, a user needs "delete" permission of the owner,
+                                      otherwise 422 (Unprocessable Entity) will be returned.
+                                    type: boolean
+                                  controller:
+                                    description: If true, this reference points to the managing
+                                      controller.
+                                    type: boolean
+                                  kind:
+                                    description: |-
+                                      Kind of the referent.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
+                                    type: string
+                                  uid:
+                                    description: |-
+                                      UID of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+                                    type: string
+                                required:
+                                - apiVersion
+                                - kind
+                                - name
+                                - uid
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                          type: object
+                      required:
+                      - group
+                      - kind
+                      type: object
+                  required:
+                  - aws
+                  - kubernetes
+                  type: object
+                status:
+                  description: AdoptedResourceStatus defines the observed status of the
+                    AdoptedResource.
+                  properties:
+                    conditions:
+                      description: |-
+                        A collection of `ackv1alpha1.Condition` objects that describe the various
+                        terminal states of the adopted resource CR and its target custom resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                  required:
+                  - conditions
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: fieldExportCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: fieldexports.services.k8s.aws
+      spec:
+        group: services.k8s.aws
+        names:
+          kind: FieldExport
+          listKind: FieldExportList
+          plural: fieldexports
+          singular: fieldexport
+        scope: Namespaced
+        versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: FieldExport is the schema for the FieldExport API.
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: FieldExportSpec defines the desired state of the FieldExport.
+                  properties:
+                    from:
+                      description: |-
+                        ResourceFieldSelector provides the values necessary to identify an individual
+                        field on an individual K8s resource.
+                      properties:
+                        path:
+                          type: string
+                        resource:
+                          description: |-
+                            NamespacedResource provides all the values necessary to identify an ACK
+                            resource of a given type (within the same namespace as the custom resource
+                            containing this type).
+                          properties:
+                            group:
+                              type: string
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - group
+                          - kind
+                          - name
+                          type: object
+                      required:
+                      - path
+                      - resource
+                      type: object
+                    to:
+                      description: |-
+                        FieldExportTarget provides the values necessary to identify the
+                        output path for a field export.
+                      properties:
+                        key:
+                          description: Key overrides the default value (`<namespace>.<FieldExport-resource-name>`)
+                            for the FieldExport target
+                          type: string
+                        kind:
+                          description: |-
+                            FieldExportOutputType represents all types that can be produced by a field
+                            export operation
+                          enum:
+                          - configmap
+                          - secret
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          description: Namespace is marked as optional, so we cannot compose
+                            `NamespacedName`
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                  required:
+                  - from
+                  - to
+                  type: object
+                status:
+                  description: FieldExportStatus defines the observed status of the FieldExport.
+                  properties:
+                    conditions:
+                      description: |-
+                        A collection of `ackv1alpha1.Condition` objects that describe the various
+                        recoverable states of the field CR
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                  required:
+                  - conditions
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}

--- a/examples/ack-controller/eks-controller/eks-controller-instance.yaml
+++ b/examples/ack-controller/eks-controller/eks-controller-instance.yaml
@@ -1,0 +1,23 @@
+apiVersion: x.symphony.k8s.aws/v1alpha1
+kind: EKScontroller
+metadata:
+  name: my-symphony-eks-controller
+  namespace: default
+spec:
+  name: ack-eks-controller
+  namespace: default
+  values: 
+    aws:
+      accountID: "399481058530"
+    deployment: {}
+    iamRole:
+      oidcProvider: oidc.eks.us-west-2.amazonaws.com/id/50B8942190FBD3A2EF2BF6AB7D27B06B
+    iamRolePolicy: {}
+    image:
+      resources:
+        requests: {}
+        limits: {}
+    log:
+      enabled: true
+      level: debug
+    serviceAccount: {}

--- a/examples/ack-controller/eks-controller/eks-controller.yaml
+++ b/examples/ack-controller/eks-controller/eks-controller.yaml
@@ -1,0 +1,289 @@
+apiVersion: x.symphony.k8s.aws/v1alpha1
+kind: ResourceGroup
+metadata:
+  name: ekscontrollers.x.symphony.k8s.aws
+spec:
+  apiVersion: v1alpha1
+  kind: EKSController
+  definition:
+    spec:
+      name: string | default=eks-controller
+      namespace: string | default=default
+      values:
+        aws:
+          accountID: string | required=true
+          region: string | default=us-west-2
+        deployment:
+          containerPort: integer | default=8080
+          replicas: integer | default=1
+        iamRole:
+          maxSessionDuration: integer | default=3600
+          oidcProvider: string | required=true
+          roleDescription: string | default=IRSA role for ACK EKS controller deployement on EKS cluster using Symphony Resource group
+        iamPolicy:
+          # would prefer to add a policyDocument here, need to support multiline string here
+          description: string | default="policy for eks controller"
+        image:
+          deletePolicy: string | default=delete
+          repository: string | default=public.ecr.aws/aws-controllers-k8s/eks-controller
+          tag: string | default=1.4.7
+          resources:
+            requests:
+              memory: string | default=64Mi
+              cpu: string | default=50m
+            limits:
+              memory: string | default=128Mi
+              cpu: string | default=100m
+        log:
+          enabled: boolean | default=false
+          level: string | default=info
+        serviceAccount:
+          name: string | default=eks-controller-sa
+  resources:
+  - name: eksCRDGroup
+    definition:
+      apiVersion: x.symphony.k8s.aws/v1alpha1
+      kind: EKSCRDGroup
+      metadata:
+        name: ${spec.name}-crd-group
+      spec:
+        name: ${spec.name}-crd-group
+  - name: eksControllerIamPolicy
+    definition:
+      apiVersion: iam.services.k8s.aws/v1alpha1
+      kind: Policy
+      metadata:
+        name: ${spec.name}-iam-policy
+      spec:
+        name: ${spec.name}-iam-policy
+        description: ${spec.values.iamPolicy.description}
+        policyDocument: >
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "VisualEditor0",
+                "Effect": "Allow",
+                "Action": [
+                  "eks:*",
+                  "iam:GetRole",
+                  "iam:PassRole",
+                  "iam:ListAttachedRolePolicies",
+                  "ec2:DescribeSubnets"
+                ],
+                "Resource": "*"
+              }
+            ]
+          }
+  - name: eksControllerIamRole
+    definition:
+      apiVersion: iam.services.k8s.aws/v1alpha1
+      kind: Role
+      metadata:
+        name: ${spec.name}-iam-role
+        namespace: ${spec.namespace}
+      spec:
+        name: ${spec.name}-iam-role
+        description: ${spec.values.iamRole.roleDescription}
+        maxSessionDuration: ${spec.values.iamRole.maxSessionDuration}
+        policies:
+        - ${eksControllerIamPolicy.status.ackResourceMetadata.arn}
+        assumeRolePolicyDocument: >
+          {
+            "Version":"2012-10-17",
+            "Statement": [{
+              "Effect":"Allow",
+              "Principal": {"Federated": "arn:aws:iam::${spec.values.aws.accountID}:oidc-provider/${spec.values.iamRole.oidcProvider}"},
+              "Action": ["sts:AssumeRoleWithWebIdentity"],
+              "Condition": {
+                "StringEquals": {"${spec.values.iamRole.oidcProvider}:sub": "system:serviceaccount:${spec.namespace}:${spec.values.serviceAccount.name}"}
+              }
+            }]
+          }
+  - name: serviceAccount
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ${spec.values.serviceAccount.name}
+        namespace: ${spec.namespace}
+        annotations:
+          eks.amazonaws.com/role-arn : ${eksControllerIamRole.status.ackResourceMetadata.arn}
+  - name: deployment
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ${spec.name}-deployment
+        namespace: ${spec.namespace}
+        labels:
+          app.kubernetes.io.name: ${spec.name}-deployment
+          app.kubernetes.io.instance: ${spec.name}
+      spec:
+        replicas: ${spec.values.deployment.replicas}
+        selector:
+          matchLabels:
+            app.kubernetes.io.name: ${spec.name}-deployment
+            app.kubernetes.io.instance: ${spec.name}
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io.name: ${spec.name}-deployment
+              app.kubernetes.io.instance: ${spec.name}
+          spec:
+            serviceAccountName: ${serviceAccount.metadata.name}
+            containers:
+            - command:
+              - ./bin/controller
+              args:
+              - --aws-region
+              - ${spec.values.aws.region}
+              - --enable-development-logging=${spec.values.log.enabled}
+              - --log-level
+              - ${spec.values.log.level}
+              - --deletion-policy
+              - ${spec.values.image.deletePolicy}
+              - --watch-namespace
+              - ${spec.namespace}
+              image: ${spec.values.image.repository}:${spec.values.image.tag}
+              name: controller
+              ports:
+                - name: http
+                  containerPort: ${spec.values.deployment.containerPort}
+              resources:
+                requests:
+                  memory: ${spec.values.image.resources.requests.memory}
+                  cpu: ${spec.values.image.resources.requests.cpu}
+                limits:
+                    memory: ${spec.values.image.resources.limits.memory}
+                    cpu: ${spec.values.image.resources.limits.cpu}
+              env:
+              - name: ACK_SYSTEM_NAMESPACE
+                value: ${spec.namespace}
+              - name: AWS_REGION
+                value: ${spec.values.aws.region}
+              - name: DELETE_POLICY
+                value: ${spec.values.image.deletePolicy}
+              - name: ACK_LOG_LEVEL
+                value: ${spec.values.log.level}              
+              ports:
+              - containerPort: 80
+  - name: clusterRoleBinding
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: ${spec.name}-clusterrolebinding
+      roleRef:
+        kind: ClusterRole
+        apiGroup: rbac.authorization.k8s.io
+        name: ${clusterRole.metadata.name}
+      subjects:
+      - kind: ServiceAccount
+        name: ${serviceAccount.metadata.name}
+        namespace: ${serviceAccount.metadata.namespace}
+  - name: clusterRole
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ${spec.name}-clusterrole
+      rules:
+      - apiGroups:
+        - ""
+        resources:
+        - configmaps
+        - secrets
+        verbs:
+        - get
+        - list
+        - patch
+        - watch
+      - apiGroups:
+        - ""
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ec2.services.k8s.aws
+        resources:
+        - securitygroups
+        - securitygroups/status
+        - subnets
+        - subnets/status
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - eks.services.k8s.aws
+        resources:
+        - accessentries
+        - addons
+        - clusters
+        - fargateprofiles
+        - identityproviderconfigs
+        - nodegroups
+        - podidentityassociations
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - eks.services.k8s.aws
+        resources:
+        - accessentries/status
+        - addons/status
+        - clusters/status
+        - fargateprofiles/status
+        - identityproviderconfigs/status
+        - nodegroups/status
+        - podidentityassociations/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - iam.services.k8s.aws
+        resources:
+        - roles
+        - roles/status
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - kms.services.k8s.aws
+        resources:
+        - keys
+        - keys/status
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - services.k8s.aws
+        resources:
+        - adoptedresources
+        - fieldexports
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - services.k8s.aws
+        resources:
+        - adoptedresources/status
+        - fieldexports/status
+        verbs:
+        - get
+        - patch
+        - update

--- a/examples/ack-controller/eks-controller/eks-crd-group.yaml
+++ b/examples/ack-controller/eks-controller/eks-crd-group.yaml
@@ -1,0 +1,2190 @@
+apiVersion: x.symphony.k8s.aws/v1alpha1
+kind: ResourceGroup
+metadata:
+  name: ekscrds.x.symphony.k8s.aws
+spec:
+  apiVersion: v1alpha1
+  kind: EKSCRDGroup
+  definition:
+    spec:
+      name: string | default=eksCRDGroup
+  resources:
+  - name: accessEntryCRD
+    definition: 
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.16.2
+        name: accessentries.eks.services.k8s.aws
+      spec:
+        group: eks.services.k8s.aws
+        names:
+          kind: AccessEntry
+          listKind: AccessEntryList
+          plural: accessentries
+          singular: accessentry
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .spec.clusterName
+            name: CLUSTER
+            type: string
+          - jsonPath: .spec.type
+            name: TYPE
+            type: string
+          - jsonPath: .spec.username
+            name: USERNAME
+            type: string
+          - jsonPath: .spec.principalARN
+            name: PRINCIPALARN
+            priority: 1
+            type: string
+          - jsonPath: .status.conditions[?(@.type=="ACK.ResourceSynced")].status
+            name: Synced
+            type: string
+          - jsonPath: .metadata.creationTimestamp
+            name: Age
+            type: date
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: AccessEntry is the Schema for the AccessEntries API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    AccessEntrySpec defines the desired state of AccessEntry.
+
+                    An access entry allows an IAM principal (user or role) to access your cluster.
+                    Access entries can replace the need to maintain the aws-auth ConfigMap for
+                    authentication. For more information about access entries, see Access entries
+                    (https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html) in
+                    the Amazon EKS User Guide.
+                  properties:
+                    accessPolicies:
+                      items:
+                        properties:
+                          accessScope:
+                            description: The scope of an AccessPolicy that's associated
+                              to an AccessEntry.
+                            properties:
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              type:
+                                type: string
+                            type: object
+                          policyARN:
+                            type: string
+                        type: object
+                      type: array
+                    clusterName:
+                      description: The name of your cluster.
+                      type: string
+                    clusterRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    kubernetesGroups:
+                      description: |-
+                        The value for name that you've specified for kind: Group as a subject in
+                        a Kubernetes RoleBinding or ClusterRoleBinding object. Amazon EKS doesn't
+                        confirm that the value for name exists in any bindings on your cluster. You
+                        can specify one or more names.
+
+                        Kubernetes authorizes the principalArn of the access entry to access any
+                        cluster objects that you've specified in a Kubernetes Role or ClusterRole
+                        object that is also specified in a binding's roleRef. For more information
+                        about creating Kubernetes RoleBinding, ClusterRoleBinding, Role, or ClusterRole
+                        objects, see Using RBAC Authorization in the Kubernetes documentation (https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
+
+                        If you want Amazon EKS to authorize the principalArn (instead of, or in addition
+                        to Kubernetes authorizing the principalArn), you can associate one or more
+                        access policies to the access entry using AssociateAccessPolicy. If you associate
+                        any access policies, the principalARN has all permissions assigned in the
+                        associated access policies and all permissions in any Kubernetes Role or
+                        ClusterRole objects that the group names are bound to.
+                      items:
+                        type: string
+                      type: array
+                    principalARN:
+                      description: |-
+                        The ARN of the IAM principal for the AccessEntry. You can specify one ARN
+                        for each access entry. You can't specify the same ARN in more than one access
+                        entry. This value can't be changed after access entry creation.
+
+                        The valid principals differ depending on the type of the access entry in
+                        the type field. The only valid ARN is IAM roles for the types of access entries
+                        for nodes: . You can use every IAM principal type for STANDARD access entries.
+                        You can't use the STS session principal type with access entries because
+                        this is a temporary principal for each session and not a permanent identity
+                        that can be assigned permissions.
+
+                        IAM best practices (https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#bp-users-federation-idp)
+                        recommend using IAM roles with temporary credentials, rather than IAM users
+                        with long-term credentials.
+                      type: string
+                    tags:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Metadata that assists with categorization and organization. Each tag consists
+                        of a key and an optional value. You define both. Tags don't propagate to
+                        any other cluster or Amazon Web Services resources.
+                      type: object
+                    type:
+                      description: |-
+                        The type of the new access entry. Valid values are Standard, FARGATE_LINUX,
+                        EC2_LINUX, and EC2_WINDOWS.
+
+                        If the principalArn is for an IAM role that's used for self-managed Amazon
+                        EC2 nodes, specify EC2_LINUX or EC2_WINDOWS. Amazon EKS grants the necessary
+                        permissions to the node for you. If the principalArn is for any other purpose,
+                        specify STANDARD. If you don't specify a value, Amazon EKS sets the value
+                        to STANDARD. It's unnecessary to create access entries for IAM roles used
+                        with Fargate profiles or managed Amazon EC2 nodes, because Amazon EKS creates
+                        entries in the aws-auth ConfigMap for the roles. You can't change this value
+                        once you've created the access entry.
+
+                        If you set the value to EC2_LINUX or EC2_WINDOWS, you can't specify values
+                        for kubernetesGroups, or associate an AccessPolicy to the access entry.
+                      type: string
+                    username:
+                      description: |-
+                        The username to authenticate to Kubernetes with. We recommend not specifying
+                        a username and letting Amazon EKS specify it for you. For more information
+                        about the value Amazon EKS specifies for you, or constraints before specifying
+                        your own username, see Creating access entries (https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html#creating-access-entries)
+                        in the Amazon EKS User Guide.
+                      type: string
+                  required:
+                  - principalARN
+                  type: object
+                status:
+                  description: AccessEntryStatus defines the observed state of AccessEntry
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    createdAt:
+                      description: The Unix epoch timestamp at object creation.
+                      format: date-time
+                      type: string
+                    modifiedAt:
+                      description: The Unix epoch timestamp for the last modification to
+                        the object.
+                      format: date-time
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: addonsCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.16.2
+        name: addons.eks.services.k8s.aws
+      spec:
+        group: eks.services.k8s.aws
+        names:
+          kind: Addon
+          listKind: AddonList
+          plural: addons
+          singular: addon
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .spec.clusterName
+            name: CLUSTER
+            type: string
+          - jsonPath: .spec.addonVersion
+            name: ADDONVERSION
+            type: string
+          - jsonPath: .spec.resolveConflicts
+            name: RESOLVECONFLICTS
+            type: string
+          - jsonPath: .status.status
+            name: STATUS
+            priority: 1
+            type: string
+          - jsonPath: .spec.serviceAccountRoleARN
+            name: SERVICEACCOUNTROLEARN
+            priority: 1
+            type: string
+          - jsonPath: .status.conditions[?(@.type=="ACK.ResourceSynced")].status
+            name: Synced
+            type: string
+          - jsonPath: .metadata.creationTimestamp
+            name: Age
+            type: date
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: Addon is the Schema for the Addons API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    AddonSpec defines the desired state of Addon.
+
+                    An Amazon EKS add-on. For more information, see Amazon EKS add-ons (https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html)
+                    in the Amazon EKS User Guide.
+                  properties:
+                    addonVersion:
+                      description: |-
+                        The version of the add-on. The version must match one of the versions returned
+                        by DescribeAddonVersions (https://docs.aws.amazon.com/eks/latest/APIReference/API_DescribeAddonVersions.html).
+                      type: string
+                    clientRequestToken:
+                      description: |-
+                        A unique, case-sensitive identifier that you provide to ensure the idempotency
+                        of the request.
+                      type: string
+                    clusterName:
+                      description: The name of your cluster.
+                      type: string
+                    clusterRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    configurationValues:
+                      description: |-
+                        The set of configuration values for the add-on that's created. The values
+                        that you provide are validated against the schema returned by DescribeAddonConfiguration.
+                      type: string
+                    name:
+                      description: |-
+                        The name of the add-on. The name must match one of the names returned by
+                        DescribeAddonVersions.
+                      type: string
+                    podIdentityAssociations:
+                      description: |-
+                        An array of Pod Identity Assocations to be created. Each EKS Pod Identity
+                        association maps a Kubernetes service account to an IAM Role.
+
+                        For more information, see Attach an IAM Role to an Amazon EKS add-on using
+                        Pod Identity (https://docs.aws.amazon.com/eks/latest/userguide/add-ons-iam.html)
+                        in the EKS User Guide.
+                      items:
+                        description: |-
+                          A type of Pod Identity Association owned by an Amazon EKS Add-on.
+
+                          Each EKS Pod Identity Association maps a role to a service account in a namespace
+                          in the cluster.
+
+                          For more information, see Attach an IAM Role to an Amazon EKS add-on using
+                          Pod Identity (https://docs.aws.amazon.com/eks/latest/userguide/add-ons-iam.html)
+                          in the EKS User Guide.
+                        properties:
+                          roleARN:
+                            type: string
+                          serviceAccount:
+                            type: string
+                        type: object
+                      type: array
+                    resolveConflicts:
+                      description: |-
+                        How to resolve field value conflicts for an Amazon EKS add-on. Conflicts
+                        are handled based on the value you choose:
+
+                          * None – If the self-managed version of the add-on is installed on your
+                          cluster, Amazon EKS doesn't change the value. Creation of the add-on might
+                          fail.
+
+                          * Overwrite – If the self-managed version of the add-on is installed
+                          on your cluster and the Amazon EKS default value is different than the
+                          existing value, Amazon EKS changes the value to the Amazon EKS default
+                          value.
+
+                          * Preserve – This is similar to the NONE option. If the self-managed
+                          version of the add-on is installed on your cluster Amazon EKS doesn't
+                          change the add-on resource properties. Creation of the add-on might fail
+                          if conflicts are detected. This option works differently during the update
+                          operation. For more information, see UpdateAddon (https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
+
+                        If you don't currently have the self-managed version of the add-on installed
+                        on your cluster, the Amazon EKS add-on is installed. Amazon EKS sets all
+                        values to default values, regardless of the option that you specify.
+                      type: string
+                    serviceAccountRoleARN:
+                      description: |-
+                        The Amazon Resource Name (ARN) of an existing IAM role to bind to the add-on's
+                        service account. The role must be assigned the IAM permissions required by
+                        the add-on. If you don't specify an existing IAM role, then the add-on uses
+                        the permissions assigned to the node IAM role. For more information, see
+                        Amazon EKS node IAM role (https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html)
+                        in the Amazon EKS User Guide.
+
+                        To specify an existing IAM role, you must have an IAM OpenID Connect (OIDC)
+                        provider created for your cluster. For more information, see Enabling IAM
+                        roles for service accounts on your cluster (https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html)
+                        in the Amazon EKS User Guide.
+                      type: string
+                    serviceAccountRoleRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    tags:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Metadata that assists with categorization and organization. Each tag consists
+                        of a key and an optional value. You define both. Tags don't propagate to
+                        any other cluster or Amazon Web Services resources.
+                      type: object
+                  required:
+                  - name
+                  type: object
+                status:
+                  description: AddonStatus defines the observed state of Addon
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    createdAt:
+                      description: The Unix epoch timestamp at object creation.
+                      format: date-time
+                      type: string
+                    health:
+                      description: An object that represents the health of the add-on.
+                      properties:
+                        issues:
+                          items:
+                            description: An issue related to an add-on.
+                            properties:
+                              code:
+                                type: string
+                              message:
+                                type: string
+                              resourceIDs:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                      type: object
+                    marketplaceInformation:
+                      description: Information about an Amazon EKS add-on from the Amazon
+                        Web Services Marketplace.
+                      properties:
+                        productID:
+                          type: string
+                        productURL:
+                          type: string
+                      type: object
+                    modifiedAt:
+                      description: The Unix epoch timestamp for the last modification to
+                        the object.
+                      format: date-time
+                      type: string
+                    owner:
+                      description: The owner of the add-on.
+                      type: string
+                    publisher:
+                      description: The publisher of the add-on.
+                      type: string
+                    status:
+                      description: The status of the add-on.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: clusterCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.16.2
+        name: clusters.eks.services.k8s.aws
+      spec:
+        group: eks.services.k8s.aws
+        names:
+          kind: Cluster
+          listKind: ClusterList
+          plural: clusters
+          singular: cluster
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .spec.version
+            name: VERSION
+            type: string
+          - jsonPath: .status.status
+            name: STATUS
+            type: string
+          - jsonPath: .status.platformVersion
+            name: PLATFORMVERSION
+            priority: 1
+            type: string
+          - jsonPath: .status.endpoint
+            name: ENDPOINT
+            priority: 1
+            type: string
+          - jsonPath: .status.conditions[?(@.type=="ACK.ResourceSynced")].status
+            name: Synced
+            type: string
+          - jsonPath: .metadata.creationTimestamp
+            name: Age
+            type: date
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: Cluster is the Schema for the Clusters API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    ClusterSpec defines the desired state of Cluster.
+
+                    An object representing an Amazon EKS cluster.
+                  properties:
+                    accessConfig:
+                      description: The access configuration for the cluster.
+                      properties:
+                        authenticationMode:
+                          type: string
+                        bootstrapClusterCreatorAdminPermissions:
+                          type: boolean
+                      type: object
+                    clientRequestToken:
+                      description: |-
+                        A unique, case-sensitive identifier that you provide to ensure the idempotency
+                        of the request.
+                      type: string
+                    encryptionConfig:
+                      description: The encryption configuration for the cluster.
+                      items:
+                        description: The encryption configuration for the cluster.
+                        properties:
+                          provider:
+                            description: Identifies the Key Management Service (KMS) key
+                              used to encrypt the secrets.
+                            properties:
+                              keyARN:
+                                type: string
+                              keyRef:
+                                description: Reference field for KeyARN
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    type: object
+                                type: object
+                            type: object
+                          resources:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    kubernetesNetworkConfig:
+                      description: The Kubernetes network configuration for the cluster.
+                      properties:
+                        ipFamily:
+                          type: string
+                        serviceIPv4CIDR:
+                          type: string
+                      type: object
+                    logging:
+                      description: |-
+                        Enable or disable exporting the Kubernetes control plane logs for your cluster
+                        to CloudWatch Logs. By default, cluster control plane logs aren't exported
+                        to CloudWatch Logs. For more information, see Amazon EKS Cluster control
+                        plane logs (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)
+                        in the Amazon EKS User Guide .
+
+                        CloudWatch Logs ingestion, archive storage, and data scanning rates apply
+                        to exported control plane logs. For more information, see CloudWatch Pricing
+                        (http://aws.amazon.com/cloudwatch/pricing/).
+                      properties:
+                        clusterLogging:
+                          items:
+                            description: |-
+                              An object representing the enabled or disabled Kubernetes control plane logs
+                              for your cluster.
+                            properties:
+                              enabled:
+                                type: boolean
+                              types:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                      type: object
+                    name:
+                      description: The unique name to give to your cluster.
+                      type: string
+                    outpostConfig:
+                      description: |-
+                        An object representing the configuration of your local Amazon EKS cluster
+                        on an Amazon Web Services Outpost. Before creating a local cluster on an
+                        Outpost, review Local clusters for Amazon EKS on Amazon Web Services Outposts
+                        (https://docs.aws.amazon.com/eks/latest/userguide/eks-outposts-local-cluster-overview.html)
+                        in the Amazon EKS User Guide. This object isn't available for creating Amazon
+                        EKS clusters on the Amazon Web Services cloud.
+                      properties:
+                        controlPlaneInstanceType:
+                          type: string
+                        controlPlanePlacement:
+                          description: |-
+                            The placement configuration for all the control plane instances of your local
+                            Amazon EKS cluster on an Amazon Web Services Outpost. For more information,
+                            see Capacity considerations (https://docs.aws.amazon.com/eks/latest/userguide/eks-outposts-capacity-considerations.html)
+                            in the Amazon EKS User Guide.
+                          properties:
+                            groupName:
+                              type: string
+                          type: object
+                        outpostARNs:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    resourcesVPCConfig:
+                      description: |-
+                        The VPC configuration that's used by the cluster control plane. Amazon EKS
+                        VPC resources have specific requirements to work properly with Kubernetes.
+                        For more information, see Cluster VPC Considerations (https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html)
+                        and Cluster Security Group Considerations (https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html)
+                        in the Amazon EKS User Guide. You must specify at least two subnets. You
+                        can specify up to five security groups. However, we recommend that you use
+                        a dedicated security group for your cluster control plane.
+                      properties:
+                        endpointPrivateAccess:
+                          type: boolean
+                        endpointPublicAccess:
+                          type: boolean
+                        publicAccessCIDRs:
+                          items:
+                            type: string
+                          type: array
+                        securityGroupIDs:
+                          items:
+                            type: string
+                          type: array
+                        securityGroupRefs:
+                          description: Reference field for SecurityGroupIDs
+                          items:
+                            description: "AWSResourceReferenceWrapper provides a wrapper
+                              around *AWSResourceReference\ntype to provide more user friendly
+                              syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                              \ name: my-api"
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        subnetIDs:
+                          items:
+                            type: string
+                          type: array
+                        subnetRefs:
+                          description: Reference field for SubnetIDs
+                          items:
+                            description: "AWSResourceReferenceWrapper provides a wrapper
+                              around *AWSResourceReference\ntype to provide more user friendly
+                              syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                              \ name: my-api"
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                    roleARN:
+                      description: |-
+                        The Amazon Resource Name (ARN) of the IAM role that provides permissions
+                        for the Kubernetes control plane to make calls to Amazon Web Services API
+                        operations on your behalf. For more information, see Amazon EKS Service IAM
+                        Role (https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html)
+                        in the Amazon EKS User Guide .
+                      type: string
+                    roleRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    tags:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Metadata that assists with categorization and organization. Each tag consists
+                        of a key and an optional value. You define both. Tags don't propagate to
+                        any other cluster or Amazon Web Services resources.
+                      type: object
+                    version:
+                      description: |-
+                        The desired Kubernetes version for your cluster. If you don't specify a value
+                        here, the default version available in Amazon EKS is used.
+
+                        The default version might not be the latest version available.
+                      type: string
+                  required:
+                  - name
+                  - resourcesVPCConfig
+                  type: object
+                status:
+                  description: ClusterStatus defines the observed state of Cluster
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    certificateAuthority:
+                      description: The certificate-authority-data for your cluster.
+                      properties:
+                        data:
+                          type: string
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    connectorConfig:
+                      description: The configuration used to connect to a cluster for registration.
+                      properties:
+                        activationCode:
+                          type: string
+                        activationExpiry:
+                          format: date-time
+                          type: string
+                        activationID:
+                          type: string
+                        provider:
+                          type: string
+                        roleARN:
+                          type: string
+                      type: object
+                    createdAt:
+                      description: The Unix epoch timestamp at object creation.
+                      format: date-time
+                      type: string
+                    endpoint:
+                      description: The endpoint for your Kubernetes API server.
+                      type: string
+                    health:
+                      description: An object representing the health of your Amazon EKS
+                        cluster.
+                      properties:
+                        issues:
+                          items:
+                            description: An issue with your Amazon EKS cluster.
+                            properties:
+                              code:
+                                type: string
+                              message:
+                                type: string
+                              resourceIDs:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                      type: object
+                    id:
+                      description: |-
+                        The ID of your local Amazon EKS cluster on an Amazon Web Services Outpost.
+                        This property isn't available for an Amazon EKS cluster on the Amazon Web
+                        Services cloud.
+                      type: string
+                    identity:
+                      description: The identity provider information for the cluster.
+                      properties:
+                        oidc:
+                          description: |-
+                            An object representing the OpenID Connect (https://openid.net/connect/) (OIDC)
+                            identity provider information for the cluster.
+                          properties:
+                            issuer:
+                              type: string
+                          type: object
+                      type: object
+                    platformVersion:
+                      description: |-
+                        The platform version of your Amazon EKS cluster. For more information about
+                        clusters deployed on the Amazon Web Services Cloud, see Platform versions
+                        (https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html)
+                        in the Amazon EKS User Guide . For more information about local clusters
+                        deployed on an Outpost, see Amazon EKS local cluster platform versions (https://docs.aws.amazon.com/eks/latest/userguide/eks-outposts-platform-versions.html)
+                        in the Amazon EKS User Guide .
+                      type: string
+                    status:
+                      description: The current status of the cluster.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: fargateProfilesCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.16.2
+        name: fargateprofiles.eks.services.k8s.aws
+      spec:
+        group: eks.services.k8s.aws
+        names:
+          kind: FargateProfile
+          listKind: FargateProfileList
+          plural: fargateprofiles
+          singular: fargateprofile
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .spec.clusterName
+            name: CLUSTER
+            type: string
+          - jsonPath: .status.status
+            name: STATUS
+            type: string
+          - jsonPath: .spec.podExecutionRoleARN
+            name: PODEXECUTIONROLEARN
+            priority: 1
+            type: string
+          - jsonPath: .status.conditions[?(@.type=="ACK.ResourceSynced")].status
+            name: Synced
+            type: string
+          - jsonPath: .metadata.creationTimestamp
+            name: Age
+            type: date
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: FargateProfile is the Schema for the FargateProfiles API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    FargateProfileSpec defines the desired state of FargateProfile.
+
+                    An object representing an Fargate profile.
+                  properties:
+                    clientRequestToken:
+                      description: |-
+                        A unique, case-sensitive identifier that you provide to ensure the idempotency
+                        of the request.
+                      type: string
+                    clusterName:
+                      description: The name of your cluster.
+                      type: string
+                    clusterRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    name:
+                      description: The name of the Fargate profile.
+                      type: string
+                    podExecutionRoleARN:
+                      description: |-
+                        The Amazon Resource Name (ARN) of the Pod execution role to use for a Pod
+                        that matches the selectors in the Fargate profile. The Pod execution role
+                        allows Fargate infrastructure to register with your cluster as a node, and
+                        it provides read access to Amazon ECR image repositories. For more information,
+                        see Pod execution role (https://docs.aws.amazon.com/eks/latest/userguide/pod-execution-role.html)
+                        in the Amazon EKS User Guide.
+                      type: string
+                    podExecutionRoleRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    selectors:
+                      description: |-
+                        The selectors to match for a Pod to use this Fargate profile. Each selector
+                        must have an associated Kubernetes namespace. Optionally, you can also specify
+                        labels for a namespace. You may specify up to five selectors in a Fargate
+                        profile.
+                      items:
+                        description: An object representing an Fargate profile selector.
+                        properties:
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          namespace:
+                            type: string
+                        type: object
+                      type: array
+                    subnetRefs:
+                      items:
+                        description: "AWSResourceReferenceWrapper provides a wrapper around
+                          *AWSResourceReference\ntype to provide more user friendly syntax
+                          for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                          \ name: my-api"
+                        properties:
+                          from:
+                            description: |-
+                              AWSResourceReference provides all the values necessary to reference another
+                              k8s resource for finding the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                    subnets:
+                      description: |-
+                        The IDs of subnets to launch a Pod into. A Pod running on Fargate isn't assigned
+                        a public IP address, so only private subnets (with no direct route to an
+                        Internet Gateway) are accepted for this parameter.
+                      items:
+                        type: string
+                      type: array
+                    tags:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Metadata that assists with categorization and organization. Each tag consists
+                        of a key and an optional value. You define both. Tags don't propagate to
+                        any other cluster or Amazon Web Services resources.
+                      type: object
+                  required:
+                  - name
+                  type: object
+                status:
+                  description: FargateProfileStatus defines the observed state of FargateProfile
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    createdAt:
+                      description: The Unix epoch timestamp at object creation.
+                      format: date-time
+                      type: string
+                    status:
+                      description: The current status of the Fargate profile.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: identityProviderCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.16.2
+        name: identityproviderconfigs.eks.services.k8s.aws
+      spec:
+        group: eks.services.k8s.aws
+        names:
+          kind: IdentityProviderConfig
+          listKind: IdentityProviderConfigList
+          plural: identityproviderconfigs
+          singular: identityproviderconfig
+        scope: Namespaced
+        versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: IdentityProviderConfig is the Schema for the IdentityProviderConfigs
+                API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    IdentityProviderConfigSpec defines the desired state of IdentityProviderConfig.
+
+                    An object representing an identity provider configuration.
+                  properties:
+                    clusterName:
+                      description: The name of your cluster.
+                      type: string
+                    clusterRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    oidc:
+                      description: An object representing an OpenID Connect (OIDC) identity
+                        provider configuration.
+                      properties:
+                        clientID:
+                          type: string
+                        groupsClaim:
+                          type: string
+                        groupsPrefix:
+                          type: string
+                        identityProviderConfigName:
+                          type: string
+                        issuerURL:
+                          type: string
+                        requiredClaims:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        usernameClaim:
+                          type: string
+                        usernamePrefix:
+                          type: string
+                      type: object
+                    tags:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Metadata that assists with categorization and organization. Each tag consists
+                        of a key and an optional value. You define both. Tags don't propagate to
+                        any other cluster or Amazon Web Services resources.
+                      type: object
+                  required:
+                  - oidc
+                  type: object
+                status:
+                  description: IdentityProviderConfigStatus defines the observed state of
+                    IdentityProviderConfig
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    status:
+                      description: The status of the OIDC identity provider.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: nodeGroupsCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.16.2
+        name: nodegroups.eks.services.k8s.aws
+      spec:
+        group: eks.services.k8s.aws
+        names:
+          kind: Nodegroup
+          listKind: NodegroupList
+          plural: nodegroups
+          singular: nodegroup
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .spec.clusterName
+            name: CLUSTER
+            type: string
+          - jsonPath: .spec.version
+            name: VERSION
+            type: string
+          - jsonPath: .status.status
+            name: STATUS
+            type: string
+          - jsonPath: .spec.releaseVersion
+            name: RELEASEVERSION
+            priority: 1
+            type: string
+          - jsonPath: .spec.scalingConfig.desiredSize
+            name: DESIREDSIZE
+            type: integer
+          - jsonPath: .spec.scalingConfig.minSize
+            name: MINSIZE
+            type: integer
+          - jsonPath: .spec.scalingConfig.maxSize
+            name: MAXSIZE
+            type: integer
+          - jsonPath: .spec.diskSize
+            name: DISKSIZE
+            priority: 1
+            type: integer
+          - jsonPath: .status.conditions[?(@.type=="ACK.ResourceSynced")].status
+            name: Synced
+            type: string
+          - jsonPath: .metadata.creationTimestamp
+            name: Age
+            type: date
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: Nodegroup is the Schema for the Nodegroups API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    NodegroupSpec defines the desired state of Nodegroup.
+
+                    An object representing an Amazon EKS managed node group.
+                  properties:
+                    amiType:
+                      description: |-
+                        The AMI type for your node group. If you specify launchTemplate, and your
+                        launch template uses a custom AMI, then don't specify amiType, or the node
+                        group deployment will fail. If your launch template uses a Windows custom
+                        AMI, then add eks:kube-proxy-windows to your Windows nodes rolearn in the
+                        aws-auth ConfigMap. For more information about using launch templates with
+                        Amazon EKS, see Customizing managed nodes with launch templates (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html)
+                        in the Amazon EKS User Guide.
+                      type: string
+                    capacityType:
+                      description: The capacity type for your node group.
+                      type: string
+                    clientRequestToken:
+                      description: |-
+                        A unique, case-sensitive identifier that you provide to ensure the idempotency
+                        of the request.
+                      type: string
+                    clusterName:
+                      description: The name of your cluster.
+                      type: string
+                    clusterRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    diskSize:
+                      description: |-
+                        The root device disk size (in GiB) for your node group instances. The default
+                        disk size is 20 GiB for Linux and Bottlerocket. The default disk size is
+                        50 GiB for Windows. If you specify launchTemplate, then don't specify diskSize,
+                        or the node group deployment will fail. For more information about using
+                        launch templates with Amazon EKS, see Customizing managed nodes with launch
+                        templates (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html)
+                        in the Amazon EKS User Guide.
+                      format: int64
+                      type: integer
+                    instanceTypes:
+                      description: |-
+                        Specify the instance types for a node group. If you specify a GPU instance
+                        type, make sure to also specify an applicable GPU AMI type with the amiType
+                        parameter. If you specify launchTemplate, then you can specify zero or one
+                        instance type in your launch template or you can specify 0-20 instance types
+                        for instanceTypes. If however, you specify an instance type in your launch
+                        template and specify any instanceTypes, the node group deployment will fail.
+                        If you don't specify an instance type in a launch template or for instanceTypes,
+                        then t3.medium is used, by default. If you specify Spot for capacityType,
+                        then we recommend specifying multiple values for instanceTypes. For more
+                        information, see Managed node group capacity types (https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types)
+                        and Customizing managed nodes with launch templates (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html)
+                        in the Amazon EKS User Guide.
+                      items:
+                        type: string
+                      type: array
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        The Kubernetes labels to apply to the nodes in the node group when they are
+                        created.
+                      type: object
+                    launchTemplate:
+                      description: |-
+                        An object representing a node group's launch template specification. When
+                        using this object, don't directly specify instanceTypes, diskSize, or remoteAccess.
+                        Make sure that the launch template meets the requirements in launchTemplateSpecification.
+                        Also refer to Customizing managed nodes with launch templates (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html)
+                        in the Amazon EKS User Guide.
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                    name:
+                      description: The unique name to give your node group.
+                      type: string
+                    nodeRole:
+                      description: |-
+                        The Amazon Resource Name (ARN) of the IAM role to associate with your node
+                        group. The Amazon EKS worker node kubelet daemon makes calls to Amazon Web
+                        Services APIs on your behalf. Nodes receive permissions for these API calls
+                        through an IAM instance profile and associated policies. Before you can launch
+                        nodes and register them into a cluster, you must create an IAM role for those
+                        nodes to use when they are launched. For more information, see Amazon EKS
+                        node IAM role (https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html)
+                        in the Amazon EKS User Guide . If you specify launchTemplate, then don't
+                        specify IamInstanceProfile (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IamInstanceProfile.html)
+                        in your launch template, or the node group deployment will fail. For more
+                        information about using launch templates with Amazon EKS, see Customizing
+                        managed nodes with launch templates (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html)
+                        in the Amazon EKS User Guide.
+                      type: string
+                    nodeRoleRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    releaseVersion:
+                      description: |-
+                        The AMI version of the Amazon EKS optimized AMI to use with your node group.
+                        By default, the latest available AMI version for the node group's current
+                        Kubernetes version is used. For information about Linux versions, see Amazon
+                        EKS optimized Amazon Linux AMI versions (https://docs.aws.amazon.com/eks/latest/userguide/eks-linux-ami-versions.html)
+                        in the Amazon EKS User Guide. Amazon EKS managed node groups support the
+                        November 2022 and later releases of the Windows AMIs. For information about
+                        Windows versions, see Amazon EKS optimized Windows AMI versions (https://docs.aws.amazon.com/eks/latest/userguide/eks-ami-versions-windows.html)
+                        in the Amazon EKS User Guide.
+
+                        If you specify launchTemplate, and your launch template uses a custom AMI,
+                        then don't specify releaseVersion, or the node group deployment will fail.
+                        For more information about using launch templates with Amazon EKS, see Customizing
+                        managed nodes with launch templates (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html)
+                        in the Amazon EKS User Guide.
+                      type: string
+                    remoteAccess:
+                      description: |-
+                        The remote access configuration to use with your node group. For Linux, the
+                        protocol is SSH. For Windows, the protocol is RDP. If you specify launchTemplate,
+                        then don't specify remoteAccess, or the node group deployment will fail.
+                        For more information about using launch templates with Amazon EKS, see Customizing
+                        managed nodes with launch templates (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html)
+                        in the Amazon EKS User Guide.
+                      properties:
+                        ec2SshKey:
+                          type: string
+                        sourceSecurityGroupRefs:
+                          description: Reference field for SourceSecurityGroups
+                          items:
+                            description: "AWSResourceReferenceWrapper provides a wrapper
+                              around *AWSResourceReference\ntype to provide more user friendly
+                              syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                              \ name: my-api"
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        sourceSecurityGroups:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    scalingConfig:
+                      description: |-
+                        The scaling configuration details for the Auto Scaling group that is created
+                        for your node group.
+                      properties:
+                        desiredSize:
+                          format: int64
+                          type: integer
+                        maxSize:
+                          format: int64
+                          type: integer
+                        minSize:
+                          format: int64
+                          type: integer
+                      type: object
+                    subnetRefs:
+                      items:
+                        description: "AWSResourceReferenceWrapper provides a wrapper around
+                          *AWSResourceReference\ntype to provide more user friendly syntax
+                          for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                          \ name: my-api"
+                        properties:
+                          from:
+                            description: |-
+                              AWSResourceReference provides all the values necessary to reference another
+                              k8s resource for finding the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                    subnets:
+                      description: |-
+                        The subnets to use for the Auto Scaling group that is created for your node
+                        group. If you specify launchTemplate, then don't specify SubnetId (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateNetworkInterface.html)
+                        in your launch template, or the node group deployment will fail. For more
+                        information about using launch templates with Amazon EKS, see Customizing
+                        managed nodes with launch templates (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html)
+                        in the Amazon EKS User Guide.
+                      items:
+                        type: string
+                      type: array
+                    tags:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Metadata that assists with categorization and organization. Each tag consists
+                        of a key and an optional value. You define both. Tags don't propagate to
+                        any other cluster or Amazon Web Services resources.
+                      type: object
+                    taints:
+                      description: |-
+                        The Kubernetes taints to be applied to the nodes in the node group. For more
+                        information, see Node taints on managed node groups (https://docs.aws.amazon.com/eks/latest/userguide/node-taints-managed-node-groups.html).
+                      items:
+                        description: |-
+                          A property that allows a node to repel a Pod. For more information, see Node
+                          taints on managed node groups (https://docs.aws.amazon.com/eks/latest/userguide/node-taints-managed-node-groups.html)
+                          in the Amazon EKS User Guide.
+                        properties:
+                          effect:
+                            type: string
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    updateConfig:
+                      description: The node group update configuration.
+                      properties:
+                        maxUnavailable:
+                          format: int64
+                          type: integer
+                        maxUnavailablePercentage:
+                          format: int64
+                          type: integer
+                      type: object
+                    version:
+                      description: |-
+                        The Kubernetes version to use for your managed nodes. By default, the Kubernetes
+                        version of the cluster is used, and this is the only accepted specified value.
+                        If you specify launchTemplate, and your launch template uses a custom AMI,
+                        then don't specify version, or the node group deployment will fail. For more
+                        information about using launch templates with Amazon EKS, see Customizing
+                        managed nodes with launch templates (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html)
+                        in the Amazon EKS User Guide.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                status:
+                  description: NodegroupStatus defines the observed state of Nodegroup
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    createdAt:
+                      description: The Unix epoch timestamp at object creation.
+                      format: date-time
+                      type: string
+                    health:
+                      description: |-
+                        The health status of the node group. If there are issues with your node group's
+                        health, they are listed here.
+                      properties:
+                        issues:
+                          items:
+                            description: An object representing an issue with an Amazon
+                              EKS resource.
+                            properties:
+                              code:
+                                type: string
+                              message:
+                                type: string
+                              resourceIDs:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                      type: object
+                    modifiedAt:
+                      description: The Unix epoch timestamp for the last modification to
+                        the object.
+                      format: date-time
+                      type: string
+                    resources:
+                      description: |-
+                        The resources associated with the node group, such as Auto Scaling groups
+                        and security groups for remote access.
+                      properties:
+                        autoScalingGroups:
+                          items:
+                            description: |-
+                              An Auto Scaling group that is associated with an Amazon EKS managed node
+                              group.
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          type: array
+                        remoteAccessSecurityGroup:
+                          type: string
+                      type: object
+                    status:
+                      description: The current status of the managed node group.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: podIdentityAssociationCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.16.2
+        name: podidentityassociations.eks.services.k8s.aws
+      spec:
+        group: eks.services.k8s.aws
+        names:
+          kind: PodIdentityAssociation
+          listKind: PodIdentityAssociationList
+          plural: podidentityassociations
+          singular: podidentityassociation
+        scope: Namespaced
+        versions:
+        - additionalPrinterColumns:
+          - jsonPath: .spec.clusterName
+            name: CLUSTER
+            type: string
+          - jsonPath: .spec.namespace
+            name: NAMESPACE
+            type: string
+          - jsonPath: .spec.serviceAccount
+            name: SERVICEACCOUNT
+            type: string
+          - jsonPath: .spec.roleARN
+            name: ROLEARN
+            priority: 1
+            type: string
+          - jsonPath: .status.associationID
+            name: ASSOCIATIONID
+            priority: 1
+            type: string
+          - jsonPath: .status.conditions[?(@.type=="ACK.ResourceSynced")].status
+            name: Synced
+            type: string
+          - jsonPath: .metadata.creationTimestamp
+            name: Age
+            type: date
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: PodIdentityAssociation is the Schema for the PodIdentityAssociations
+                API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    PodIdentityAssociationSpec defines the desired state of PodIdentityAssociation.
+
+                    Amazon EKS Pod Identity associations provide the ability to manage credentials
+                    for your applications, similar to the way that Amazon EC2 instance profiles
+                    provide credentials to Amazon EC2 instances.
+                  properties:
+                    clientRequestToken:
+                      description: |-
+                        A unique, case-sensitive identifier that you provide to ensure the idempotency
+                        of the request.
+                      type: string
+                    clusterName:
+                      description: The name of the cluster to create the association in.
+                      type: string
+                    clusterRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    namespace:
+                      description: |-
+                        The name of the Kubernetes namespace inside the cluster to create the association
+                        in. The service account and the pods that use the service account must be
+                        in this namespace.
+                      type: string
+                    roleARN:
+                      description: |-
+                        The Amazon Resource Name (ARN) of the IAM role to associate with the service
+                        account. The EKS Pod Identity agent manages credentials to assume this role
+                        for applications in the containers in the pods that use this service account.
+                      type: string
+                    roleRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccount:
+                      description: |-
+                        The name of the Kubernetes service account inside the cluster to associate
+                        the IAM credentials with.
+                      type: string
+                    tags:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Metadata that assists with categorization and organization. Each tag consists
+                        of a key and an optional value. You define both. Tags don't propagate to
+                        any other cluster or Amazon Web Services resources.
+
+                        The following basic restrictions apply to tags:
+
+                          * Maximum number of tags per resource – 50
+
+                          * For each resource, each tag key must be unique, and each tag key can
+                          have only one value.
+
+                          * Maximum key length – 128 Unicode characters in UTF-8
+
+                          * Maximum value length – 256 Unicode characters in UTF-8
+
+                          * If your tagging schema is used across multiple services and resources,
+                          remember that other services may have restrictions on allowed characters.
+                          Generally allowed characters are: letters, numbers, and spaces representable
+                          in UTF-8, and the following characters: + - = . _ : / @.
+
+                          * Tag keys and values are case-sensitive.
+
+                          * Do not use aws:, AWS:, or any upper or lowercase combination of such
+                          as a prefix for either keys or values as it is reserved for Amazon Web
+                          Services use. You cannot edit or delete tag keys or values with this prefix.
+                          Tags with this prefix do not count against your tags per resource limit.
+                      type: object
+                  required:
+                  - namespace
+                  - serviceAccount
+                  type: object
+                status:
+                  description: PodIdentityAssociationStatus defines the observed state of
+                    PodIdentityAssociation
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    associationARN:
+                      description: The Amazon Resource Name (ARN) of the association.
+                      type: string
+                    associationID:
+                      description: The ID of the association.
+                      type: string
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    createdAt:
+                      description: The timestamp that the association was created at.
+                      format: date-time
+                      type: string
+                    modifiedAt:
+                      description: The most recent timestamp that the association was modified
+                        at
+                      format: date-time
+                      type: string
+                    ownerARN:
+                      description: If defined, the Pod Identity Association is owned by
+                        an Amazon EKS Addon.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}

--- a/examples/ack-controller/iam-controller/iam-controller-instance.yaml
+++ b/examples/ack-controller/iam-controller/iam-controller-instance.yaml
@@ -1,0 +1,21 @@
+apiVersion: x.symphony.k8s.aws/v1alpha1
+kind: IAMController
+metadata:
+  name: my-symphony-iam-controller
+  namespace: default
+spec:
+  name: ack-iam-controller
+  namespace: default
+  values: 
+    aws: {}
+    deployment: {}
+    image:
+      resources:
+        requests: {}
+        limits: {}
+    log:
+      enabled: true
+      level: debug
+    aws: {}
+    serviceAccount:
+      roleArn: arn:aws:iam::399481058530:role/another-iam-controller

--- a/examples/ack-controller/iam-controller/iam-controller.yaml
+++ b/examples/ack-controller/iam-controller/iam-controller.yaml
@@ -1,0 +1,318 @@
+apiVersion: x.symphony.k8s.aws/v1alpha1
+kind: ResourceGroup
+metadata:
+  name: iamcontroller.x.symphony.k8s.aws
+spec:
+  apiVersion: v1alpha1
+  kind: IAMController
+  definition:
+    spec:
+      name: string | default=iam-controller
+      namespace: string | default=default
+      values:
+        aws:
+          region: string | default=us-west-2
+        deployment:
+          containerPort: integer | default=8080
+          replicas: integer | default=1
+        image:
+          deletePolicy: string | default=delete
+          repository: string | default=public.ecr.aws/aws-controllers-k8s/iam-controller
+          tag: string | default=1.3.13
+          resources:
+            requests:
+              memory: string | default=64Mi
+              cpu: string | default=50m
+            limits:
+              memory: string | default=128Mi
+              cpu: string | default=100m
+        log:
+          enabled: boolean | default=false
+          level: string | default=info
+        serviceAccount:
+          name: string | default=ack-iam-controller-sa
+          roleArn: string | required=true
+  resources:
+  - name: iamCRDGroup
+    definition:
+      apiVersion: x.symphony.k8s.aws/v1alpha1
+      kind: IAMCRDGroup
+      metadata:
+        name: ${spec.name}-crd-group
+      spec:
+        name: ${spec.name}-crd-group
+  - name: serviceAccount
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ${spec.values.serviceAccount.name}
+        namespace: ${spec.namespace}
+        annotations:
+          eks.amazonaws.com/role-arn: ${spec.values.serviceAccount.roleArn}
+  - name: deployment
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ${spec.name}-deployment
+        namespace: ${spec.namespace}
+        labels:
+          app.kubernetes.io.name: ${spec.name}-deployment
+          app.kubernetes.io.instance: ${spec.name}
+      spec:
+        replicas: ${spec.values.deployment.replicas}
+        selector:
+          matchLabels:
+            app.kubernetes.io.name: ${spec.name}-deployment
+            app.kubernetes.io.instance: ${spec.name}
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io.name: ${spec.name}-deployment
+              app.kubernetes.io.instance: ${spec.name}
+          spec:
+            serviceAccountName: ${serviceAccount.metadata.name}
+            containers:
+            - command:
+              - ./bin/controller
+              args:
+              - --aws-region
+              - ${spec.values.aws.region}
+              - --enable-development-logging=${spec.values.log.enabled}
+              - --log-level
+              - ${spec.values.log.level}
+              - --deletion-policy
+              - ${spec.values.image.deletePolicy}
+              - --watch-namespace
+              - ${spec.namespace}
+              image: ${spec.values.image.repository}:${spec.values.image.tag}
+              name: controller
+              ports:
+                - name: http
+                  containerPort: ${spec.values.deployment.containerPort}
+              resources:
+                requests:
+                  memory: ${spec.values.image.resources.requests.memory}
+                  cpu: ${spec.values.image.resources.requests.cpu}
+                limits:
+                    memory: ${spec.values.image.resources.limits.memory}
+                    cpu: ${spec.values.image.resources.limits.cpu}
+              env:
+              - name: ACK_SYSTEM_NAMESPACE
+                value: ${spec.namespace}
+              - name: AWS_REGION
+                value: ${spec.values.aws.region}
+              - name: DELETE_POLICY
+                value: ${spec.values.image.deletePolicy}
+              - name: ACK_LOG_LEVEL
+                value: ${spec.values.log.level}              
+              ports:
+              - containerPort: 80
+  - name: clusterRoleBinding
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: ${spec.name}-clusterrolebinding
+      roleRef:
+        kind: ClusterRole
+        apiGroup: rbac.authorization.k8s.io
+        name: ${clusterRole.metadata.name}
+      subjects:
+      - kind: ServiceAccount
+        name: ${serviceAccount.metadata.name}
+        namespace: ${serviceAccount.metadata.namespace}
+  - name: clusterRole
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ${spec.name}-clusterrole
+      rules:
+      - apiGroups:
+        - ""
+        resources:
+        - configmaps
+        verbs:
+        - get
+        - list
+        - patch
+        - watch
+      - apiGroups:
+        - ""
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ""
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - patch
+        - watch
+      - apiGroups:
+        - iam.services.k8s.aws
+        resources:
+        - groups
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - iam.services.k8s.aws
+        resources:
+        - groups/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - iam.services.k8s.aws
+        resources:
+        - instanceprofiles
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - iam.services.k8s.aws
+        resources:
+        - instanceprofiles/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - iam.services.k8s.aws
+        resources:
+        - openidconnectproviders
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - iam.services.k8s.aws
+        resources:
+        - openidconnectproviders/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - iam.services.k8s.aws
+        resources:
+        - policies
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - iam.services.k8s.aws
+        resources:
+        - policies/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - iam.services.k8s.aws
+        resources:
+        - roles
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - iam.services.k8s.aws
+        resources:
+        - roles/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - iam.services.k8s.aws
+        resources:
+        - users
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - iam.services.k8s.aws
+        resources:
+        - users/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - services.k8s.aws
+        resources:
+        - adoptedresources
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - services.k8s.aws
+        resources:
+        - adoptedresources/status
+        verbs:
+        - get
+        - patch
+        - update
+      - apiGroups:
+        - services.k8s.aws
+        resources:
+        - fieldexports
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - services.k8s.aws
+        resources:
+        - fieldexports/status
+        verbs:
+        - get
+        - patch
+        - update

--- a/examples/ack-controller/iam-controller/iam-crd-group.yaml
+++ b/examples/ack-controller/iam-controller/iam-crd-group.yaml
@@ -1,0 +1,1528 @@
+apiVersion: x.symphony.k8s.aws/v1alpha1
+kind: ResourceGroup
+metadata:
+  name: iamcrdgroup.x.symphony.k8s.aws
+spec:
+  apiVersion: v1alpha1
+  kind: IAMCRDGroup
+  definition:
+    spec:
+      name: string | default=iamCRDGroup
+  resources:
+  - name: iamGroupCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: groups.iam.services.k8s.aws
+      spec:
+        group: iam.services.k8s.aws
+        names:
+          kind: Group
+          listKind: GroupList
+          plural: groups
+          singular: group
+        scope: Namespaced
+        versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: Group is the Schema for the Groups API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    GroupSpec defines the desired state of Group.
+
+
+                    Contains information about an IAM group entity.
+
+
+                    This data type is used as a response element in the following operations:
+
+
+                      * CreateGroup
+
+
+                      * GetGroup
+
+
+                      * ListGroups
+                  properties:
+                    inlinePolicies:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    name:
+                      description: |-
+                        The name of the group to create. Do not include the path in this value.
+
+
+                        IAM user, group, role, and policy names must be unique within the account.
+                        Names are not distinguished by case. For example, you cannot create resources
+                        named both "MyResource" and "myresource".
+                      type: string
+                    path:
+                      description: |-
+                        The path to the group. For more information about paths, see IAM identifiers
+                        (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
+                        in the IAM User Guide.
+
+
+                        This parameter is optional. If it is not included, it defaults to a slash
+                        (/).
+
+
+                        This parameter allows (through its regex pattern (http://wikipedia.org/wiki/regex))
+                        a string of characters consisting of either a forward slash (/) by itself
+                        or a string that must begin and end with forward slashes. In addition, it
+                        can contain any ASCII character from the ! (\u0021) through the DEL character
+                        (\u007F), including most punctuation characters, digits, and upper and lowercased
+                        letters.
+                      type: string
+                    policies:
+                      items:
+                        type: string
+                      type: array
+                    policyRefs:
+                      items:
+                        description: "AWSResourceReferenceWrapper provides a wrapper around
+                          *AWSResourceReference\ntype to provide more user friendly syntax
+                          for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                          \ name: my-api"
+                        properties:
+                          from:
+                            description: |-
+                              AWSResourceReference provides all the values necessary to reference another
+                              k8s resource for finding the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  type: object
+                status:
+                  description: GroupStatus defines the observed state of Group
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    createDate:
+                      description: |-
+                        The date and time, in ISO 8601 date-time format (http://www.iso.org/iso/iso8601),
+                        when the group was created.
+                      format: date-time
+                      type: string
+                    groupID:
+                      description: |-
+                        The stable and unique string identifying the group. For more information
+                        about IDs, see IAM identifiers (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
+                        in the IAM User Guide.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: iamInstanceProfileCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: instanceprofiles.iam.services.k8s.aws
+      spec:
+        group: iam.services.k8s.aws
+        names:
+          kind: InstanceProfile
+          listKind: InstanceProfileList
+          plural: instanceprofiles
+          singular: instanceprofile
+        scope: Namespaced
+        versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: InstanceProfile is the Schema for the InstanceProfiles API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    InstanceProfileSpec defines the desired state of InstanceProfile.
+
+
+                    Contains information about an instance profile.
+
+
+                    This data type is used as a response element in the following operations:
+
+
+                      * CreateInstanceProfile
+
+
+                      * GetInstanceProfile
+
+
+                      * ListInstanceProfiles
+
+
+                      * ListInstanceProfilesForRole
+                  properties:
+                    name:
+                      description: |-
+                        The name of the instance profile to create.
+
+
+                        This parameter allows (through its regex pattern (http://wikipedia.org/wiki/regex))
+                        a string of characters consisting of upper and lowercase alphanumeric characters
+                        with no spaces. You can also include any of the following characters: _+=,.@-
+                      type: string
+                    path:
+                      description: |-
+                        The path to the instance profile. For more information about paths, see IAM
+                        Identifiers (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
+                        in the IAM User Guide.
+
+
+                        This parameter is optional. If it is not included, it defaults to a slash
+                        (/).
+
+
+                        This parameter allows (through its regex pattern (http://wikipedia.org/wiki/regex))
+                        a string of characters consisting of either a forward slash (/) by itself
+                        or a string that must begin and end with forward slashes. In addition, it
+                        can contain any ASCII character from the ! (\u0021) through the DEL character
+                        (\u007F), including most punctuation characters, digits, and upper and lowercased
+                        letters.
+                      type: string
+                    role:
+                      type: string
+                    roleRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    tags:
+                      description: |-
+                        A list of tags that you want to attach to the newly created IAM instance
+                        profile. Each tag consists of a key name and an associated value. For more
+                        information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+                        in the IAM User Guide.
+
+
+                        If any one of the tags is invalid or if you exceed the allowed maximum number
+                        of tags, then the entire request fails and the resource is not created.
+                      items:
+                        description: |-
+                          A structure that represents user-provided metadata that can be associated
+                          with an IAM resource. For more information about tagging, see Tagging IAM
+                          resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+                          in the IAM User Guide.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  type: object
+                status:
+                  description: InstanceProfileStatus defines the observed state of InstanceProfile
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    createDate:
+                      description: The date when the instance profile was created.
+                      format: date-time
+                      type: string
+                    instanceProfileID:
+                      description: |-
+                        The stable and unique string identifying the instance profile. For more information
+                        about IDs, see IAM identifiers (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
+                        in the IAM User Guide.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: iamOpenIDConnectProviderCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: openidconnectproviders.iam.services.k8s.aws
+      spec:
+        group: iam.services.k8s.aws
+        names:
+          kind: OpenIDConnectProvider
+          listKind: OpenIDConnectProviderList
+          plural: openidconnectproviders
+          singular: openidconnectprovider
+        scope: Namespaced
+        versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: OpenIDConnectProvider is the Schema for the OpenIDConnectProviders
+                API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: OpenIDConnectProviderSpec defines the desired state of OpenIDConnectProvider.
+                  properties:
+                    clientIDs:
+                      description: |-
+                        Provides a list of client IDs, also known as audiences. When a mobile or
+                        web app registers with an OpenID Connect provider, they establish a value
+                        that identifies the application. This is the value that's sent as the client_id
+                        parameter on OAuth requests.
+
+
+                        You can register multiple client IDs with the same provider. For example,
+                        you might have multiple applications that use the same OIDC provider. You
+                        cannot register more than 100 client IDs with a single IAM OIDC provider.
+
+
+                        There is no defined format for a client ID. The CreateOpenIDConnectProviderRequest
+                        operation accepts client IDs up to 255 characters long.
+                      items:
+                        type: string
+                      type: array
+                    tags:
+                      description: |-
+                        A list of tags that you want to attach to the new IAM OpenID Connect (OIDC)
+                        provider. Each tag consists of a key name and an associated value. For more
+                        information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+                        in the IAM User Guide.
+
+
+                        If any one of the tags is invalid or if you exceed the allowed maximum number
+                        of tags, then the entire request fails and the resource is not created.
+                      items:
+                        description: |-
+                          A structure that represents user-provided metadata that can be associated
+                          with an IAM resource. For more information about tagging, see Tagging IAM
+                          resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+                          in the IAM User Guide.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    thumbprints:
+                      description: |-
+                        A list of server certificate thumbprints for the OpenID Connect (OIDC) identity
+                        provider's server certificates. Typically this list includes only one entry.
+                        However, IAM lets you have up to five thumbprints for an OIDC provider. This
+                        lets you maintain multiple thumbprints if the identity provider is rotating
+                        certificates.
+
+
+                        The server certificate thumbprint is the hex-encoded SHA-1 hash value of
+                        the X.509 certificate used by the domain where the OpenID Connect provider
+                        makes its keys available. It is always a 40-character string.
+
+
+                        You must provide at least one thumbprint when creating an IAM OIDC provider.
+                        For example, assume that the OIDC provider is server.example.com and the
+                        provider stores its keys at https://keys.server.example.com/openid-connect.
+                        In that case, the thumbprint string would be the hex-encoded SHA-1 hash value
+                        of the certificate used by https://keys.server.example.com.
+
+
+                        For more information about obtaining the OIDC provider thumbprint, see Obtaining
+                        the thumbprint for an OpenID Connect provider (https://docs.aws.amazon.com/IAM/latest/UserGuide/identity-providers-oidc-obtain-thumbprint.html)
+                        in the IAM user Guide.
+                      items:
+                        type: string
+                      type: array
+                    url:
+                      description: |-
+                        The URL of the identity provider. The URL must begin with https:// and should
+                        correspond to the iss claim in the provider's OpenID Connect ID tokens. Per
+                        the OIDC standard, path components are allowed but query parameters are not.
+                        Typically the URL consists of only a hostname, like https://server.example.org
+                        or https://example.com. The URL should not contain a port number.
+
+
+                        You cannot register the same provider multiple times in a single Amazon Web
+                        Services account. If you try to submit a URL that has already been used for
+                        an OpenID Connect provider in the Amazon Web Services account, you will get
+                        an error.
+                      type: string
+                  required:
+                  - thumbprints
+                  - url
+                  type: object
+                status:
+                  description: OpenIDConnectProviderStatus defines the observed state of
+                    OpenIDConnectProvider
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: iamPolicyCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: policies.iam.services.k8s.aws
+      spec:
+        group: iam.services.k8s.aws
+        names:
+          kind: Policy
+          listKind: PolicyList
+          plural: policies
+          singular: policy
+        scope: Namespaced
+        versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: Policy is the Schema for the Policies API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    PolicySpec defines the desired state of Policy.
+
+
+                    Contains information about a managed policy.
+
+
+                    This data type is used as a response element in the CreatePolicy, GetPolicy,
+                    and ListPolicies operations.
+
+
+                    For more information about managed policies, refer to Managed policies and
+                    inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+                    in the IAM User Guide.
+                  properties:
+                    description:
+                      description: |-
+                        A friendly description of the policy.
+
+
+                        Typically used to store information about the permissions defined in the
+                        policy. For example, "Grants access to production DynamoDB tables."
+
+
+                        The policy description is immutable. After a value is assigned, it cannot
+                        be changed.
+                      type: string
+                    name:
+                      description: |-
+                        The friendly name of the policy.
+
+
+                        IAM user, group, role, and policy names must be unique within the account.
+                        Names are not distinguished by case. For example, you cannot create resources
+                        named both "MyResource" and "myresource".
+                      type: string
+                    path:
+                      description: |-
+                        The path for the policy.
+
+
+                        For more information about paths, see IAM identifiers (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
+                        in the IAM User Guide.
+
+
+                        This parameter is optional. If it is not included, it defaults to a slash
+                        (/).
+
+
+                        This parameter allows (through its regex pattern (http://wikipedia.org/wiki/regex))
+                        a string of characters consisting of either a forward slash (/) by itself
+                        or a string that must begin and end with forward slashes. In addition, it
+                        can contain any ASCII character from the ! (\u0021) through the DEL character
+                        (\u007F), including most punctuation characters, digits, and upper and lowercased
+                        letters.
+
+
+                        You cannot use an asterisk (*) in the path name.
+                      type: string
+                    policyDocument:
+                      description: |-
+                        The JSON policy document that you want to use as the content for the new
+                        policy.
+
+
+                        You must provide policies in JSON format in IAM. However, for CloudFormation
+                        templates formatted in YAML, you can provide the policy in JSON or YAML format.
+                        CloudFormation always converts a YAML policy to JSON format before submitting
+                        it to IAM.
+
+
+                        The maximum length of the policy document that you can pass in this operation,
+                        including whitespace, is listed below. To view the maximum character counts
+                        of a managed policy with no whitespaces, see IAM and STS character quotas
+                        (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length).
+
+
+                        To learn more about JSON policy grammar, see Grammar of the IAM JSON policy
+                        language (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html)
+                        in the IAM User Guide.
+
+
+                        The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
+                        parameter is a string of characters consisting of the following:
+
+
+                          * Any printable ASCII character ranging from the space character (\u0020)
+                          through the end of the ASCII character range
+
+
+                          * The printable characters in the Basic Latin and Latin-1 Supplement character
+                          set (through \u00FF)
+
+
+                          * The special characters tab (\u0009), line feed (\u000A), and carriage
+                          return (\u000D)
+                      type: string
+                    tags:
+                      description: |-
+                        A list of tags that you want to attach to the new IAM customer managed policy.
+                        Each tag consists of a key name and an associated value. For more information
+                        about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+                        in the IAM User Guide.
+
+
+                        If any one of the tags is invalid or if you exceed the allowed maximum number
+                        of tags, then the entire request fails and the resource is not created.
+                      items:
+                        description: |-
+                          A structure that represents user-provided metadata that can be associated
+                          with an IAM resource. For more information about tagging, see Tagging IAM
+                          resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+                          in the IAM User Guide.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - policyDocument
+                  type: object
+                status:
+                  description: PolicyStatus defines the observed state of Policy
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    attachmentCount:
+                      description: |-
+                        The number of entities (users, groups, and roles) that the policy is attached
+                        to.
+                      format: int64
+                      type: integer
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    createDate:
+                      description: |-
+                        The date and time, in ISO 8601 date-time format (http://www.iso.org/iso/iso8601),
+                        when the policy was created.
+                      format: date-time
+                      type: string
+                    defaultVersionID:
+                      description: The identifier for the version of the policy that is
+                        set as the default version.
+                      type: string
+                    isAttachable:
+                      description: Specifies whether the policy can be attached to an IAM
+                        user, group, or role.
+                      type: boolean
+                    permissionsBoundaryUsageCount:
+                      description: |-
+                        The number of entities (users and roles) for which the policy is used to
+                        set the permissions boundary.
+
+
+                        For more information about permissions boundaries, see Permissions boundaries
+                        for IAM identities (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html)
+                        in the IAM User Guide.
+                      format: int64
+                      type: integer
+                    policyID:
+                      description: |-
+                        The stable and unique string identifying the policy.
+
+
+                        For more information about IDs, see IAM identifiers (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
+                        in the IAM User Guide.
+                      type: string
+                    updateDate:
+                      description: |-
+                        The date and time, in ISO 8601 date-time format (http://www.iso.org/iso/iso8601),
+                        when the policy was last updated.
+
+
+                        When a policy has only one version, this field contains the date and time
+                        when the policy was created. When a policy has more than one version, this
+                        field contains the date and time when the most recent policy version was
+                        created.
+                      format: date-time
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: iamRoleCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: roles.iam.services.k8s.aws
+      spec:
+        group: iam.services.k8s.aws
+        names:
+          kind: Role
+          listKind: RoleList
+          plural: roles
+          singular: role
+        scope: Namespaced
+        versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: Role is the Schema for the Roles API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    RoleSpec defines the desired state of Role.
+
+
+                    Contains information about an IAM role. This structure is returned as a response
+                    element in several API operations that interact with roles.
+                  properties:
+                    assumeRolePolicyDocument:
+                      description: |-
+                        The trust relationship policy document that grants an entity permission to
+                        assume the role.
+
+
+                        In IAM, you must provide a JSON policy that has been converted to a string.
+                        However, for CloudFormation templates formatted in YAML, you can provide
+                        the policy in JSON or YAML format. CloudFormation always converts a YAML
+                        policy to JSON format before submitting it to IAM.
+
+
+                        The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
+                        parameter is a string of characters consisting of the following:
+
+
+                          * Any printable ASCII character ranging from the space character (\u0020)
+                          through the end of the ASCII character range
+
+
+                          * The printable characters in the Basic Latin and Latin-1 Supplement character
+                          set (through \u00FF)
+
+
+                          * The special characters tab (\u0009), line feed (\u000A), and carriage
+                          return (\u000D)
+
+
+                        Upon success, the response includes the same trust policy in JSON format.
+                      type: string
+                    description:
+                      description: A description of the role.
+                      type: string
+                    inlinePolicies:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    maxSessionDuration:
+                      description: |-
+                        The maximum session duration (in seconds) that you want to set for the specified
+                        role. If you do not specify a value for this setting, the default value of
+                        one hour is applied. This setting can have a value from 1 hour to 12 hours.
+
+
+                        Anyone who assumes the role from the CLI or API can use the DurationSeconds
+                        API parameter or the duration-seconds CLI parameter to request a longer session.
+                        The MaxSessionDuration setting determines the maximum duration that can be
+                        requested using the DurationSeconds parameter. If users don't specify a value
+                        for the DurationSeconds parameter, their security credentials are valid for
+                        one hour by default. This applies when you use the AssumeRole* API operations
+                        or the assume-role* CLI operations but does not apply when you use those
+                        operations to create a console URL. For more information, see Using IAM roles
+                        (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html) in the
+                        IAM User Guide.
+                      format: int64
+                      type: integer
+                    name:
+                      description: |-
+                        The name of the role to create.
+
+
+                        IAM user, group, role, and policy names must be unique within the account.
+                        Names are not distinguished by case. For example, you cannot create resources
+                        named both "MyResource" and "myresource".
+
+
+                        This parameter allows (through its regex pattern (http://wikipedia.org/wiki/regex))
+                        a string of characters consisting of upper and lowercase alphanumeric characters
+                        with no spaces. You can also include any of the following characters: _+=,.@-
+                      type: string
+                    path:
+                      description: |-
+                        The path to the role. For more information about paths, see IAM Identifiers
+                        (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
+                        in the IAM User Guide.
+
+
+                        This parameter is optional. If it is not included, it defaults to a slash
+                        (/).
+
+
+                        This parameter allows (through its regex pattern (http://wikipedia.org/wiki/regex))
+                        a string of characters consisting of either a forward slash (/) by itself
+                        or a string that must begin and end with forward slashes. In addition, it
+                        can contain any ASCII character from the ! (\u0021) through the DEL character
+                        (\u007F), including most punctuation characters, digits, and upper and lowercased
+                        letters.
+                      type: string
+                    permissionsBoundary:
+                      description: |-
+                        The ARN of the managed policy that is used to set the permissions boundary
+                        for the role.
+
+
+                        A permissions boundary policy defines the maximum permissions that identity-based
+                        policies can grant to an entity, but does not grant permissions. Permissions
+                        boundaries do not define the maximum permissions that a resource-based policy
+                        can grant to an entity. To learn more, see Permissions boundaries for IAM
+                        entities (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html)
+                        in the IAM User Guide.
+
+
+                        For more information about policy types, see Policy types (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#access_policy-types)
+                        in the IAM User Guide.
+                      type: string
+                    permissionsBoundaryRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    policies:
+                      items:
+                        type: string
+                      type: array
+                    policyRefs:
+                      items:
+                        description: "AWSResourceReferenceWrapper provides a wrapper around
+                          *AWSResourceReference\ntype to provide more user friendly syntax
+                          for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                          \ name: my-api"
+                        properties:
+                          from:
+                            description: |-
+                              AWSResourceReference provides all the values necessary to reference another
+                              k8s resource for finding the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                    tags:
+                      description: |-
+                        A list of tags that you want to attach to the new role. Each tag consists
+                        of a key name and an associated value. For more information about tagging,
+                        see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+                        in the IAM User Guide.
+
+
+                        If any one of the tags is invalid or if you exceed the allowed maximum number
+                        of tags, then the entire request fails and the resource is not created.
+                      items:
+                        description: |-
+                          A structure that represents user-provided metadata that can be associated
+                          with an IAM resource. For more information about tagging, see Tagging IAM
+                          resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+                          in the IAM User Guide.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - assumeRolePolicyDocument
+                  - name
+                  type: object
+                status:
+                  description: RoleStatus defines the observed state of Role
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    createDate:
+                      description: |-
+                        The date and time, in ISO 8601 date-time format (http://www.iso.org/iso/iso8601),
+                        when the role was created.
+                      format: date-time
+                      type: string
+                    roleID:
+                      description: |-
+                        The stable and unique string identifying the role. For more information about
+                        IDs, see IAM identifiers (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
+                        in the IAM User Guide.
+                      type: string
+                    roleLastUsed:
+                      description: |-
+                        Contains information about the last time that an IAM role was used. This
+                        includes the date and time and the Region in which the role was last used.
+                        Activity is only reported for the trailing 400 days. This period can be shorter
+                        if your Region began supporting these features within the last year. The
+                        role might have been used more than 400 days ago. For more information, see
+                        Regions where data is tracked (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#access-advisor_tracking-period)
+                        in the IAM user Guide.
+                      properties:
+                        lastUsedDate:
+                          format: date-time
+                          type: string
+                        region:
+                          type: string
+                      type: object
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  - name: iamUserCRD
+    definition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.14.0
+        name: users.iam.services.k8s.aws
+      spec:
+        group: iam.services.k8s.aws
+        names:
+          kind: User
+          listKind: UserList
+          plural: users
+          singular: user
+        scope: Namespaced
+        versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              description: User is the Schema for the Users API
+              properties:
+                apiVersion:
+                  description: |-
+                    APIVersion defines the versioned schema of this representation of an object.
+                    Servers should convert recognized schemas to the latest internal value, and
+                    may reject unrecognized values.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  type: string
+                kind:
+                  description: |-
+                    Kind is a string value representing the REST resource this object represents.
+                    Servers may infer this from the endpoint the client submits requests to.
+                    Cannot be updated.
+                    In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: |-
+                    UserSpec defines the desired state of User.
+
+
+                    Contains information about an IAM user entity.
+
+
+                    This data type is used as a response element in the following operations:
+
+
+                      * CreateUser
+
+
+                      * GetUser
+
+
+                      * ListUsers
+                  properties:
+                    inlinePolicies:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    name:
+                      description: |-
+                        The name of the user to create.
+
+
+                        IAM user, group, role, and policy names must be unique within the account.
+                        Names are not distinguished by case. For example, you cannot create resources
+                        named both "MyResource" and "myresource".
+                      type: string
+                    path:
+                      description: |-
+                        The path for the user name. For more information about paths, see IAM identifiers
+                        (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
+                        in the IAM User Guide.
+
+
+                        This parameter is optional. If it is not included, it defaults to a slash
+                        (/).
+
+
+                        This parameter allows (through its regex pattern (http://wikipedia.org/wiki/regex))
+                        a string of characters consisting of either a forward slash (/) by itself
+                        or a string that must begin and end with forward slashes. In addition, it
+                        can contain any ASCII character from the ! (\u0021) through the DEL character
+                        (\u007F), including most punctuation characters, digits, and upper and lowercased
+                        letters.
+                      type: string
+                    permissionsBoundary:
+                      description: |-
+                        The ARN of the managed policy that is used to set the permissions boundary
+                        for the user.
+
+
+                        A permissions boundary policy defines the maximum permissions that identity-based
+                        policies can grant to an entity, but does not grant permissions. Permissions
+                        boundaries do not define the maximum permissions that a resource-based policy
+                        can grant to an entity. To learn more, see Permissions boundaries for IAM
+                        entities (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html)
+                        in the IAM User Guide.
+
+
+                        For more information about policy types, see Policy types (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#access_policy-types)
+                        in the IAM User Guide.
+                      type: string
+                    permissionsBoundaryRef:
+                      description: "AWSResourceReferenceWrapper provides a wrapper around
+                        *AWSResourceReference\ntype to provide more user friendly syntax
+                        for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                        \ name: my-api"
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    policies:
+                      items:
+                        type: string
+                      type: array
+                    policyRefs:
+                      items:
+                        description: "AWSResourceReferenceWrapper provides a wrapper around
+                          *AWSResourceReference\ntype to provide more user friendly syntax
+                          for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                          \ name: my-api"
+                        properties:
+                          from:
+                            description: |-
+                              AWSResourceReference provides all the values necessary to reference another
+                              k8s resource for finding the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                    tags:
+                      description: |-
+                        A list of tags that you want to attach to the new user. Each tag consists
+                        of a key name and an associated value. For more information about tagging,
+                        see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+                        in the IAM User Guide.
+
+
+                        If any one of the tags is invalid or if you exceed the allowed maximum number
+                        of tags, then the entire request fails and the resource is not created.
+                      items:
+                        description: |-
+                          A structure that represents user-provided metadata that can be associated
+                          with an IAM resource. For more information about tagging, see Tagging IAM
+                          resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+                          in the IAM User Guide.
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  type: object
+                status:
+                  description: UserStatus defines the observed state of User
+                  properties:
+                    ackResourceMetadata:
+                      description: |-
+                        All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
+                        that is used to contain resource sync state, account ownership,
+                        constructed ARN for the resource
+                      properties:
+                        arn:
+                          description: |-
+                            ARN is the Amazon Resource Name for the resource. This is a
+                            globally-unique identifier and is set only by the ACK service controller
+                            once the controller has orchestrated the creation of the resource OR
+                            when it has verified that an "adopted" resource (a resource where the
+                            ARN annotation was set by the Kubernetes user on the CR) exists and
+                            matches the supplied CR's Spec field values.
+                            TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+                            https://github.com/aws/aws-controllers-k8s/issues/270
+                          type: string
+                        ownerAccountID:
+                          description: |-
+                            OwnerAccountID is the AWS Account ID of the account that owns the
+                            backend AWS service API resource.
+                          type: string
+                        region:
+                          description: Region is the AWS region in which the resource exists
+                            or will exist.
+                          type: string
+                      required:
+                      - ownerAccountID
+                      - region
+                      type: object
+                    conditions:
+                      description: |-
+                        All CRS managed by ACK have a common `Status.Conditions` member that
+                        contains a collection of `ackv1alpha1.Condition` objects that describe
+                        the various terminal states of the CR and its backend AWS service API
+                        resource
+                      items:
+                        description: |-
+                          Condition is the common struct used by all CRDs managed by ACK service
+                          controllers to indicate terminal states  of the CR and its backend AWS
+                          service API resource
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status
+                              to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about
+                              the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the Condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    createDate:
+                      description: |-
+                        The date and time, in ISO 8601 date-time format (http://www.iso.org/iso/iso8601),
+                        when the user was created.
+                      format: date-time
+                      type: string
+                    passwordLastUsed:
+                      description: |-
+                        The date and time, in ISO 8601 date-time format (http://www.iso.org/iso/iso8601),
+                        when the user's password was last used to sign in to an Amazon Web Services
+                        website. For a list of Amazon Web Services websites that capture a user's
+                        last sign-in time, see the Credential reports (https://docs.aws.amazon.com/IAM/latest/UserGuide/credential-reports.html)
+                        topic in the IAM User Guide. If a password is used more than once in a five-minute
+                        span, only the first use is returned in this field. If the field is null
+                        (no value), then it indicates that they never signed in with a password.
+                        This can be because:
+
+
+                          * The user never had a password.
+
+
+                          * A password exists but has not been used since IAM started tracking this
+                          information on October 20, 2014.
+
+
+                        A null value does not mean that the user never had a password. Also, if the
+                        user does not currently have a password but had one in the past, then this
+                        field contains the date and time the most recent password was used.
+
+
+                        This value is returned only in the GetUser and ListUsers operations.
+                      format: date-time
+                      type: string
+                    userID:
+                      description: |-
+                        The stable and unique string identifying the user. For more information about
+                        IDs, see IAM identifiers (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
+                        in the IAM User Guide.
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}

--- a/examples/ack-eks-cluster/eks-cluster.yaml
+++ b/examples/ack-eks-cluster/eks-cluster.yaml
@@ -13,8 +13,8 @@ spec:
     status:
       networkingInfo:
         vpcID: ${clusterVPC.status.vpcID}
-        subnetAZA: ${subnetAZA.status.subnetID}
-        subnetAZB: ${subnetAZB.status.subnetID}
+        subnetAZA: ${clusterSubnetA.status.subnetID}
+        subnetAZB: ${clusterSubnetB.status.subnetID}
       clusterARN: ${cluster.status.ackResourceMetadata.arn}
   # resources
   resources:
@@ -23,52 +23,84 @@ spec:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: VPC
       metadata:
-        name: cluster-vpc-${spec.name}
+        name: symphony-cluster-vpc
       spec:
         cidrBlocks:
         - 192.168.0.0/16
-        enableDNSHostnames: false
         enableDNSSupport: true
-  - name: subnetAZA
+        enableDNSHostnames: true
+  - name: clusterElasticIPAddress
+    definition:
+      apiVersion: ec2.services.k8s.aws/v1alpha1
+      kind: ElasticIPAddress
+      metadata:
+        name: symphony-cluster-eip
+      spec: {}
+  - name: clusterInternetGateway
+    definition:
+      apiVersion: ec2.services.k8s.aws/v1alpha1
+      kind: InternetGateway
+      metadata:
+        name: symphony-cluster-igw
+      spec:
+        vpc: ${clusterVPC.status.vpcID}
+  - name: clusterRouteTable
+    definition:
+      apiVersion: ec2.services.k8s.aws/v1alpha1
+      kind: RouteTable
+      metadata:
+        name: symphony-cluster-public-route-table
+      spec:
+        vpcID: ${clusterVPC.status.vpcID}
+        routes:
+          - destinationCIDRBlock: 0.0.0.0/0
+            gatewayID: ${clusterInternetGateway.status.internetGatewayID}
+  - name: clusterSubnetA
     definition:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: Subnet
       metadata:
-        name: cluster-subnet-a-${spec.name}
+        name: symphony-cluster-public-subnet1
       spec:
         availabilityZone: us-west-2a
         cidrBlock: 192.168.0.0/18
         vpcID: ${clusterVPC.status.vpcID}
-  - name: securityGroup
-    definition:
-      apiVersion: ec2.services.k8s.aws/v1alpha1
-      kind: SecurityGroup
-      metadata:
-        name: cluster-security-group-${spec.name}
-      spec:
-        vpcID: ${clusterVPC.status.vpcID}
-        name: my-eks-cluster-sg-${spec.name}
-        description: something something
-  - name: subnetAZB
+        routeTables: 
+        - ${clusterRouteTable.status.routeTableID}
+        mapPublicIPOnLaunch: true
+  - name: clusterSubnetB
     definition:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: Subnet
       metadata:
-        name: cluster-subnet-b-${spec.name}
+        name: symphony-cluster-public-subnet2
       spec:
         availabilityZone: us-west-2b
         cidrBlock: 192.168.64.0/18
         vpcID: ${clusterVPC.status.vpcID}
+        routeTables:
+        - ${clusterRouteTable.status.routeTableID}
+        mapPublicIPOnLaunch: true
+  - name: clusterNATGateway
+    definition:
+      apiVersion: ec2.services.k8s.aws/v1alpha1
+      kind: NATGateway
+      metadata:
+        name: symphony-cluster-natgateway1
+      spec:
+        subnetID: ${clusterSubnetB.status.subnetID}
+        allocationID: ${clusterElasticIPAddress.status.allocationID}
   - name: clusterRole
     definition:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Role
       metadata:
-        name: cluster-role-${spec.name}
+        name: symphony-cluster-role
       spec:
-        name: cluster-role-${spec.name}
+        name: symphony-cluster-role
+        description: "Symphony created cluster cluster role"
         policies:
-        - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+          - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
         assumeRolePolicyDocument: |
           {
             "Version": "2012-10-17",
@@ -82,18 +114,19 @@ spec:
               }
             ]
           }
-  - name: nodeRole
+  - name: clusterNodeRole
     definition:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Role
       metadata:
-        name: cluster-node-role-${spec.name}
+        name: symphony-cluster-node-role
       spec:
-        name: cluster-node-role-${spec.name}
+        name: symphony-cluster-node-role
+        description: "Symphony created cluster node role"
         policies:
-        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
-        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
-        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+          - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+          - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+          - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
         assumeRolePolicyDocument: |
           {
             "Version": "2012-10-17",
@@ -107,17 +140,69 @@ spec:
               }
             ]
           }
+  - name: clusterAdminRole
+    definition:
+      apiVersion: iam.services.k8s.aws/v1alpha1
+      kind: Role
+      metadata:
+        name: symphony-cluster-pia-role
+      spec:
+        name: symphony-cluster-pia-role
+        description: "Symphony created cluster admin pia role"
+        policies:
+          - arn:aws:iam::aws:policy/AdministratorAccess
+        assumeRolePolicyDocument: |
+          {
+              "Version": "2012-10-17",
+              "Statement": [
+                  {
+                      "Sid": "AllowEksAuthToAssumeRoleForPodIdentity",
+                      "Effect": "Allow",
+                      "Principal": {
+                          "Service": "pods.eks.amazonaws.com"
+                      },
+                      "Action": [
+                          "sts:AssumeRole",
+                          "sts:TagSession"
+                      ]
+                  }
+              ]
+          }
   - name: cluster
     definition:
       apiVersion: eks.services.k8s.aws/v1alpha1
       kind: Cluster
       metadata:
-        name: cluster-${spec.name}
+        name: ${spec.name}
       spec:
-        name: cluster-${spec.name}
+        name: ${spec.name}
+        accessConfig:
+          authenticationMode: API_AND_CONFIG_MAP
         roleARN: ${clusterRole.status.ackResourceMetadata.arn}
         version: ${spec.version}
         resourcesVPCConfig:
+          endpointPrivateAccess: false
+          endpointPublicAccess: true
           subnetIDs:
-            - ${subnetAZA.status.subnetID}
-            - ${subnetAZB.status.subnetID}
+          - ${clusterSubnetA.status.subnetID}
+          - ${clusterSubnetB.status.subnetID}
+  - name: clusterNodeGroup
+    definition:
+      apiVersion: eks.services.k8s.aws/v1alpha1
+      kind: Nodegroup
+      metadata:
+        name: symphony-cluster-nodegroup
+      spec:
+        name: symphony-cluster-ng
+        diskSize: 100
+        clusterName: ${cluster.spec.name}
+        subnets:
+        - ${clusterSubnetA.status.subnetID}
+        - ${clusterSubnetB.status.subnetID}
+        nodeRole: ${clusterNodeRole.status.ackResourceMetadata.arn}
+        updateConfig:
+          maxUnavailable: 1
+        scalingConfig:
+          minSize: 1
+          maxSize: 1
+          desiredSize: 1 


### PR DESCRIPTION
Description of changes:
Creating steps to deploy the IAM, EC2, and EKS Controllers to a cluster with symphony.
Subsequently, added a manifest that creates an  EKS cluster and its subresources using the 
controllers mentioned above

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
