### PR TITLE
Include Schema in runtime resource

### DIFF
--- a/internal/controller/instance/controller_reconcile.go
+++ b/internal/controller/instance/controller_reconcile.go
@@ -198,15 +198,10 @@ func (igr *instanceGraphReconciler) reconcileResource(ctx context.Context, resou
 	igr.runtime.SetResource(resourceID, observed)
 
 	log.V(1).Info("Checking if resource is Ready", "resource", resourceID)
-	if ready, err := igr.runtime.IsResourceReady(resourceID); err != nil {
-		log.V(1).Info("Resource not ready", "resource", resourceID)
+	if ready, reason, err := igr.runtime.IsResourceReady(resourceID); err != nil || !ready {
+		log.V(1).Info("Resource not ready", "resource", resourceID, "reason", reason, "error", err)
 		resourceState.State = "WaitingForReadiness"
 		resourceState.Err = fmt.Errorf("resource not ready: %w", err)
-		return igr.delayedRequeue(resourceState.Err)
-	} else if !ready {
-		log.V(1).Info("Resource not ready", "resource", resourceID)
-		resourceState.State = "WaitingForReadiness"
-		resourceState.Err = fmt.Errorf("resource not ready")
 		return igr.delayedRequeue(resourceState.Err)
 	}
 

--- a/internal/resourcegroup/graph/resource.go
+++ b/internal/resourcegroup/graph/resource.go
@@ -153,6 +153,7 @@ func (r *Resource) DeepCopy() *Resource {
 	return &Resource{
 		id:                 r.id,
 		gvr:                r.gvr,
+		schema:             r.schema,
 		originalObject:     r.originalObject.DeepCopy(),
 		variables:          slices.Clone(r.variables),
 		dependencies:       slices.Clone(r.dependencies),

--- a/internal/resourcegroup/runtime/runtime.go
+++ b/internal/resourcegroup/runtime/runtime.go
@@ -58,7 +58,7 @@ type Interface interface {
 	SetInstance(obj *unstructured.Unstructured)
 
 	// IsResourceReady returns true if the resource is ready, and false otherwise.
-	IsResourceReady(resourceID string) (bool, error)
+	IsResourceReady(resourceID string) (bool, string, error)
 }
 
 // ResourceDescriptor provides metadata about a resource.

--- a/internal/typesystem/variable/variable.go
+++ b/internal/typesystem/variable/variable.go
@@ -103,6 +103,17 @@ const (
 	//    spec:
 	//	    vpcID: ${vpc.status.vpcID}
 	ResourceVariableKindDynamic ResourceVariableKind = "dynamic"
+	// ResourceVariableKindReadyOn represents readyOn variables. ReadyOn variables
+	// are resolved at runtime. The difference between them, and the dynamic variables
+	// is that dynamic variable resolutions wait for other resources to provide a value
+	// while ReadyOn variables are created and wait for certain conditions before
+	// moving forward to the next resource to create
+	//
+	// For example:
+	//   name: cluster
+	//   readyOn:
+	//   - ${status.status == "Active"}
+	ResourceVariableKindReadyOn ResourceVariableKind = "readyOn"
 )
 
 // String returns the string representation of a ResourceVariableKind.


### PR DESCRIPTION
Description of changes:
The schema is necessary to get the top level fields of a resource,
which is necessary when running readyOn expressions. In the 
future we can store the top level fields and remove the schema if needed.

Also adding a new resource variable kind for readyOn expressions, 
to prevent the resolveDynamicVariables function from evaluating them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
