### PR TITLE
We are changing one of the liters for golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ linters:
   enable:
     - dupl
     - errcheck
-    - exportloopref
+    - copyloopvar
     - goconst
     - gocyclo
     - gofmt


### PR DESCRIPTION
Description of changes:
This is happening due to an update mentioned [here](https://golangci-lint.run/usage/linters/#exportloopref)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
