### PR TITLE
feat: add service account impersonation support for controllers

### DIFF
--- a/api/v1alpha1/resource_group.go
+++ b/api/v1alpha1/resource_group.go
@@ -18,6 +18,12 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	// DefaultServiceAccountKey is the key to use for the default service account
+	// in the serviceAccounts map.
+	DefaultServiceAccountKey = "*"
+)
+
 // ResourceGroupSpec defines the desired state of ResourceGroup
 type ResourceGroupSpec struct {
 	// The kind of the resourcegroup. This is used to generate
@@ -25,7 +31,6 @@ type ResourceGroupSpec struct {
 	//
 	// +kubebuilder:validation:Required
 	Kind string `json:"kind,omitempty"`
-
 	// The APIVersion of the resourcegroup. This is used to generate
 	// and create the CRD for the resourcegroup.
 	//
@@ -40,6 +45,13 @@ type ResourceGroupSpec struct {
 	//
 	// +kubebuilder:validation:Optional
 	Resources []*Resource `json:"resources,omitempty"`
+	// ServiceAccount configuration for controller impersonation.
+	// Key is the namespace, value is the service account name to use.
+	// Special key "*" defines the default service account for any
+	// namespace not explicitly mapped.
+	//
+	// +kubebuilder:validation:Optional
+	ServiceAccounts map[string]string `json:"serviceAccounts,omitempty"`
 }
 
 // Definition represents the attributes that define an instance of

--- a/internal/controller/instance/metrics.go
+++ b/internal/controller/instance/metrics.go
@@ -1,0 +1,69 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package instance
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	// MetricImpersonationTotal is the total number of impersonation requests
+	// made by the controller
+	MetricImpersonationTotal = "controller_impersonation_total"
+	// MetricImpersonationErrors is the total number of errors encountered
+	// while making impersonation requests
+	MetricImpersonationErrors = "controller_impersonation_errors_total"
+	// MetricImpersonationDuration tracks the duration of impersonation operations
+	MetricImpersonationDuration = "controller_impersonation_duration_seconds"
+)
+
+var (
+	impersonationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricImpersonationTotal,
+			Help: "Total number of service account impersonation attempts by namespace and result",
+		},
+		[]string{"namespace", "service_account", "result"},
+	)
+
+	impersonationErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricImpersonationErrors,
+			Help: "Total number of service account impersonation errors by category",
+		},
+		[]string{"namespace", "service_account", "error_type"},
+	)
+
+	impersonationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    MetricImpersonationDuration,
+			Help:    "Duration of service account impersonation operations",
+			Buckets: []float64{0.01, 0.1, 0.5, 1, 2, 5},
+		},
+		[]string{"namespace", "service_account"},
+	)
+)
+
+func recordImpersonateError(namespace, sa string, category errorCategory) {
+	impersonationErrors.WithLabelValues(namespace, sa, string(category)).Inc()
+}
+
+func init() {
+	metrics.Registry.MustRegister(
+		impersonationTotal,
+		impersonationErrors,
+		impersonationDuration,
+	)
+}

--- a/internal/controller/resourcegroup/controller_reconcile.go
+++ b/internal/controller/resourcegroup/controller_reconcile.go
@@ -67,6 +67,7 @@ func (r *ResourceGroupReconciler) reconcileResourceGroup(ctx context.Context, rg
 		gvr,
 		processedRG,
 		r.dynamicClient,
+		rg.Spec.ServiceAccounts,
 		graphExecLabeler,
 	)
 

--- a/internal/kubernetes/clients.go
+++ b/internal/kubernetes/clients.go
@@ -41,3 +41,25 @@ func NewClients() (*rest.Config, *kubernetes.Clientset, *dynamic.DynamicClient, 
 	}
 	return config, clientset, dynamicClient, apiExtensionsClient, nil
 }
+
+// NewDynamicClient creates a new dynamic client with optional service account
+// impersonation
+func NewDynamicClient(impersonateUser string) (*dynamic.DynamicClient, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if impersonateUser != "" {
+		config.Impersonate = rest.ImpersonationConfig{
+			UserName: impersonateUser,
+		}
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return dynamicClient, nil
+}

--- a/internal/kubernetes/clients_dev.go
+++ b/internal/kubernetes/clients_dev.go
@@ -58,3 +58,24 @@ func NewClients() (*rest.Config, *kubernetes.Clientset, dynamic.Interface, *apie
 	}
 	return config, clientset, dynamicClient, apiExtensionsClient, nil
 }
+
+// NewDynamicClient creates a new dynamic client with optional service account
+// impersonation
+func NewDynamicClient(impersonateUser string) (*dynamic.DynamicClient, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if impersonateUser != "" {
+		config.Impersonate = rest.ImpersonationConfig{
+			UserName: impersonateUser,
+		}
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return dynamicClient, nil
+}


### PR DESCRIPTION
Add support for per namespace service account impersonation in controllers.
This enables running controller operations with different service account
permissions based on namespace configuration.

Key changes:
- Add `ServiceAccounts` field to `ResourceGroupSpec` for mapping namespaces
  to service accounts
- Implement dynamic client creation with service account impersonation
- Add metrics for tracking impersonation `success`/`failures` and `latency`
- Support default service account fallback using `"*"` key


e.g usage:
```yaml
apiVersion: x.symphony.k8s.aws/v1alpha1
kind: ResourceGroup
metadata:
  name: deploymentservice.x.symphony.k8s.aws
spec:
  # NOTE: this is just an initial implementation, we'll probably
  # review and redesign this.
  serviceAccounts:
    production: prod-sa
    staging: staging-sa
    "*": fallback-sa
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
