### PR TITLE
Safe faulty ResourceGroup cleanup

### DIFF
--- a/test/integration/environment/setup.go
+++ b/test/integration/environment/setup.go
@@ -80,7 +80,7 @@ func New(controllerConfig ControllerConfig) (*Environment, error) {
 			filepath.Join("../..", "crds", "ack-eks-controller"),
 		},
 		ErrorIfCRDPathMissing:   true,
-		ControlPlaneStopTimeout: 1 * time.Minute,
+		ControlPlaneStopTimeout: 2 * time.Minute,
 	}
 
 	// Start the test environment


### PR DESCRIPTION
Description of changes:
When the ResourceGroup graph is faulty, the cleanup tends to panic.
With this change, during cleanup, we avoid creating the entire 
resourceGroup, but we just retrieve the values we need to delete such 
as the GVR and the CRD name.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
