### PR TITLE
graph: enhance graph builder validation and add comprehensive tests

### DIFF
--- a/internal/graph/builder_test.go
+++ b/internal/graph/builder_test.go
@@ -1,0 +1,1228 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+
+	"github.com/awslabs/symphony/internal/graph/emulator"
+	"github.com/awslabs/symphony/internal/graph/variable"
+	"github.com/awslabs/symphony/internal/testutil/generator"
+	"github.com/awslabs/symphony/internal/testutil/k8s"
+)
+
+func TestGraphBuilder_Validation(t *testing.T) {
+	fakeResolver, fakeDiscovery := k8s.NewFakeResolver()
+	builder := &Builder{
+		schemaResolver:   fakeResolver,
+		discoveryClient:  fakeDiscovery,
+		resourceEmulator: emulator.NewEmulator(),
+	}
+
+	tests := []struct {
+		name              string
+		resourceGroupOpts []generator.ResourceGroupOption
+		wantErr           bool
+		errMsg            string
+	}{
+		{
+			name: "invalid resource type",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "unknown.k8s.aws/v1alpha1", // Unknown API group
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "schema not found",
+		},
+		{
+			name: "invalid resource name with operator",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("vpc-1", map[string]interface{}{ // Invalid name with operator
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "naming convention violation",
+		},
+		{
+			name: "resource without a valid GVK",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("vpc", map[string]interface{}{ // Invalid name with operator
+					"vvvvv": "ec2.services.k8s.aws/v1alpha1",
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "is not a valid Kubernetes object",
+		},
+		{
+			name: "invalid CEL syntax in readyOn",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+				}, []string{"invalid ! syntax"}, nil),
+			},
+			wantErr: true,
+			errMsg:  "failed to parse readyOn expressions",
+		},
+		{
+			name: "invalid CEL syntax in conditional",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+				}, nil, []string{"invalid ! syntax"}),
+			},
+			wantErr: true,
+			errMsg:  "failed to parse conditional expressions",
+		},
+		{
+			name: "missing required field",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					// Missing metadata
+					"spec": map[string]interface{}{
+						"cidrBlocks": []interface{}{"10.0.0.0/16"},
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "metadata field not found",
+		},
+		{
+			name: "invalid field reference",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("subnet", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "Subnet",
+					"metadata": map[string]interface{}{
+						"name": "test-subnet",
+					},
+					"spec": map[string]interface{}{
+						"vpcID": "${vpc.status.nonexistentField}", // Invalid field
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "failed to validate resource CEL expression",
+		},
+		{
+			name: "valid VPC with valid conditional subnets",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name":          "string",
+						"enableSubnets": "boolean",
+					},
+					nil,
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks":         []interface{}{"10.0.0.0/16"},
+						"enableDNSSupport":   true,
+						"enableDNSHostnames": true,
+					},
+				}, []string{"${status.state == 'available'}"}, nil),
+				generator.WithResource("subnet1", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "Subnet",
+					"metadata": map[string]interface{}{
+						"name": "test-subnet",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlock": "10.0.1.0/24",
+						"vpcID":     "${vpc.status.vpcID}",
+					},
+				}, []string{"${status.state == 'available'}"}, []string{"${spec.enableSubnets == true}"}),
+				generator.WithResource("subnet2", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "Subnet",
+					"metadata": map[string]interface{}{
+						"name": "test-subnet-2",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlock": "10.0.127.0/24",
+						"vpcID":     "${vpc.status.vpcID}",
+					},
+				}, []string{"${status.state == 'available'}"}, []string{"${spec.enableSubnets}"})},
+			wantErr: false,
+		},
+		{
+			name: "invalid resource type",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "unknown.k8s.aws/v1alpha1", // Unknown API group
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "schema not found",
+		},
+		{
+			name: "invalid instance spec field type",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"port": "wrongtype",
+					},
+					nil,
+				),
+			},
+			wantErr: true,
+			errMsg:  "failed to build OpenAPI schema for instance",
+		},
+		{
+			name: "invalid instance status field reference",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					map[string]interface{}{
+						"status": "${nonexistent.status}", // invalid reference
+					},
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "undeclared reference to 'nonexistent'",
+		},
+		{
+			name: "invalid field type in resource spec",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks": "10.0.0.0/16", // should be array
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "expected string type or AdditionalProperties for path spec.cidrBlocks",
+		},
+		{
+			name: "crds aren't allowed to have variables in their spec fields",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("somecrd", map[string]interface{}{
+					"apiVersion": "apiextensions.k8s.io/v1",
+					"kind":       "CustomResourceDefinition",
+					"metadata": map[string]interface{}{
+						"name": "vpcs.ec2.services.k8s.aws",
+					},
+					"spec": map[string]interface{}{
+						"group":   "ec2.services.k8s.aws",
+						"version": "v1alpha1",
+						"names": map[string]interface{}{
+							"kind":     "VPC",
+							"listKind": "VPCList",
+							"singular": "vpc",
+							"plural":   "vpcs",
+						},
+						"scope": "Namespaced-${spec.name}",
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "CEL expressions are not supported for CRDs",
+		},
+		{
+			name: "valid instance definition with complex types",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name":     "string",
+						"port":     "integer | default=80",
+						"tags":     "map[string]string",
+						"replicas": "integer | default=3",
+					},
+					map[string]interface{}{
+						"state": "${vpc.status.state}",
+						"id":    "${vpc.status.vpcID}",
+					},
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks": []interface{}{"10.0.0.0/16"},
+					},
+				}, nil, nil),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rg := generator.NewResourceGroup("test-group", tt.resourceGroupOpts...)
+			_, err := builder.NewResourceGroup(rg)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGraphBuilder_DependencyValidation(t *testing.T) {
+	fakeResolver, fakeDiscovery := k8s.NewFakeResolver()
+	builder := &Builder{
+		schemaResolver:   fakeResolver,
+		discoveryClient:  fakeDiscovery,
+		resourceEmulator: emulator.NewEmulator(),
+	}
+
+	tests := []struct {
+		name              string
+		resourceGroupOpts []generator.ResourceGroupOption
+		wantErr           bool
+		errMsg            string
+		validateDeps      func(*testing.T, *Graph)
+	}{
+		{
+			name: "complex eks setup dependencies",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				// First layer: Base resources with no dependencies
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "testvpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks": []interface{}{"10.0.0.0/16"},
+					},
+				}, nil, nil),
+				generator.WithResource("clusterpolicy", map[string]interface{}{
+					"apiVersion": "iam.services.k8s.aws/v1alpha1",
+					"kind":       "Policy",
+					"metadata": map[string]interface{}{
+						"name": "clusterpolicy",
+					},
+					"spec": map[string]interface{}{
+						"name":     "testclusterpolicy",
+						"document": "{}",
+					},
+				}, nil, nil),
+				// Second layer: Resources depending on first layer
+				generator.WithResource("clusterrole", map[string]interface{}{
+					"apiVersion": "iam.services.k8s.aws/v1alpha1",
+					"kind":       "Role",
+					"metadata": map[string]interface{}{
+						"name": "clusterrole",
+					},
+					"spec": map[string]interface{}{
+						"name":                     "${clusterpolicy.status.policyID}role",
+						"assumeRolePolicyDocument": "{}",
+					},
+				}, nil, nil),
+				generator.WithResource("subnet1", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "Subnet",
+					"metadata": map[string]interface{}{
+						"name": "subnet1",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlock": "10.0.1.0/24",
+						"vpcID":     "${vpc.status.vpcID}",
+					},
+				}, nil, nil),
+				generator.WithResource("subnet2", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "Subnet",
+					"metadata": map[string]interface{}{
+						"name": "subnet2",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlock": "10.0.2.0/24",
+						"vpcID":     "${vpc.status.vpcID}",
+					},
+				}, nil, nil),
+				// Third layer: EKS Cluster depending on roles and subnets
+				generator.WithResource("cluster", map[string]interface{}{
+					"apiVersion": "eks.services.k8s.aws/v1alpha1",
+					"kind":       "Cluster",
+					"metadata": map[string]interface{}{
+						"name": "cluster",
+					},
+					"spec": map[string]interface{}{
+						"name":    "testcluster",
+						"roleARN": "${clusterrole.status.roleID}",
+						"resourcesVPCConfig": map[string]interface{}{
+							"subnetIDs": []interface{}{
+								"${subnet1.status.subnetID}",
+								"${subnet2.status.subnetID}",
+							},
+						},
+					},
+				}, nil, nil)},
+			validateDeps: func(t *testing.T, g *Graph) {
+				// Validate dependencies
+				assert.Empty(t, g.Resources["vpc"].GetDependencies())
+				assert.Empty(t, g.Resources["clusterpolicy"].GetDependencies())
+
+				assert.Equal(t, []string{"vpc"}, g.Resources["subnet1"].GetDependencies())
+				assert.Equal(t, []string{"vpc"}, g.Resources["subnet2"].GetDependencies())
+				assert.Equal(t, []string{"clusterpolicy"}, g.Resources["clusterrole"].GetDependencies())
+
+				clusterDeps := g.Resources["cluster"].GetDependencies()
+				assert.Len(t, clusterDeps, 3)
+				assert.Contains(t, clusterDeps, "clusterrole")
+				assert.Contains(t, clusterDeps, "subnet1")
+				assert.Contains(t, clusterDeps, "subnet2")
+
+				// Validate topological order
+				assert.Equal(t, []string{"clusterpolicy", "clusterrole", "vpc", "subnet1", "subnet2", "cluster"}, g.TopologicalOrder)
+			},
+		},
+		{
+			name: "missing dependency",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("subnet", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "Subnet",
+					"metadata": map[string]interface{}{
+						"name": "subnet",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlock": "10.0.0.0/24",
+						"vpcID":     "${missingvpc.status.vpcID}",
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "undeclared reference to 'missingvpc'",
+		},
+		{
+			name: "cyclic dependency",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("role1", map[string]interface{}{
+					"apiVersion": "iam.services.k8s.aws/v1alpha1",
+					"kind":       "Role",
+					"metadata": map[string]interface{}{
+						"name": "${role2.metadata.name}1",
+					},
+					"spec": map[string]interface{}{
+						"name":                     "testrole1",
+						"assumeRolePolicyDocument": "{}",
+					},
+				}, nil, nil),
+				generator.WithResource("role2", map[string]interface{}{
+					"apiVersion": "iam.services.k8s.aws/v1alpha1",
+					"kind":       "Role",
+					"metadata": map[string]interface{}{
+						"name": "${role1.metadata.name}2",
+					},
+					"spec": map[string]interface{}{
+						"name":                     "testrole2",
+						"assumeRolePolicyDocument": "{}",
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "This would create a cycle",
+		},
+		{
+			name: "independent pods",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("pod1", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "pod1",
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "nginx1",
+								"image": "nginx:latest",
+							},
+						},
+					},
+				}, nil, nil),
+				generator.WithResource("pod2", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "pod2",
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "nginx2",
+								"image": "nginx:latest",
+							},
+						},
+					},
+				}, nil, nil),
+				generator.WithResource("pod3", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "pod3",
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "nginx3",
+								"image": "nginx:latest",
+							},
+						},
+					},
+				}, nil, nil),
+				generator.WithResource("pod4", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "pod4",
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "nginx4",
+								"image": "nginx:latest",
+							},
+						},
+					},
+				}, nil, nil),
+			},
+			validateDeps: func(t *testing.T, g *Graph) {
+				assert.Len(t, g.Resources, 4)
+				assert.Empty(t, g.Resources["pod1"].GetDependencies())
+				assert.Empty(t, g.Resources["pod2"].GetDependencies())
+				assert.Empty(t, g.Resources["pod3"].GetDependencies())
+				assert.Empty(t, g.Resources["pod4"].GetDependencies())
+				// Order doesn't matter as they're all independent
+				assert.Len(t, g.TopologicalOrder, 4)
+			},
+		},
+		{
+			name: "cyclic pod dependencies",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("pod1", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "${pod4.status.podIP}app1",
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "nginx1",
+								"image": "nginx:latest",
+							},
+						},
+					},
+				}, nil, nil),
+				generator.WithResource("pod2", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "${pod1.status.podIP}app2",
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "nginx2",
+								"image": "nginx:latest",
+							},
+						},
+					},
+				}, nil, nil),
+				generator.WithResource("pod3", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "${pod2.status.podIP}app3",
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "nginx3",
+								"image": "nginx:latest",
+							},
+						},
+					},
+				}, nil, nil),
+				generator.WithResource("pod4", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "${pod3.status.podIP}app4",
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "nginx4",
+								"image": "nginx:latest",
+							},
+						},
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "This would create a cycle",
+		},
+		{
+			name: "shared infrastructure dependencies",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				// Base infrastructure
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "vpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks": []interface{}{"10.0.0.0/16"},
+					},
+				}, nil, nil),
+				generator.WithResource("subnet1", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "Subnet",
+					"metadata": map[string]interface{}{
+						"name": "subnet1",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlock": "10.0.1.0/24",
+						"vpcID":     "${vpc.status.vpcID}",
+					},
+				}, nil, nil),
+				generator.WithResource("subnet2", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "Subnet",
+					"metadata": map[string]interface{}{
+						"name": "subnet2",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlock": "10.0.2.0/24",
+						"vpcID":     "${vpc.status.vpcID}",
+					},
+				}, nil, nil),
+				generator.WithResource("subnet3", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "Subnet",
+					"metadata": map[string]interface{}{
+						"name": "subnet3",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlock": "10.0.3.0/24",
+						"vpcID":     "${vpc.status.vpcID}",
+					},
+				}, nil, nil),
+				generator.WithResource("secgroup", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "SecurityGroup",
+					"metadata": map[string]interface{}{
+						"name": "secgroup",
+					},
+					"spec": map[string]interface{}{
+						"vpcID": "${vpc.status.vpcID}",
+					},
+				}, nil, nil),
+				generator.WithResource("policy", map[string]interface{}{
+					"apiVersion": "iam.services.k8s.aws/v1alpha1",
+					"kind":       "Policy",
+					"metadata": map[string]interface{}{
+						"name": "policy",
+					},
+					"spec": map[string]interface{}{
+						"document": "{}",
+					},
+				}, nil, nil),
+				generator.WithResource("role", map[string]interface{}{
+					"apiVersion": "iam.services.k8s.aws/v1alpha1",
+					"kind":       "Role",
+					"metadata": map[string]interface{}{
+						"name": "role",
+					},
+					"spec": map[string]interface{}{
+						"name":                     "${policy.status.policyID}role",
+						"assumeRolePolicyDocument": "{}",
+					},
+				}, nil, nil),
+				// Three clusters using the same infrastructure
+				generator.WithResource("cluster1", map[string]interface{}{
+					"apiVersion": "eks.services.k8s.aws/v1alpha1",
+					"kind":       "Cluster",
+					"metadata": map[string]interface{}{
+						"name": "cluster1",
+					},
+					"spec": map[string]interface{}{
+						"roleARN": "${role.status.roleID}",
+						"resourcesVPCConfig": map[string]interface{}{
+							"subnetIDs": []interface{}{
+								"${subnet1.status.subnetID}",
+								"${subnet2.status.subnetID}",
+								"${subnet3.status.subnetID}",
+							},
+						},
+					},
+				}, nil, nil),
+				generator.WithResource("cluster2", map[string]interface{}{
+					"apiVersion": "eks.services.k8s.aws/v1alpha1",
+					"kind":       "Cluster",
+					"metadata": map[string]interface{}{
+						"name": "cluster2",
+					},
+					"spec": map[string]interface{}{
+						"roleARN": "${role.status.roleID}",
+						"resourcesVPCConfig": map[string]interface{}{
+							"subnetIDs": []interface{}{
+								"${subnet1.status.subnetID}",
+								"${subnet2.status.subnetID}",
+								"${subnet3.status.subnetID}",
+							},
+						},
+					},
+				}, nil, nil),
+				generator.WithResource("cluster3", map[string]interface{}{
+					"apiVersion": "eks.services.k8s.aws/v1alpha1",
+					"kind":       "Cluster",
+					"metadata": map[string]interface{}{
+						"name": "cluster3",
+					},
+					"spec": map[string]interface{}{
+						"roleARN": "${role.status.roleID}",
+						"resourcesVPCConfig": map[string]interface{}{
+							"subnetIDs": []interface{}{
+								"${subnet1.status.subnetID}",
+								"${subnet2.status.subnetID}",
+								"${subnet3.status.subnetID}",
+							},
+						},
+					},
+				}, nil, nil),
+				// Pod depending on all clusters
+				generator.WithResource("monitor", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "monitor",
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "monitor",
+								"image": "monitor:latest",
+								"env": []interface{}{
+									map[string]interface{}{
+										"name":  "CLUSTER1_ARN",
+										"value": "${cluster1.status.ackResourceMetadata.arn}",
+									},
+									map[string]interface{}{
+										"name":  "CLUSTER2_ARN",
+										"value": "${cluster2.status.ackResourceMetadata.arn}",
+									},
+									map[string]interface{}{
+										"name":  "CLUSTER3_ARN",
+										"value": "${cluster3.status.ackResourceMetadata.arn}",
+									},
+								},
+							},
+						},
+					},
+				}, nil, nil),
+			},
+			validateDeps: func(t *testing.T, g *Graph) {
+				// Base infrastructure dependencies
+				assert.Empty(t, g.Resources["vpc"].GetDependencies())
+				assert.Empty(t, g.Resources["policy"].GetDependencies())
+
+				assert.Equal(t, []string{"vpc"}, g.Resources["subnet1"].GetDependencies())
+				assert.Equal(t, []string{"vpc"}, g.Resources["subnet2"].GetDependencies())
+				assert.Equal(t, []string{"vpc"}, g.Resources["subnet3"].GetDependencies())
+				assert.Equal(t, []string{"vpc"}, g.Resources["secgroup"].GetDependencies())
+				assert.Equal(t, []string{"policy"}, g.Resources["role"].GetDependencies())
+
+				// Cluster dependencies
+				clusterDeps := []string{"role", "subnet1", "subnet2", "subnet3"}
+				assert.ElementsMatch(t, clusterDeps, g.Resources["cluster1"].GetDependencies())
+				assert.ElementsMatch(t, clusterDeps, g.Resources["cluster2"].GetDependencies())
+				assert.ElementsMatch(t, clusterDeps, g.Resources["cluster3"].GetDependencies())
+
+				// Monitor pod dependencies
+				monitorDeps := []string{"cluster1", "cluster2", "cluster3"}
+				assert.ElementsMatch(t, monitorDeps, g.Resources["monitor"].GetDependencies())
+
+				// Validate topological order
+				assert.Equal(t, []string{
+					"policy",
+					"role",
+					"vpc",
+					"subnet1",
+					"subnet2",
+					"subnet3",
+					"cluster1",
+					"cluster2",
+					"cluster3",
+					"monitor",
+					"secgroup",
+				}, g.TopologicalOrder)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rg := generator.NewResourceGroup("testgroup", tt.resourceGroupOpts...)
+			g, err := builder.NewResourceGroup(rg)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.validateDeps != nil {
+				tt.validateDeps(t, g)
+			}
+		})
+	}
+}
+
+func TestGraphBuilder_ExpressionParsing(t *testing.T) {
+	fakeResolver, fakeDiscovery := k8s.NewFakeResolver()
+	builder := &Builder{
+		schemaResolver:   fakeResolver,
+		discoveryClient:  fakeDiscovery,
+		resourceEmulator: emulator.NewEmulator(),
+	}
+
+	tests := []struct {
+		name              string
+		resourceGroupOpts []generator.ResourceGroupOption
+		validateVars      func(*testing.T, *Graph)
+	}{
+		{
+			name: "complex resource variable parsing",
+			resourceGroupOpts: []generator.ResourceGroupOption{
+				generator.WithKind("Test", "v1alpha1"),
+				generator.WithDefinition(
+					map[string]interface{}{
+						"replicas":         "integer | default=3",
+						"environment":      "string | default=dev",
+						"createMonitoring": "boolean | default=false",
+					},
+					nil,
+				),
+				// Resource with no expressions
+				generator.WithResource("policy", map[string]interface{}{
+					"apiVersion": "iam.services.k8s.aws/v1alpha1",
+					"kind":       "Policy",
+					"metadata": map[string]interface{}{
+						"name": "policy",
+					},
+					"spec": map[string]interface{}{
+						"document": "{}",
+					},
+				}, nil, nil),
+				// Resource with only readyOn expressions
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "vpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks": []interface{}{"10.0.0.0/16"},
+					},
+				}, []string{
+					"${status.state == 'available'}",
+					"${status.vpcID != ''}",
+				}, nil),
+				// Resource with mix of static and dynamic expressions
+				generator.WithResource("subnet", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "Subnet",
+					"metadata": map[string]interface{}{
+						"name": "subnet",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlock": "10.0.1.0/24",
+						"vpcID":     "${vpc.status.vpcID}",
+						"tags": []interface{}{
+							map[string]interface{}{
+								"key":   "Environment",
+								"value": "${spec.environment}",
+							},
+						},
+					},
+				}, []string{"${status.state == 'available'}"}, nil),
+				// Non-standalone expressions
+				generator.WithResource("cluster", map[string]interface{}{
+					"apiVersion": "eks.services.k8s.aws/v1alpha1",
+					"kind":       "Cluster",
+					"metadata": map[string]interface{}{
+						"name": "${vpc.metadata.name}cluster${spec.environment}",
+					},
+					"spec": map[string]interface{}{
+						"name": "testcluster",
+						"resourcesVPCConfig": map[string]interface{}{
+							"subnetIDs": []interface{}{
+								"${subnet.status.subnetID}",
+							},
+						},
+					},
+				}, []string{
+					"${status.status == 'ACTIVE'}",
+				}, []string{
+					"${spec.createMonitoring}",
+				}),
+				// All the above combined
+				generator.WithResource("monitor", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "monitor",
+						"labels": map[string]interface{}{
+							"environment":  "${spec.environment}",
+							"cluster":      "${cluster.metadata.name}",
+							"combined":     "${cluster.metadata.name}-${spec.environment}",
+							"two.statics":  "${spec.environment}-static-${spec.replicas}",
+							"two.dynamics": "${vpc.metadata.name}-${cluster.status.ackResourceMetadata.arn}",
+						},
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "monitor",
+								"image": "monitor:latest",
+								"env": []interface{}{
+									map[string]interface{}{
+										"name":  "CLUSTER_ARN",
+										"value": "${cluster.status.ackResourceMetadata.arn}",
+									},
+									map[string]interface{}{
+										"name":  "REPLICAS",
+										"value": "${spec.replicas}",
+									},
+								},
+							},
+						},
+					},
+				}, []string{
+					"${status.phase == 'Running'}",
+				}, []string{
+					"${spec.createMonitoring == true}",
+				}),
+			},
+			validateVars: func(t *testing.T, g *Graph) {
+				// Verify resource with no expressions
+				policy := g.Resources["policy"]
+				assert.Empty(t, policy.variables)
+				assert.Empty(t, policy.GetReadyOnExpressions())
+				assert.Empty(t, policy.GetConditionExpressions())
+
+				// Verify resource with only readyOn
+				vpc := g.Resources["vpc"]
+				assert.Empty(t, vpc.variables)
+				assert.Equal(t, []string{
+					"status.state == 'available'",
+					"status.vpcID != ''",
+				}, vpc.GetReadyOnExpressions())
+				assert.Empty(t, vpc.GetConditionExpressions())
+
+				// Verify resource with mixed expressions
+				subnet := g.Resources["subnet"]
+				assert.Len(t, subnet.variables, 2)
+				// Create expected variables to match against
+				validateVariables(t, subnet.variables, []expectedVar{
+					{
+						path:                 "spec.vpcID",
+						expressions:          []string{"vpc.status.vpcID"},
+						kind:                 variable.ResourceVariableKindDynamic,
+						standaloneExpression: true,
+					},
+					{
+						path:                 "spec.tags[0].value",
+						expressions:          []string{"spec.environment"},
+						kind:                 variable.ResourceVariableKindStatic,
+						standaloneExpression: true,
+					},
+				})
+
+				// Verify resource with multiple expressions in one field
+				cluster := g.Resources["cluster"]
+				assert.Len(t, cluster.variables, 2)
+				validateVariables(t, cluster.variables, []expectedVar{
+					{
+						path:                 "metadata.name",
+						expressions:          []string{"vpc.metadata.name", "spec.environment"},
+						kind:                 variable.ResourceVariableKindDynamic,
+						standaloneExpression: false,
+					},
+					{
+						path:                 "spec.resourcesVPCConfig.subnetIDs[0]",
+						expressions:          []string{"subnet.status.subnetID"},
+						kind:                 variable.ResourceVariableKindDynamic,
+						standaloneExpression: true,
+					},
+				})
+				assert.Equal(t, []string{"spec.createMonitoring"}, cluster.GetConditionExpressions())
+
+				// Verify monitor pod with all types of expressions
+				monitor := g.Resources["monitor"]
+				assert.Len(t, monitor.variables, 7)
+				validateVariables(t, monitor.variables, []expectedVar{
+					{
+						path:                 "metadata.labels.environment",
+						expressions:          []string{"spec.environment"},
+						kind:                 variable.ResourceVariableKindStatic,
+						standaloneExpression: true,
+					},
+					{
+						path:                 "metadata.labels.cluster",
+						expressions:          []string{"cluster.metadata.name"},
+						kind:                 variable.ResourceVariableKindDynamic,
+						standaloneExpression: true,
+					},
+					{
+						path:                 "metadata.labels.combined",
+						expressions:          []string{"cluster.metadata.name", "spec.environment"},
+						kind:                 variable.ResourceVariableKindDynamic,
+						standaloneExpression: false,
+					},
+					{
+						path:                 "metadata.labels[\"two.statics\"]",
+						expressions:          []string{"spec.environment", "spec.replicas"},
+						kind:                 variable.ResourceVariableKindStatic,
+						standaloneExpression: false,
+					},
+					{
+						path:                 "metadata.labels[\"two.dynamics\"]",
+						expressions:          []string{"vpc.metadata.name", "cluster.status.ackResourceMetadata.arn"},
+						kind:                 variable.ResourceVariableKindDynamic,
+						standaloneExpression: false,
+					},
+					{
+						path:                 "spec.containers[0].env[0].value",
+						expressions:          []string{"cluster.status.ackResourceMetadata.arn"},
+						kind:                 variable.ResourceVariableKindDynamic,
+						standaloneExpression: true,
+					},
+					{
+						path:                 "spec.containers[0].env[1].value",
+						expressions:          []string{"spec.replicas"},
+						kind:                 variable.ResourceVariableKindStatic,
+						standaloneExpression: true,
+					},
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rg := generator.NewResourceGroup("testgroup", tt.resourceGroupOpts...)
+			g, err := builder.NewResourceGroup(rg)
+			require.NoError(t, err)
+			if tt.validateVars != nil {
+				tt.validateVars(t, g)
+			}
+		})
+	}
+}
+
+type expectedVar struct {
+	path                 string
+	expressions          []string
+	kind                 variable.ResourceVariableKind
+	standaloneExpression bool
+}
+
+func validateVariables(t *testing.T, actual []*variable.ResourceField, expected []expectedVar) {
+	assert.Equal(t, len(expected), len(actual), "variable count mismatch")
+
+	actualVars := make([]expectedVar, len(actual))
+	for i, v := range actual {
+		v.ExpectedSchema = nil
+		actualVars[i] = expectedVar{
+			path:                 v.Path,
+			expressions:          v.Expressions,
+			kind:                 v.Kind,
+			standaloneExpression: v.StandaloneExpression,
+		}
+	}
+
+	assert.ElementsMatch(t, expected, actualVars)
+}
+
+func TestNewBuilder(t *testing.T) {
+	builder, err := NewBuilder(&rest.Config{})
+	assert.Nil(t, err)
+	assert.NotNil(t, builder)
+}

