### PR TITLE
celinspector: fix variable scope conflicts and resource detection edge cases

### DIFF
--- a/internal/typesystem/celinspector/celinspector.go
+++ b/internal/typesystem/celinspector/celinspector.go
@@ -21,38 +21,87 @@ import (
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
+// ResourceDependency represents a resource and its accessed path within a CEL expression.
+// For example, in the expression "deployment.spec.replicas > 0",
+// Name would be "deployment" and Path would be "deployment.spec.replicas"
 type ResourceDependency struct {
+	// Name is the root resource identifier (e.g "deployment", "service", "pod")
 	Name string
+	// Path is the full access path including nested fields
+	// For example: "deployment.spec.replicas" or "service.metadata.name"
 	Path string
 }
 
+// FunctionCall represents an invocation of a declared function within a CEL expression.
+// This tracks both the function name and its arguments as they appear in the expression
+//
+// The arguments are string representations of the AST nodes. We mainly ignore them for
+// now, but they could be used to further analyze the expression.
 type FunctionCall struct {
-	Name      string
+	// Name is the function identifier
+	// For example: "hash" "toLower"
+	Name string
+
+	// Arguments contains the string representation of each argument passed to the function
+	// For example: ["deployment.name", "'frontend'"] for a call like concat(deployment.name, "frontend")
 	Arguments []string
 }
 
+// UnknownResource represents a resource reference in the expression that wasn't
+// declared in the known resources list. This helps identify potentially missing
+// or misspelled resource names.
 type UnknownResource struct {
+	// Name is the undeclared resource identifier that was referenced
 	Name string
+	// Path is the full access path that was attempted with this unknown resource
+	// For example: "unknown_resource.field.subfield"
 	Path string
 }
 
+// UnknownFunction represents a function call in the expression that wasn't
+// declared in the known functions list and isn't a CEL built in function.
 type UnknownFunction struct {
+	// Name is the undeclared function identifier that was called
 	Name string
 }
 
+// ExpressionInspection contains all the findings from analyzing a CEL expression.
+// It tracks all resources accessed, functions called, and any unknown references.
 type ExpressionInspection struct {
+	// ResourceDependencies lists all known resources and their access paths
+	// used in the expression
 	ResourceDependencies []ResourceDependency
-	FunctionCalls        []FunctionCall
-	UnknownResources     []UnknownResource
-	UnknownFunctions     []UnknownFunction
+	// FunctionCalls lists all known function calls and their arguments found
+	// in the expression
+	FunctionCalls []FunctionCall
+	// UnknownResources lists any resource references that weren't declared
+	UnknownResources []UnknownResource
+	// UnknownFunctions lists any function calls that weren't declared, either
+	// by symphony engine, standard libraries or CEL built-in functions.
+	UnknownFunctions []UnknownFunction
 }
 
+// Inspector analyzes CEL expressions to discover resource and function dependencies.
+// It maintains the CEL environment and tracks which resources and functions are known.
 type Inspector struct {
-	env       *cel.Env
+	// env is the CEL evaluation environment containing type definitions and functions
+	env *cel.Env
+
+	// resources is a set of known resource names that can be referenced in expressions
+	// The empty struct value is used to implement a memory-efficient set
 	resources map[string]struct{}
+
+	// functions is a set of known function names that can be called in expressions
+	// The empty struct value is used to implement a memory-efficient set
 	functions map[string]struct{}
+
+	// Track active loop variables
+	loopVars map[string]struct{}
 }
 
+// NewInspector creates a new Inspector instance with the given resources and functions.
+//
+// TODO(a-hilaly): unify CEL environment creation with the rest of the codebase.
 func NewInspector(resources []string, functions []string) (*Inspector, error) {
 	declarations := make([]cel.EnvOption, 0, len(resources)+len(functions))
 
@@ -80,9 +129,12 @@ func NewInspector(resources []string, functions []string) (*Inspector, error) {
 		env:       env,
 		resources: resourceMap,
 		functions: functionMap,
+		loopVars:  make(map[string]struct{}),
 	}, nil
 }
 
+// NewInspectorWithEnv creates a new Inspector instance with the given resources and functions
+// using the provided CEL environment.
 func NewInspectorWithEnv(env *cel.Env, resources []string, functions []string) *Inspector {
 	resourceMap := make(map[string]struct{})
 	for _, resource := range resources {
@@ -98,29 +150,38 @@ func NewInspectorWithEnv(env *cel.Env, resources []string, functions []string) *
 		env:       env,
 		resources: resourceMap,
 		functions: functionMap,
+		loopVars:  make(map[string]struct{}),
 	}
 }
 
+// Inspect analyzes the given CEL expression and returns an ExpressionInspection.
+//
+// This function can be called multiple times with different expressions using the same
+// Inspector instance (AND environment).
 func (a *Inspector) Inspect(expression string) (ExpressionInspection, error) {
 	ast, iss := a.env.Parse(expression)
 	if iss.Err() != nil {
 		return ExpressionInspection{}, fmt.Errorf("failed to parse expression: %v", iss.Err())
 	}
 
-	// p, _ := cel.AstToParsedExpr(ast)
-	// p.GetExpr()
-
-	return a.inspectAst(ast.Expr(), ""), nil
+	parsed, err := cel.AstToParsedExpr(ast)
+	if err != nil {
+		return ExpressionInspection{}, fmt.Errorf("failed to check expression: %v", err)
+	}
+	return a.inspectAst(parsed.GetExpr(), ""), nil
 }
 
+// inspectAst recursively traverses a CEL expressions AST and collects all resource
+// dependencies and function calls. It builds paths for nested field access and handles
+// different expression types.
 func (a *Inspector) inspectAst(expr *exprpb.Expr, currentPath string) ExpressionInspection {
 	switch e := expr.ExprKind.(type) {
 	case *exprpb.Expr_SelectExpr:
-		newPath := currentPath
+		// build the path in **reverse order** /!\
+		newPath := e.SelectExpr.Field
 		if currentPath != "" {
-			newPath += "."
+			newPath = newPath + "." + currentPath
 		}
-		newPath += e.SelectExpr.Field
 		return a.inspectAst(e.SelectExpr.Operand, newPath)
 	case *exprpb.Expr_CallExpr:
 		return a.inspectCall(e.CallExpr, currentPath)
@@ -133,33 +194,15 @@ func (a *Inspector) inspectAst(expr *exprpb.Expr, currentPath string) Expression
 	}
 }
 
+// inspectCall analyzes function calls and method invocations within a CEL expression.
+// It tracks three types of calls:
+// 1. Custom functions (declared in Inspector initialization)
+// 2. Method calls on resources ( list.filter(...))
+// 3. Unknown functions (neither custom nor internal)
 func (a *Inspector) inspectCall(call *exprpb.Expr_Call, currentPath string) ExpressionInspection {
 	inspection := ExpressionInspection{}
 
-	if _, isFunction := a.functions[call.Function]; isFunction {
-		functionCall := FunctionCall{
-			Name: call.Function,
-		}
-		for _, arg := range call.Args {
-			functionCall.Arguments = append(functionCall.Arguments, a.exprToString(arg))
-		}
-		inspection.FunctionCalls = append(inspection.FunctionCalls, functionCall)
-	} else {
-		if call.Target == nil && !isInternalFunction(call.Function) {
-			// This is an unknown function, but not an internal one
-			inspection.UnknownFunctions = append(inspection.UnknownFunctions, UnknownFunction{Name: call.Function})
-		} else if call.Target != nil {
-			targetInspection := a.inspectAst(call.Target, currentPath)
-			inspection.ResourceDependencies = append(inspection.ResourceDependencies, targetInspection.ResourceDependencies...)
-			inspection.FunctionCalls = append(inspection.FunctionCalls, targetInspection.FunctionCalls...)
-			inspection.UnknownResources = append(inspection.UnknownResources, targetInspection.UnknownResources...)
-			inspection.UnknownFunctions = append(inspection.UnknownFunctions, targetInspection.UnknownFunctions...)
-			inspection.FunctionCalls = append(inspection.FunctionCalls, FunctionCall{
-				Name: fmt.Sprintf("%s.%s", a.exprToString(call.Target), call.Function),
-			})
-		}
-	}
-
+	// First process arguments to get their dependencies
 	for _, arg := range call.Args {
 		argInspection := a.inspectAst(arg, "")
 		inspection.ResourceDependencies = append(inspection.ResourceDependencies, argInspection.ResourceDependencies...)
@@ -168,10 +211,46 @@ func (a *Inspector) inspectCall(call *exprpb.Expr_Call, currentPath string) Expr
 		inspection.UnknownFunctions = append(inspection.UnknownFunctions, argInspection.UnknownFunctions...)
 	}
 
+	// Handle the current function - only if it's not part of a chain
+	if _, isFunction := a.functions[call.Function]; isFunction && call.Target == nil {
+		functionCall := FunctionCall{
+			Name: call.Function,
+		}
+		for _, arg := range call.Args {
+			functionCall.Arguments = append(functionCall.Arguments, a.exprToString(arg))
+		}
+		inspection.FunctionCalls = append(inspection.FunctionCalls, functionCall)
+	}
+
+	// Then handle the target if it exists
+	if call.Target != nil {
+		targetInspection := a.inspectAst(call.Target, currentPath)
+		inspection.ResourceDependencies = append(inspection.ResourceDependencies, targetInspection.ResourceDependencies...)
+		inspection.FunctionCalls = append(inspection.FunctionCalls, targetInspection.FunctionCalls...)
+		inspection.UnknownResources = append(inspection.UnknownResources, targetInspection.UnknownResources...)
+		inspection.UnknownFunctions = append(inspection.UnknownFunctions, targetInspection.UnknownFunctions...)
+
+		// Add the chained call representation
+		inspection.FunctionCalls = append(inspection.FunctionCalls, FunctionCall{
+			Name: fmt.Sprintf("%s.%s", a.exprToString(call.Target), call.Function),
+		})
+	} else if !isInternalFunction(call.Function) {
+		// This is an unknown function, but not an internal one
+		inspection.UnknownFunctions = append(inspection.UnknownFunctions, UnknownFunction{Name: call.Function})
+	}
+
 	return inspection
 }
 
+// inspectIdent analyzes identifier expressions in CEL and determines if they are known resources
+// or unknown references. It handles the base identifiers in field access chains and distinguishes
+// between declared resources and unknown/internal identifiers.
 func (a *Inspector) inspectIdent(ident *exprpb.Expr_Ident, currentPath string) ExpressionInspection {
+	// Check if it's a loop variable
+	if _, isLoopVar := a.loopVars[ident.Name]; isLoopVar {
+		return ExpressionInspection{} // Loop variables are not resources
+	}
+
 	if _, isResource := a.resources[ident.Name]; isResource {
 		fullPath := ident.Name
 		if currentPath != "" {
@@ -185,14 +264,12 @@ func (a *Inspector) inspectIdent(ident *exprpb.Expr_Ident, currentPath string) E
 		}
 	}
 	// If it's not a known resource, it's an unknown resource
-
 	if !isInternalIdentifier(ident.Name) {
 		path := ident.Name
 		if currentPath != "" {
 			path += "." + currentPath
 		}
 		return ExpressionInspection{
-
 			UnknownResources: []UnknownResource{{
 				Name: ident.Name,
 				Path: path,
@@ -202,88 +279,219 @@ func (a *Inspector) inspectIdent(ident *exprpb.Expr_Ident, currentPath string) E
 	return ExpressionInspection{}
 }
 
+// inspectComprehension analyzes list comprehensions in CEL expressions (filter and map operations).
+// It tracks dependencies from the iteration range, condition, step, and result expressions.
 func (a *Inspector) inspectComprehension(comp *exprpb.Expr_Comprehension, currentPath string) ExpressionInspection {
 	inspection := ExpressionInspection{}
 
+	// Variable scoping in CEL expressions requires careful handling of identifiers.
+	// Consider this example of variable shadowing:
+	//
+	// given:
+	//   - a declared resource: "deployment"
+	//   - an expression: `i + deployment.metadata.labels.filter(i, i == "something")`
+	//
+	// The identifier 'i' appears in two contexts:
+	//   1. As a free variable: `i +` (should be marked as unknown resource)
+	//   2. As a loop variable: `filter(i, i == "something")` (should be ignored)
+	//
+	// Even though the same identifier 'i' is used, it has different semantics:
+	//   - The first 'i' is a reference to an undeclared resource
+	//   - The second 'i' is a scoped variable within the filter comprehension
+	//   - The third 'i' refers to the loop variable from the filter
+	//
+	// This demonstrates why we need to:
+	//   1. Track loop variables separately from resources
+	//   2. Consider the scope of each identifier
+	//   3. Properly handle variable shadowing
+	a.loopVars[comp.IterVar] = struct{}{}
+	defer delete(a.loopVars, comp.IterVar)
+
+	// Inspect the range we're iterating over
 	iterRangeInspection := a.inspectAst(comp.IterRange, currentPath)
 	inspection.ResourceDependencies = append(inspection.ResourceDependencies, iterRangeInspection.ResourceDependencies...)
 	inspection.FunctionCalls = append(inspection.FunctionCalls, iterRangeInspection.FunctionCalls...)
 	inspection.UnknownResources = append(inspection.UnknownResources, iterRangeInspection.UnknownResources...)
 	inspection.UnknownFunctions = append(inspection.UnknownFunctions, iterRangeInspection.UnknownFunctions...)
 
+	// For filters, inspect the condition
+	if comp.LoopCondition != nil {
+		conditionInspection := a.inspectAst(comp.LoopCondition, "")
+		inspection.ResourceDependencies = append(inspection.ResourceDependencies, conditionInspection.ResourceDependencies...)
+		inspection.FunctionCalls = append(inspection.FunctionCalls, conditionInspection.FunctionCalls...)
+		inspection.UnknownResources = append(inspection.UnknownResources, conditionInspection.UnknownResources...)
+		inspection.UnknownFunctions = append(inspection.UnknownFunctions, conditionInspection.UnknownFunctions...)
+	}
+
+	// For maps, inspect the loop step (transformation)
+	if comp.LoopStep != nil {
+		stepInspection := a.inspectAst(comp.LoopStep, "")
+		inspection.ResourceDependencies = append(inspection.ResourceDependencies, stepInspection.ResourceDependencies...)
+		inspection.FunctionCalls = append(inspection.FunctionCalls, stepInspection.FunctionCalls...)
+		inspection.UnknownResources = append(inspection.UnknownResources, stepInspection.UnknownResources...)
+		inspection.UnknownFunctions = append(inspection.UnknownFunctions, stepInspection.UnknownFunctions...)
+	}
+
+	// Inspect the result expression
 	resultInspection := a.inspectAst(comp.Result, "")
 	inspection.ResourceDependencies = append(inspection.ResourceDependencies, resultInspection.ResourceDependencies...)
 	inspection.FunctionCalls = append(inspection.FunctionCalls, resultInspection.FunctionCalls...)
 	inspection.UnknownResources = append(inspection.UnknownResources, resultInspection.UnknownResources...)
 	inspection.UnknownFunctions = append(inspection.UnknownFunctions, resultInspection.UnknownFunctions...)
 
+	// Record the comprehension operation
 	if comp.LoopStep == nil {
 		inspection.FunctionCalls = append(inspection.FunctionCalls, FunctionCall{
-			Name:      "filter",
-			Arguments: []string{a.exprToString(comp.IterRange), a.exprToString(comp.Result)},
+			Name: "filter",
+			Arguments: []string{
+				a.exprToString(comp.IterRange),
+				a.exprToString(comp.LoopCondition), // Add filter condition
+				a.exprToString(comp.Result),
+			},
 		})
 	} else {
 		inspection.FunctionCalls = append(inspection.FunctionCalls, FunctionCall{
-			Name:      "map",
-			Arguments: []string{a.exprToString(comp.IterRange), a.exprToString(comp.Result)},
+			Name: "map",
+			Arguments: []string{
+				a.exprToString(comp.IterRange),
+				a.exprToString(comp.LoopStep), // Add map transformation
+				a.exprToString(comp.Result),
+			},
 		})
 	}
 
 	return inspection
 }
 
-// exprToString converts an expression to a string representation
+// exprToString converts a CEL expression to its string representation.
+// This is used primarily for recording function arguments and creating readable output.
 func (a *Inspector) exprToString(expr *exprpb.Expr) string {
+	if expr == nil {
+		return "<nil>"
+	}
+
 	switch e := expr.ExprKind.(type) {
 	case *exprpb.Expr_ConstExpr:
-		// Handle constant expressions (literals)
-		switch kind := e.ConstExpr.ConstantKind.(type) {
-		case *exprpb.Constant_BoolValue:
-			return fmt.Sprintf("%v", kind.BoolValue)
-		case *exprpb.Constant_BytesValue:
-			return fmt.Sprintf("%v", kind.BytesValue)
-		case *exprpb.Constant_DoubleValue:
-			return fmt.Sprintf("%v", kind.DoubleValue)
-		case *exprpb.Constant_Int64Value:
-			return fmt.Sprintf("%v", kind.Int64Value)
-		case *exprpb.Constant_StringValue:
-			return kind.StringValue
-		case *exprpb.Constant_Uint64Value:
-			return fmt.Sprintf("%v", kind.Uint64Value)
-		case *exprpb.Constant_NullValue:
-			return "null"
-		default:
-			return "<unknown constant>"
-		}
+		return a.constantExpressionToString(e.ConstExpr)
+
 	case *exprpb.Expr_IdentExpr:
-		// Handle identifiers
 		return e.IdentExpr.Name
+
 	case *exprpb.Expr_SelectExpr:
-		// Handle field selection
 		return fmt.Sprintf("%s.%s", a.exprToString(e.SelectExpr.Operand), e.SelectExpr.Field)
+
 	case *exprpb.Expr_CallExpr:
-		// Handle function and method calls
-		args := make([]string, len(e.CallExpr.Args))
-		for i, arg := range e.CallExpr.Args {
-			args[i] = a.exprToString(arg)
-		}
-		if e.CallExpr.Target != nil {
-			// This is a method call
-			return fmt.Sprintf("%s.%s(%s)", a.exprToString(e.CallExpr.Target), e.CallExpr.Function, strings.Join(args, ", "))
-		}
-		// This is a function call
-		return fmt.Sprintf("%s(%s)", e.CallExpr.Function, strings.Join(args, ", "))
-	case *exprpb.Expr_ComprehensionExpr:
-		// Handle comprehensions (filters and maps)
-		if e.ComprehensionExpr.LoopStep == nil {
-			// This is a filter operation
-			return fmt.Sprintf("filter(%s, %s)", a.exprToString(e.ComprehensionExpr.IterRange), a.exprToString(e.ComprehensionExpr.Result))
-		}
-		// This is a map operation
-		return fmt.Sprintf("map(%s, %s)", a.exprToString(e.ComprehensionExpr.IterRange), a.exprToString(e.ComprehensionExpr.Result))
+		return a.callExpressionToString(e.CallExpr)
+
+	case *exprpb.Expr_ListExpr:
+		return a.listExpressionToString(e.ListExpr)
+
+	case *exprpb.Expr_StructExpr:
+		return a.structExpressionToString(e.StructExpr)
+
 	default:
-		return "<complex expression>"
+		return fmt.Sprintf("<unknown expression type: %T>", e)
 	}
+}
+
+// constantExpressionToString converts a constant expression to its string representation.
+func (a *Inspector) constantExpressionToString(c *exprpb.Constant) string {
+	switch kind := c.ConstantKind.(type) {
+	case *exprpb.Constant_BoolValue:
+		return fmt.Sprintf("%v", kind.BoolValue)
+	case *exprpb.Constant_BytesValue:
+		return fmt.Sprintf("b\"%s\"", kind.BytesValue)
+	case *exprpb.Constant_DoubleValue:
+		return fmt.Sprintf("%v", kind.DoubleValue)
+	case *exprpb.Constant_Int64Value:
+		return fmt.Sprintf("%v", kind.Int64Value)
+	case *exprpb.Constant_StringValue:
+		return fmt.Sprintf("%q", kind.StringValue)
+	case *exprpb.Constant_Uint64Value:
+		return fmt.Sprintf("%vu", kind.Uint64Value)
+	case *exprpb.Constant_NullValue:
+		return "null"
+	default:
+		return "<unknown constant>"
+	}
+}
+
+// callExpressionToString converts a function call expression to its string representation.
+// This includes both regular function calls and operator calls.
+func (a *Inspector) callExpressionToString(call *exprpb.Expr_Call) string {
+	args := make([]string, len(call.Args))
+	for i, arg := range call.Args {
+		args[i] = a.exprToString(arg)
+	}
+
+	// Handle special operators
+	if strings.HasPrefix(call.Function, "_") && strings.HasSuffix(call.Function, "_") {
+		switch call.Function {
+		case "_+_", "_-_", "_*_", "_/_", "_%_", "_<_", "_<=_", "_>_", "_>=_", "_==_", "_!=_":
+			if len(args) == 2 {
+				op := strings.Trim(call.Function, "_")
+				return fmt.Sprintf("(%s %s %s)", args[0], op, args[1])
+			}
+		case "_&&_":
+			if len(args) == 2 {
+				return fmt.Sprintf("(%s && %s)", args[0], args[1])
+			}
+		case "_||_":
+			if len(args) == 2 {
+				return fmt.Sprintf("(%s || %s)", args[0], args[1])
+			}
+		case "_?_:_":
+			if len(args) == 3 {
+				return fmt.Sprintf("(%s ? %s : %s)", args[0], args[1], args[2])
+			}
+		case "_[_]":
+			if len(args) == 2 {
+				return fmt.Sprintf("%s[%s]", args[0], args[1])
+			}
+		}
+	}
+
+	if call.Target != nil {
+		// Method call e.g bucket.metadata.labels.keys()
+		return fmt.Sprintf("%s.%s(%s)", a.exprToString(call.Target), call.Function, strings.Join(args, ", "))
+	}
+
+	// Regular function call
+	return fmt.Sprintf("%s(%s)", call.Function, strings.Join(args, ", "))
+}
+
+func (a *Inspector) listExpressionToString(list *exprpb.Expr_CreateList) string {
+	elements := make([]string, len(list.Elements))
+	for i, elem := range list.Elements {
+		elements[i] = a.exprToString(elem)
+	}
+	return fmt.Sprintf("[%s]", strings.Join(elements, ", "))
+}
+
+func (a *Inspector) structExpressionToString(s *exprpb.Expr_CreateStruct) string {
+	if s.MessageName != "" {
+		// Message construction
+		entries := make([]string, len(s.Entries))
+		for i, entry := range s.Entries {
+			if field := entry.GetFieldKey(); field != "" {
+				value := a.exprToString(entry.GetValue())
+				entries[i] = fmt.Sprintf("%s: %s", field, value)
+			}
+		}
+		return fmt.Sprintf("%s{%s}", s.MessageName, strings.Join(entries, ", "))
+	}
+
+	// Regular struct/map creation
+	entries := make([]string, len(s.Entries))
+	for i, entry := range s.Entries {
+		value := a.exprToString(entry.GetValue())
+		if field := entry.GetFieldKey(); field != "" {
+			entries[i] = fmt.Sprintf("%s: %s", field, value)
+		} else if key := entry.GetMapKey(); key != nil {
+			entries[i] = fmt.Sprintf("%s: %s", a.exprToString(key), value)
+		}
+	}
+	return fmt.Sprintf("{%s}", strings.Join(entries, ", "))
 }
 
 func isInternalIdentifier(name string) bool {
@@ -310,7 +518,23 @@ func isInternalFunction(name string) bool {
 		"size":    true,
 		"in":      true,
 		"matches": true,
-		// Add other internal functions as needed
+		// types
+		"int":       true,
+		"uint":      true,
+		"double":    true,
+		"bool":      true,
+		"string":    true,
+		"bytes":     true,
+		"timestamp": true,
+		"duration":  true,
+		"type":      true,
+
+		// Collection Functions
+		"filter":     true,
+		"map":        true,
+		"all":        true,
+		"exists":     true,
+		"exists_one": true,
 	}
 	return internalFunctions[name]
 }

--- a/internal/typesystem/celinspector/celinspector_test.go
+++ b/internal/typesystem/celinspector/celinspector_test.go
@@ -1,0 +1,528 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package celinspector
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestInspector_InspectionResults(t *testing.T) {
+	tests := []struct {
+		name          string
+		resources     []string
+		functions     []string
+		expression    string
+		wantResources []ResourceDependency
+		wantFunctions []FunctionCall
+	}{
+		{
+			name:       "simple eks cluster state check",
+			resources:  []string{"eksCluster"},
+			expression: `eksCluster.status.state == "ACTIVE"`,
+			wantResources: []ResourceDependency{
+				{Name: "eksCluster", Path: "eksCluster.status.state"},
+			},
+		},
+		{
+			name:       "simple bucket name check",
+			resources:  []string{"bucket"},
+			expression: `bucket.spec.name == "my-bucket" && bucket.metadata.name == bucket.spec.name`,
+			wantResources: []ResourceDependency{
+				{Name: "bucket", Path: "bucket.metadata.name"},
+				{Name: "bucket", Path: "bucket.spec.name"},
+				{Name: "bucket", Path: "bucket.spec.name"},
+			},
+		},
+
+		{
+			name:       "bucket name with function",
+			resources:  []string{"bucket"},
+			functions:  []string{"toLower"},
+			expression: `toLower(bucket.name)`,
+			wantResources: []ResourceDependency{
+				{Name: "bucket", Path: "bucket.name"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "toLower"},
+			},
+		},
+		{
+			name:       "deployment replicas with function",
+			resources:  []string{"deployment"},
+			functions:  []string{"max"},
+			expression: `max(deployment.spec.replicas, 5)`,
+			wantResources: []ResourceDependency{
+				{Name: "deployment", Path: "deployment.spec.replicas"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "max"},
+			},
+		},
+		{
+			name:       "OR and index operators simple",
+			resources:  []string{"list", "flags"},
+			functions:  []string{},
+			expression: `list[0] || flags["enabled"]`,
+			wantResources: []ResourceDependency{
+				{Name: "list", Path: "list"},
+				{Name: "flags", Path: "flags"},
+			},
+			wantFunctions: []FunctionCall{},
+		},
+		{
+			name:      "mixed constant types",
+			resources: []string{},
+			functions: []string{"process"},
+			expression: `process(
+				b"bytes123",         // BytesValue
+				3.14,               // DoubleValue
+				42u,                // Uint64Value
+				null               // NullValue
+			)`,
+			wantResources: nil,
+			wantFunctions: []FunctionCall{
+				{Name: "process"},
+			},
+		},
+		{
+			name:       "test operator string conversion",
+			resources:  []string{"list", "conditions"},
+			functions:  []string{"validate"},
+			expression: `validate(conditions.ready || conditions.initialized && list[3])`,
+			wantResources: []ResourceDependency{
+				{Name: "list", Path: "list"},
+				{Name: "conditions", Path: "conditions.ready"},
+				{Name: "conditions", Path: "conditions.initialized"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "validate", Arguments: []string{
+					"(conditions.ready || conditions.initialized) && list[3]",
+				}},
+			},
+		},
+		{
+			name:       "eks and nodegroup check",
+			resources:  []string{"eksCluster", "nodeGroup"},
+			expression: `eksCluster.spec.version == nodeGroup.spec.version`,
+			wantResources: []ResourceDependency{
+				{Name: "eksCluster", Path: "eksCluster.spec.version"},
+				{Name: "nodeGroup", Path: "nodeGroup.spec.version"},
+			},
+		},
+		{
+			name:       "deployment and cluster version",
+			resources:  []string{"deployment", "eksCluster"},
+			expression: `deployment.metadata.namespace == "default" && eksCluster.spec.version == "1.31"`,
+			wantResources: []ResourceDependency{
+				{Name: "deployment", Path: "deployment.metadata.namespace"},
+				{Name: "eksCluster", Path: "eksCluster.spec.version"},
+			},
+		},
+		{
+			name:       "eks name and bucket prefix",
+			resources:  []string{"eksCluster", "bucket"},
+			functions:  []string{"concat", "toLower"},
+			expression: `concat(toLower(eksCluster.spec.name), "-", bucket.spec.name)`,
+			wantResources: []ResourceDependency{
+				{Name: "eksCluster", Path: "eksCluster.spec.name"},
+				{Name: "bucket", Path: "bucket.spec.name"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "concat"},
+				{Name: "toLower"},
+			},
+		},
+		{
+			name:       "instances count",
+			resources:  []string{"instances"},
+			functions:  []string{"count"},
+			expression: `count(instances) > 0`,
+			wantResources: []ResourceDependency{
+				{Name: "instances", Path: "instances"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "count"},
+			},
+		},
+		{
+			name:      "complex expressions",
+			resources: []string{"fargateProfile", "eksCluster"},
+			functions: []string{"contains", "count"},
+			expression: `contains(fargateProfile.spec.subnets, "subnet-123") && 
+                count(fargateProfile.spec.selectors) <= 5 && 
+                eksCluster.status.state == "ACTIVE"`,
+			wantResources: []ResourceDependency{
+				{Name: "fargateProfile", Path: "fargateProfile.spec.subnets"},
+				{Name: "fargateProfile", Path: "fargateProfile.spec.selectors"},
+				{Name: "eksCluster", Path: "eksCluster.status.state"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "contains"},
+				{Name: "count"},
+			},
+		},
+		{
+			name:      "complex security group validation",
+			resources: []string{"securityGroup", "vpc"},
+			functions: []string{"concat", "contains", "map"},
+			expression: `securityGroup.spec.vpcID == vpc.status.vpcID && 
+                securityGroup.spec.rules.all(r, 
+                    contains(map(r.ipRanges, range, concat(range.cidr, "/", range.description)), 
+                        "0.0.0.0/0"))`,
+			wantResources: []ResourceDependency{
+				{Name: "securityGroup", Path: "securityGroup.spec.vpcID"},
+				{Name: "securityGroup", Path: "securityGroup.spec.rules"},
+				{Name: "vpc", Path: "vpc.status.vpcID"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "concat"},
+				{Name: "contains"},
+				{Name: "map"}, // first map is for rules
+				{Name: "map"}, // second map is for ipRanges
+			},
+		},
+		{
+			name:      "eks cluster validation",
+			resources: []string{"eksCluster", "nodeGroups", "iamRole", "vpc"},
+			functions: []string{"filter", "contains", "timeAgo"}, // duration and size are a built-in function
+			expression: `eksCluster.status.state == "ACTIVE" && 
+				duration(timeAgo(eksCluster.status.createdAt)) > duration("24h") && 
+				size(nodeGroups.filter(ng,
+					ng.status.state == "ACTIVE" &&
+					contains(ng.labels, "environment"))) >= 1 && 
+				contains(map(iamRole.policies, p, p.actions), "eks:*") && 
+				size(vpc.subnets.filter(s, s.isPrivate)) >= 2`,
+			wantResources: []ResourceDependency{
+				{Name: "eksCluster", Path: "eksCluster.status.state"},
+				{Name: "eksCluster", Path: "eksCluster.status.createdAt"},
+				{Name: "nodeGroups", Path: "nodeGroups"},
+				{Name: "iamRole", Path: "iamRole.policies"},
+				{Name: "vpc", Path: "vpc.subnets"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "contains"},
+				{Name: "contains"},
+				{Name: "map"},
+				{Name: "map"},
+				{Name: "timeAgo"},
+				// built-in functions don't appear in the function list
+			},
+		},
+		{
+			name:      "validate order and inventory",
+			resources: []string{"order", "product", "customer", "inventory"},
+			functions: []string{"validateAddress", "calculateTax"},
+			expression: `order.total > 0 && 
+				order.items.all(item,
+					product.id == item.productId && 
+					inventory.stock[item.productId] >= item.quantity
+				) &&
+				validateAddress(customer.shippingAddress) &&
+				calculateTax(order.total, customer.address.zipCode) > 0 || true`,
+			wantResources: []ResourceDependency{
+				{Name: "order", Path: "order.total"},
+				{Name: "order", Path: "order.total"},
+				{Name: "order", Path: "order.items"},
+				{Name: "product", Path: "product.id"},
+				{Name: "inventory", Path: "inventory.stock"},
+				{Name: "customer", Path: "customer.shippingAddress"},
+				{Name: "customer", Path: "customer.address.zipCode"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "validateAddress"},
+				{Name: "map"},
+				{Name: "calculateTax"},
+			},
+		},
+		{
+			name:       "filter with explicit condition",
+			resources:  []string{"pods"},
+			functions:  []string{},
+			expression: `pods.filter(p, p.status == "Running")`,
+			wantResources: []ResourceDependency{
+				{Name: "pods", Path: "pods"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "map"},
+			},
+		},
+		{
+			name:          "create message struct",
+			resources:     []string{},
+			functions:     []string{"createPod"},
+			expression:    `createPod(Pod{metadata: {name: "test", labels: {"app": "web"}}, spec: {containers: [{name: "main", image: "nginx"}]}})`,
+			wantResources: nil,
+			wantFunctions: []FunctionCall{
+				{Name: "createPod"},
+			},
+		},
+		{
+			name:      "create map with different key types",
+			resources: []string{},
+			functions: []string{"processMap"},
+			expression: `processMap({
+				"string-key": 123,
+				42: "number-key",
+				true: "bool-key"
+			})`,
+			wantResources: nil,
+			wantFunctions: []FunctionCall{
+				{Name: "processMap"},
+			},
+		},
+		{
+			name:      "message with nested structs",
+			resources: []string{},
+			functions: []string{"validate"},
+			expression: `validate(Container{
+				resource: Resource{cpu: "100m", memory: "256Mi"},
+				env: {
+					"DB_HOST": "localhost",
+					"DB_PORT": "5432"
+				}
+			})`,
+			wantResources: nil,
+			wantFunctions: []FunctionCall{
+				{Name: "validate"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inspector, err := NewInspector(tt.resources, tt.functions)
+			if err != nil {
+				t.Fatalf("Failed to create inspector: %v", err)
+			}
+
+			got, err := inspector.Inspect(tt.expression)
+			if err != nil {
+				t.Fatalf("Inspect() error = %v", err)
+			}
+
+			// Sort for stable comparison
+			sortDependencies := func(deps []ResourceDependency) {
+				sort.Slice(deps, func(i, j int) bool {
+					return deps[i].Path < deps[j].Path
+				})
+			}
+
+			sortFunctions := func(funcs []FunctionCall) {
+				sort.Slice(funcs, func(i, j int) bool {
+					return funcs[i].Name < funcs[j].Name
+				})
+			}
+
+			sortDependencies(got.ResourceDependencies)
+			sortDependencies(tt.wantResources)
+			sortFunctions(got.FunctionCalls)
+			sortFunctions(tt.wantFunctions)
+
+			if !reflect.DeepEqual(got.ResourceDependencies, tt.wantResources) {
+				t.Errorf("ResourceDependencies = %v, want %v", got.ResourceDependencies, tt.wantResources)
+			}
+
+			// Only check function names, not arguments
+			gotFuncNames := make([]string, len(got.FunctionCalls))
+			wantFuncNames := make([]string, len(tt.wantFunctions))
+			for i, f := range got.FunctionCalls {
+				gotFuncNames[i] = f.Name
+			}
+			for i, f := range tt.wantFunctions {
+				wantFuncNames[i] = f.Name
+			}
+			sort.Strings(gotFuncNames)
+			sort.Strings(wantFuncNames)
+
+			if !reflect.DeepEqual(gotFuncNames, wantFuncNames) {
+				t.Errorf("Function names = %v, want %v", gotFuncNames, wantFuncNames)
+			}
+		})
+	}
+}
+
+func TestInspector_UnknownResourcesAndCalls(t *testing.T) {
+	tests := []struct {
+		name           string
+		resources      []string
+		functions      []string
+		expression     string
+		wantResources  []ResourceDependency
+		wantFunctions  []FunctionCall
+		wantUnknownRes []UnknownResource
+	}{
+		{
+			name:          "method call on unknown resource",
+			resources:     []string{"list"},
+			expression:    `unknownResource.someMethod(42)`,
+			wantResources: nil,
+			wantFunctions: []FunctionCall{
+				{Name: "unknownResource.someMethod"},
+			},
+			wantUnknownRes: []UnknownResource{
+				{Name: "unknownResource", Path: "unknownResource"},
+			},
+		},
+		{
+			name:          "chained method calls on unknown resource",
+			resources:     []string{},
+			expression:    `unknown.method1().method2(123)`,
+			wantResources: nil,
+			wantFunctions: []FunctionCall{
+				{Name: "unknown.method1"},
+				{Name: "unknown.method1().method2"},
+			},
+			wantUnknownRes: []UnknownResource{
+				{Name: "unknown", Path: "unknown"},
+			},
+		},
+		{
+			name:      "filter with multiple conditions",
+			resources: []string{"instances"},
+			// note that `i` is not declared as a resource, but it's not an unknown resource
+			// either, it's a loop variable.
+			expression: `instances.filter(i,
+                i.state == 'running' && 
+                i.type == 't2.micro'
+            )`,
+			wantResources: []ResourceDependency{
+				{Name: "instances", Path: "instances"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "map"},
+			},
+		},
+		{
+			name:      "ambiguous i usage - both resource and loop var",
+			resources: []string{"instances", "i"}, // 'i' is a declared resource
+			expression: `i.status == "ready" && 
+				instances.filter(i,   // reusing 'i' in filter
+					i.state == 'running'
+				)`,
+			wantResources: []ResourceDependency{
+				{Name: "i", Path: "i.status"},
+				{Name: "instances", Path: "instances"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "map"},
+			},
+			wantUnknownRes: nil,
+		},
+		{
+			name:       "test target function chaining",
+			resources:  []string{"bucket"},
+			functions:  []string{"processItems", "validate"},
+			expression: `processItems(bucket).validate()`,
+			wantResources: []ResourceDependency{
+				{Name: "bucket", Path: "bucket"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "processItems"},
+				{Name: "processItems(bucket).validate"},
+			},
+		},
+		{
+			name:          "test unknown function with target",
+			resources:     []string{},
+			functions:     []string{},
+			expression:    `result.unknownFn().anotherUnknownFn()`,
+			wantResources: nil,
+			wantFunctions: []FunctionCall{
+				{Name: "result.unknownFn"},
+				{Name: "result.unknownFn().anotherUnknownFn"},
+			},
+			wantUnknownRes: []UnknownResource{
+				{Name: "result", Path: "result"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inspector, err := NewInspector(tt.resources, tt.functions)
+			if err != nil {
+				t.Fatalf("Failed to create inspector: %v", err)
+			}
+
+			got, err := inspector.Inspect(tt.expression)
+			if err != nil {
+				t.Fatalf("Inspect() error = %v", err)
+			}
+
+			// Sort for stable comparison
+			sortDependencies := func(deps []ResourceDependency) {
+				sort.Slice(deps, func(i, j int) bool {
+					return deps[i].Path < deps[j].Path
+				})
+			}
+
+			sortFunctions := func(funcs []FunctionCall) {
+				sort.Slice(funcs, func(i, j int) bool {
+					return funcs[i].Name < funcs[j].Name
+				})
+			}
+
+			sortUnknownResources := func(res []UnknownResource) {
+				sort.Slice(res, func(i, j int) bool {
+					return res[i].Path < res[j].Path
+				})
+			}
+
+			sortDependencies(got.ResourceDependencies)
+			sortDependencies(tt.wantResources)
+			sortFunctions(got.FunctionCalls)
+			sortFunctions(tt.wantFunctions)
+			sortUnknownResources(got.UnknownResources)
+			sortUnknownResources(tt.wantUnknownRes)
+
+			if !reflect.DeepEqual(got.ResourceDependencies, tt.wantResources) {
+				t.Errorf("ResourceDependencies = %v, want %v", got.ResourceDependencies, tt.wantResources)
+			}
+
+			// Only check function names, not arguments
+			gotFuncNames := make([]string, len(got.FunctionCalls))
+			wantFuncNames := make([]string, len(tt.wantFunctions))
+			for i, f := range got.FunctionCalls {
+				gotFuncNames[i] = f.Name
+			}
+			for i, f := range tt.wantFunctions {
+				wantFuncNames[i] = f.Name
+			}
+			sort.Strings(gotFuncNames)
+			sort.Strings(wantFuncNames)
+
+			if !reflect.DeepEqual(gotFuncNames, wantFuncNames) {
+				t.Errorf("Function names = %v, want %v", gotFuncNames, wantFuncNames)
+			}
+
+			if !reflect.DeepEqual(got.UnknownResources, tt.wantUnknownRes) {
+				t.Errorf("UnknownResources = %v, want %v", got.UnknownResources, tt.wantUnknownRes)
+			}
+		})
+	}
+}
+
+func Test_InvalidExpression(t *testing.T) {
+	_ = NewInspectorWithEnv(nil, []string{""}, []string{""})
+
+	inspector, err := NewInspector([]string{}, []string{})
+	if err != nil {
+		t.Fatalf("Failed to create inspector: %v", err)
+	}
+	_, err = inspector.Inspect("invalid expression ######")
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+}


### PR DESCRIPTION
Fix several edge cases in the CEL inspector around variable scoping and resource detection:

- Fix variable scope conflicts between top-level declarations and loop variables
  (e.g when 'i' is both a declared resource and used as a loop variable in filter)
- Add proper tracking of loop variables to avoid false positives in unknown resource detection
- Fix chain method calls on unknown resources to correctly track the dependency chain
- Handle ambiguous identifiers more robustly in nested scopes
- Add comprehensive test coverage for edge cases and variable conflicts

The changes make the inspector more reliable when dealing with complex expressions
that mix resource references with loop variables and method chains.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