--- a/internal/graph/parser/conditions.go
+++ b/internal/graph/parser/conditions.go
@@ -35,7 +35,7 @@ func ParseConditionExpressions(conditions []string) ([]string, error) {
 			return nil, err
 		}
 		if !ok {
-			return nil, fmt.Errorf("single expression per line allowed")
+			return nil, fmt.Errorf("only standalone expressions are allowed")
 		}
 		expressions = append(expressions, strings.Trim(e, "${}"))
 	}

--- a/internal/graph/parser/conditions_test.go
+++ b/internal/graph/parser/conditions_test.go
@@ -26,17 +26,17 @@ func TestParseReadyOn(t *testing.T) {
 		{
 			name:          "Two expressions",
 			expression:    []string{"${hello}${goodbye}"},
-			expectedError: "single expression per line allowed",
+			expectedError: "only standalone expressions are allowed",
 		},
 		{
 			name:          "With Postfix",
 			expression:    []string{"${hello}-world"},
-			expectedError: "single expression per line allowed",
+			expectedError: "only standalone expressions are allowed",
 		},
 		{
 			name:          "With Prefix",
 			expression:    []string{"hello-${world}"},
-			expectedError: "single expression per line allowed",
+			expectedError: "only standalone expressions are allowed",
 		},
 		{
 			name:          "Standalone expression",

--- a/internal/graph/parser/parser.go
+++ b/internal/graph/parser/parser.go
@@ -142,7 +142,7 @@ func parseString(field string, schema *spec.Schema, path, expectedType string) (
 	}
 
 	if expectedType != "string" && expectedType != "any" {
-		return nil, fmt.Errorf("expected string type or AdditionalProperties allowed for path %s, got %v", path, field)
+		return nil, fmt.Errorf("expected string type or AdditionalProperties for path %s, got %v", path, field)
 	}
 
 	expressions, err := extractExpressions(field)

--- a/internal/graph/parser/parser_test.go
+++ b/internal/graph/parser/parser_test.go
@@ -545,7 +545,7 @@ func TestParserEdgeCases(t *testing.T) {
 				},
 			},
 			resource:      "true",
-			expectedError: "expected string type or AdditionalProperties allowed for path , got true",
+			expectedError: "expected string type or AdditionalProperties for path , got true",
 		},
 		{
 			name: "Type mismatch integer/float",

--- a/internal/graph/resource_test.go
+++ b/internal/graph/resource_test.go
@@ -1,0 +1,73 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResource_Dependencies(t *testing.T) {
+	tests := []struct {
+		name         string
+		dependencies []string
+		checkDep     string
+		hasDep       bool
+		addDeps      []string
+		finalDeps    []string
+	}{
+		{
+			name:         "empty dependencies",
+			dependencies: []string{},
+			checkDep:     "test",
+			hasDep:       false,
+			addDeps:      []string{"test1", "test2"},
+			finalDeps:    []string{"test1", "test2"},
+		},
+		{
+			name:         "existing dependency",
+			dependencies: []string{"test1", "test2"},
+			checkDep:     "test1",
+			hasDep:       true,
+			addDeps:      []string{"test3", "test1"}, // test1 is duplicate
+			finalDeps:    []string{"test1", "test2", "test3"},
+		},
+		{
+			name:         "multiple additions",
+			dependencies: []string{"test1"},
+			checkDep:     "test3",
+			hasDep:       false,
+			addDeps:      []string{"test2", "test3", "test4"},
+			finalDeps:    []string{"test1", "test2", "test3", "test4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Resource{
+				dependencies: tt.dependencies,
+			}
+
+			// Test HasDependency
+			assert.Equal(t, tt.hasDep, r.HasDependency(tt.checkDep))
+
+			// Test AddDependencies
+			r.addDependencies(tt.addDeps...)
+
+			// Verify final dependencies
+			assert.ElementsMatch(t, tt.finalDeps, r.GetDependencies())
+		})
+	}
+}

--- a/internal/testutil/k8s/discovery.go
+++ b/internal/testutil/k8s/discovery.go
@@ -1,0 +1,680 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package k8s
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/testing"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// FakeResolver implements resolver.SchemaResolver for testing
+type FakeResolver struct {
+	schemas map[schema.GroupVersionKind]*spec.Schema
+}
+
+// ResolveSchema implements resolver.SchemaResolver
+func (f *FakeResolver) ResolveSchema(gvk schema.GroupVersionKind) (*spec.Schema, error) {
+	if schema, ok := f.schemas[gvk]; ok {
+		return schema, nil
+	}
+	return nil, fmt.Errorf("schema not found for GVK: %v", gvk)
+}
+
+// AddSchema adds a new schema to the resolver
+func (f *FakeResolver) AddSchema(gvk schema.GroupVersionKind, schema *spec.Schema) {
+	f.schemas[gvk] = schema
+}
+
+// Helper to create ACK common status schema
+func ackStatusSchema() map[string]spec.Schema {
+	return map[string]spec.Schema{
+		"ackResourceMetadata": {
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"arn":            {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"ownerAccountID": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"region":         {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+				},
+			},
+		},
+		"conditions": {
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"array"},
+				Items: &spec.SchemaOrArray{
+					Schema: &spec.Schema{
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"lastTransitionTime": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"status":             {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"type":               {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func NewFakeResolver() (*FakeResolver, *fake.FakeDiscovery) {
+	schemas := map[schema.GroupVersionKind]*spec.Schema{
+		// ACK EC2 resources
+		{Group: "ec2.services.k8s.aws", Version: "v1alpha1", Kind: "VPC"}: {
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"metadata":   metadataSchema(),
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"cidrBlocks":         {SchemaProps: spec.SchemaProps{Type: []string{"array"}, Items: &spec.SchemaOrArray{Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}}}}}},
+								"enableDNSHostnames": {SchemaProps: spec.SchemaProps{Type: []string{"boolean"}}},
+								"enableDNSSupport":   {SchemaProps: spec.SchemaProps{Type: []string{"boolean"}}},
+								"tags":               awsTagsSchema(),
+							},
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: mergeSchemas(ackStatusSchema(), map[string]spec.Schema{
+								"vpcID": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"state": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+							}),
+						},
+					},
+				},
+			},
+		},
+		{Group: "ec2.services.k8s.aws", Version: "v1alpha1", Kind: "Subnet"}: {
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"metadata":   metadataSchema(),
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"cidrBlock": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"vpcID":     {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"tags":      awsTagsSchema(),
+							},
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: mergeSchemas(ackStatusSchema(), map[string]spec.Schema{
+								"subnetID": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"state":    {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+							}),
+						},
+					},
+				},
+			},
+		},
+		{Group: "ec2.services.k8s.aws", Version: "v1alpha1", Kind: "SecurityGroup"}: {
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"metadata":   metadataSchema(),
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"vpcID":       {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"description": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"tags":        awsTagsSchema(),
+							},
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: mergeSchemas(ackStatusSchema(), map[string]spec.Schema{
+								"id":    {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"state": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+							}),
+						},
+					},
+				},
+			},
+		},
+		// ACK EKS resources
+		{Group: "eks.services.k8s.aws", Version: "v1alpha1", Kind: "Cluster"}: {
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"metadata":   metadataSchema(),
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"name":    {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"roleARN": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"version": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"accessConfig": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"object"},
+										Properties: map[string]spec.Schema{
+											"authenticationMode": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+										},
+									},
+								},
+								"resourcesVPCConfig": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"object"},
+										Properties: map[string]spec.Schema{
+											"endpointPrivateAccess": {SchemaProps: spec.SchemaProps{Type: []string{"boolean"}}},
+											"endpointPublicAccess":  {SchemaProps: spec.SchemaProps{Type: []string{"boolean"}}},
+											"subnetIDs": {
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: mergeSchemas(ackStatusSchema(), map[string]spec.Schema{
+								"status": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+							}),
+						},
+					},
+				},
+			},
+		},
+		{Group: "eks.services.k8s.aws", Version: "v1alpha1", Kind: "Nodegroup"}: {
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"metadata":   metadataSchema(),
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"name":           {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"clusterName":    {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"nodeRole":       {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"version":        {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"releaseVersion": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"subnets": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"array"},
+										Items: &spec.SchemaOrArray{
+											Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+										},
+									},
+								},
+								"scalingConfig": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"object"},
+										Properties: map[string]spec.Schema{
+											"minSize":     {SchemaProps: spec.SchemaProps{Type: []string{"integer"}}},
+											"maxSize":     {SchemaProps: spec.SchemaProps{Type: []string{"integer"}}},
+											"desiredSize": {SchemaProps: spec.SchemaProps{Type: []string{"integer"}}},
+										},
+									},
+								},
+							},
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: mergeSchemas(ackStatusSchema(), map[string]spec.Schema{
+								"status": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+							}),
+						},
+					},
+				},
+			},
+		},
+		// iam services
+		{Group: "iam.services.k8s.aws", Version: "v1alpha1", Kind: "Policy"}: {
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"metadata":   metadataSchema(),
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"name":     {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"document": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"tags":     awsTagsSchema(),
+							},
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: mergeSchemas(ackStatusSchema(), map[string]spec.Schema{
+								"policyID": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+							}),
+						},
+					},
+				},
+			},
+		},
+		{Group: "iam.services.k8s.aws", Version: "v1alpha1", Kind: "Role"}: {
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"metadata":   metadataSchema(),
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"name":                     {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"assumeRolePolicyDocument": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"tags":                     awsTagsSchema(),
+							},
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: mergeSchemas(ackStatusSchema(), map[string]spec.Schema{
+								"roleID": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+							}),
+						},
+					},
+				},
+			},
+		},
+		// v1 resources
+		{Version: "v1", Kind: "Pod"}: {
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"metadata":   metadataSchema(),
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"nodeName": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"containers": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"array"},
+										Items: &spec.SchemaOrArray{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"object"},
+													Properties: map[string]spec.Schema{
+														"name":  {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+														"image": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+														"env": {
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"array"},
+																Items: &spec.SchemaOrArray{
+																	Schema: &spec.Schema{
+																		SchemaProps: spec.SchemaProps{
+																			Type: []string{"object"},
+																			Properties: map[string]spec.Schema{
+																				"name":  {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+																				"value": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"phase":  {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"hostIP": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"podIP":  {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+							},
+						},
+					},
+				},
+			},
+		},
+		// CRDs
+		{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}: {
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"metadata":   metadataSchema(),
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"group":   {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"version": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+								"names": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"object"},
+										Properties: map[string]spec.Schema{
+											"kind":     {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+											"listKind": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+											"singular": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+											"plural":   {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+										},
+									},
+								},
+								"scope": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeDiscovery := &fake.FakeDiscovery{Fake: &testing.Fake{}}
+
+	fakeDiscovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "ec2.services.k8s.aws/v1alpha1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:       "vpcs",
+					Namespaced: true,
+					Kind:       "VPC",
+					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+				{
+					Name:       "subnets",
+					Namespaced: true,
+					Kind:       "Subnet",
+					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+				{
+					Name:       "securitygroups",
+					Namespaced: true,
+					Kind:       "SecurityGroup",
+					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+			},
+		},
+		{
+			GroupVersion: "iam.services.k8s.aws/v1alpha1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:       "policies",
+					Namespaced: true,
+					Kind:       "Policy",
+					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+				{
+					Name:       "roles",
+					Namespaced: true,
+					Kind:       "Role",
+					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+			},
+		},
+		{
+			GroupVersion: "eks.services.k8s.aws/v1alpha1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:       "clusters",
+					Namespaced: true,
+					Kind:       "Cluster",
+					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+				{
+					Name:       "nodegroups",
+					Namespaced: true,
+					Kind:       "Nodegroup",
+					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+			},
+		},
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:       "pods",
+					Namespaced: true,
+					Kind:       "Pod",
+					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+			},
+		},
+		// CRD
+		{
+			GroupVersion: "apiextensions.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:       "customresourcedefinitions",
+					Namespaced: false,
+					Kind:       "CustomResourceDefinition",
+					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+			},
+		},
+	}
+
+	return &FakeResolver{schemas: schemas}, fakeDiscovery
+}
+
+// Helper to create AWS tags schema
+func awsTagsSchema() spec.Schema {
+	return spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: []string{"array"},
+			Items: &spec.SchemaOrArray{
+				Schema: &spec.Schema{
+					SchemaProps: spec.SchemaProps{
+						Type: []string{"object"},
+						Properties: map[string]spec.Schema{
+							"key":   {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+							"value": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Helper to create common metadata schema that matches Kubernetes ObjectMeta
+func metadataSchema() spec.Schema {
+	return spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: []string{"object"},
+			Properties: map[string]spec.Schema{
+				"name": {
+					SchemaProps: spec.SchemaProps{
+						Type: []string{"string"},
+					},
+				},
+				"namespace": {
+					SchemaProps: spec.SchemaProps{
+						Type: []string{"string"},
+					},
+				},
+				"labels": {
+					SchemaProps: spec.SchemaProps{
+						Type: []string{"object"},
+						AdditionalProperties: &spec.SchemaOrBool{
+							Allows: true,
+							Schema: &spec.Schema{
+								SchemaProps: spec.SchemaProps{
+									Type: []string{"string"},
+								},
+							},
+						},
+					},
+				},
+				"annotations": {
+					SchemaProps: spec.SchemaProps{
+						Type: []string{"object"},
+						AdditionalProperties: &spec.SchemaOrBool{
+							Allows: true,
+							Schema: &spec.Schema{
+								SchemaProps: spec.SchemaProps{
+									Type: []string{"string"},
+								},
+							},
+						},
+					},
+				},
+				"generateName": {
+					SchemaProps: spec.SchemaProps{
+						Type: []string{"string"},
+					},
+				},
+				"uid": {
+					SchemaProps: spec.SchemaProps{
+						Type: []string{"string"},
+					},
+				},
+				"resourceVersion": {
+					SchemaProps: spec.SchemaProps{
+						Type: []string{"string"},
+					},
+				},
+				"generation": {
+					SchemaProps: spec.SchemaProps{
+						Type: []string{"integer"},
+					},
+				},
+				"creationTimestamp": {
+					SchemaProps: spec.SchemaProps{
+						Type:   []string{"string"},
+						Format: "date-time",
+					},
+				},
+				"deletionTimestamp": {
+					SchemaProps: spec.SchemaProps{
+						Type:   []string{"string"},
+						Format: "date-time",
+					},
+				},
+				"deletionGracePeriodSeconds": {
+					SchemaProps: spec.SchemaProps{
+						Type: []string{"integer"},
+					},
+				},
+				"finalizers": {
+					SchemaProps: spec.SchemaProps{
+						Type: []string{"array"},
+						Items: &spec.SchemaOrArray{
+							Schema: &spec.Schema{
+								SchemaProps: spec.SchemaProps{
+									Type: []string{"string"},
+								},
+							},
+						},
+					},
+				},
+				"ownerReferences": {
+					SchemaProps: spec.SchemaProps{
+						Type: []string{"array"},
+						Items: &spec.SchemaOrArray{
+							Schema: &spec.Schema{
+								SchemaProps: spec.SchemaProps{
+									Type: []string{"object"},
+									Properties: map[string]spec.Schema{
+										"apiVersion": {
+											SchemaProps: spec.SchemaProps{
+												Type: []string{"string"},
+											},
+										},
+										"kind": {
+											SchemaProps: spec.SchemaProps{
+												Type: []string{"string"},
+											},
+										},
+										"name": {
+											SchemaProps: spec.SchemaProps{
+												Type: []string{"string"},
+											},
+										},
+										"uid": {
+											SchemaProps: spec.SchemaProps{
+												Type: []string{"string"},
+											},
+										},
+										"controller": {
+											SchemaProps: spec.SchemaProps{
+												Type: []string{"boolean"},
+											},
+										},
+										"blockOwnerDeletion": {
+											SchemaProps: spec.SchemaProps{
+												Type: []string{"boolean"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Helper to merge two schema maps
+func mergeSchemas(a, b map[string]spec.Schema) map[string]spec.Schema {
+	merged := make(map[string]spec.Schema)
+	for k, v := range a {
+		merged[k] = v
+	}
+	for k, v := range b {
+		merged[k] = v
+	}
+	return merged
+}


### PR DESCRIPTION
- Fix variable type determination in dependency graph building
- Switch `discoveryClient` to use an interface instead of concrete ptr type
- Fix condition expression parsing and error messages
- Add extensive test coverage for graph validation, dependencies and expressions
- Add "fake resolver" and discovery client for testing infrastructure
- Improve error handling for resource validation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
