### PR TITLE
Change static variable starting field to `schema`

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -17,7 +17,6 @@
 package v1alpha1
 
 import (
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )

--- a/examples/ack-controller/ec2-controller/ec2-controller.yaml
+++ b/examples/ack-controller/ec2-controller/ec2-controller.yaml
@@ -42,20 +42,20 @@ spec:
       apiVersion: kro.run/v1alpha1
       kind: EC2CRDGroup
       metadata:
-        name: ${spec.name}-crd-group
+        name: ${schema.spec.name}-crd-group
       spec:
-        name: ${spec.name}-crd-group
+        name: ${schema.spec.name}-crd-group
   - name: ec2ControllerIamRole
     template:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Role
       metadata:
-        name: ${spec.name}-iam-role
-        namespace: ${spec.namespace}
+        name: ${schema.spec.name}-iam-role
+        namespace: ${schema.spec.namespace}
       spec:
-        name: ${spec.name}-iam-role
-        description: ${spec.values.iamRole.roleDescription}
-        maxSessionDuration: ${spec.values.iamRole.maxSessionDuration}
+        name: ${schema.spec.name}-iam-role
+        description: ${schema.spec.values.iamRole.roleDescription}
+        maxSessionDuration: ${schema.spec.values.iamRole.maxSessionDuration}
         policies:
         - arn:aws:iam::aws:policy/AmazonEC2FullAccess
         assumeRolePolicyDocument: >
@@ -63,10 +63,10 @@ spec:
             "Version": "2012-10-17",
             "Statement": [{
               "Effect": "Allow",
-              "Principal": {"Federated": "arn:aws:iam::${spec.values.aws.accountID}:oidc-provider/${spec.values.iamRole.oidcProvider}"},
+              "Principal": {"Federated": "arn:aws:iam::${schema.spec.values.aws.accountID}:oidc-provider/${schema.spec.values.iamRole.oidcProvider}"},
               "Action": "sts:AssumeRoleWithWebIdentity",
               "Condition": {
-                  "StringEquals": {"${spec.values.iamRole.oidcProvider}:sub": "system:serviceaccount:${spec.namespace}:${spec.values.serviceAccount.name}"}
+                  "StringEquals": {"${schema.spec.values.iamRole.oidcProvider}:sub": "system:serviceaccount:${schema.spec.namespace}:${schema.spec.values.serviceAccount.name}"}
               }
             }]
           }
@@ -75,8 +75,8 @@ spec:
       apiVersion: v1
       kind: ServiceAccount
       metadata:
-        name: ${spec.values.serviceAccount.name}
-        namespace: ${spec.namespace}
+        name: ${schema.spec.values.serviceAccount.name}
+        namespace: ${schema.spec.namespace}
         annotations:
           eks.amazonaws.com/role-arn: ${ec2ControllerIamRole.status.ackResourceMetadata.arn}
   - name: deployment
@@ -84,22 +84,22 @@ spec:
       apiVersion: apps/v1
       kind: Deployment
       metadata:
-        name: ${spec.name}-deployment
-        namespace: ${spec.namespace}
+        name: ${schema.spec.name}-deployment
+        namespace: ${schema.spec.namespace}
         labels:
-          app.kubernetes.io.name: ${spec.name}-deployment
-          app.kubernetes.io.instance: ${spec.name}
+          app.kubernetes.io.name: ${schema.spec.name}-deployment
+          app.kubernetes.io.instance: ${schema.spec.name}
       spec:
-        replicas: ${spec.values.deployment.replicas}
+        replicas: ${schema.spec.values.deployment.replicas}
         selector:
           matchLabels:
-            app.kubernetes.io.name: ${spec.name}-deployment
-            app.kubernetes.io.instance: ${spec.name}
+            app.kubernetes.io.name: ${schema.spec.name}-deployment
+            app.kubernetes.io.instance: ${schema.spec.name}
         template:
           metadata:
             labels:
-              app.kubernetes.io.name: ${spec.name}-deployment
-              app.kubernetes.io.instance: ${spec.name}
+              app.kubernetes.io.name: ${schema.spec.name}-deployment
+              app.kubernetes.io.instance: ${schema.spec.name}
           spec:
             serviceAccountName: ${serviceAccount.metadata.name}
             containers:
@@ -107,35 +107,35 @@ spec:
               - ./bin/controller
               args:
               - --aws-region
-              - ${spec.values.aws.region}
-              - --enable-development-logging=${spec.values.log.enabled}
+              - ${schema.spec.values.aws.region}
+              - --enable-development-logging=${schema.spec.values.log.enabled}
               - --log-level
-              - ${spec.values.log.level}
+              - ${schema.spec.values.log.level}
               - --deletion-policy
-              - ${spec.values.image.deletePolicy}
+              - ${schema.spec.values.image.deletePolicy}
               - --watch-namespace
-              - ${spec.namespace}
-              image: ${spec.values.image.repository}:${spec.values.image.tag}
+              - ${schema.spec.namespace}
+              image: ${schema.spec.values.image.repository}:${schema.spec.values.image.tag}
               name: controller
               ports:
                 - name: http
-                  containerPort: ${spec.values.deployment.containerPort}
+                  containerPort: ${schema.spec.values.deployment.containerPort}
               resources:
                 requests:
-                  memory: ${spec.values.image.resources.requests.memory}
-                  cpu: ${spec.values.image.resources.requests.cpu}
+                  memory: ${schema.spec.values.image.resources.requests.memory}
+                  cpu: ${schema.spec.values.image.resources.requests.cpu}
                 limits:
-                    memory: ${spec.values.image.resources.limits.memory}
-                    cpu: ${spec.values.image.resources.limits.cpu}
+                    memory: ${schema.spec.values.image.resources.limits.memory}
+                    cpu: ${schema.spec.values.image.resources.limits.cpu}
               env:
               - name: ACK_SYSTEM_NAMESPACE
-                value: ${spec.namespace}
+                value: ${schema.spec.namespace}
               - name: AWS_REGION
-                value: ${spec.values.aws.region}
+                value: ${schema.spec.values.aws.region}
               - name: DELETE_POLICY
-                value: ${spec.values.image.deletePolicy}
+                value: ${schema.spec.values.image.deletePolicy}
               - name: ACK_LOG_LEVEL
-                value: ${spec.values.log.level}              
+                value: ${schema.spec.values.log.level}              
               ports:
               - containerPort: 80
   - name: clusterRoleBinding
@@ -143,7 +143,7 @@ spec:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: ${spec.name}-clusterrolebinding
+        name: ${schema.spec.name}-clusterrolebinding
       roleRef:
         kind: ClusterRole
         apiGroup: rbac.authorization.k8s.io
@@ -157,7 +157,7 @@ spec:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: ${spec.name}-clusterrole
+        name: ${schema.spec.name}-clusterrole
       rules:
       - apiGroups:
         - ""

--- a/examples/ack-controller/eks-controller/eks-controller.yaml
+++ b/examples/ack-controller/eks-controller/eks-controller.yaml
@@ -45,18 +45,18 @@ spec:
       apiVersion: kro.run/v1alpha1
       kind: EKSCRDGroup
       metadata:
-        name: ${spec.name}-crd-group
+        name: ${schema.spec.name}-crd-group
       spec:
-        name: ${spec.name}-crd-group
+        name: ${schema.spec.name}-crd-group
   - name: eksControllerIamPolicy
     template:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Policy
       metadata:
-        name: ${spec.name}-iam-policy
+        name: ${schema.spec.name}-iam-policy
       spec:
-        name: ${spec.name}-iam-policy
-        description: ${spec.values.iamPolicy.description}
+        name: ${schema.spec.name}-iam-policy
+        description: ${schema.spec.values.iamPolicy.description}
         policyDocument: >
           {
             "Version": "2012-10-17",
@@ -80,12 +80,12 @@ spec:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Role
       metadata:
-        name: ${spec.name}-iam-role
-        namespace: ${spec.namespace}
+        name: ${schema.spec.name}-iam-role
+        namespace: ${schema.spec.namespace}
       spec:
-        name: ${spec.name}-iam-role
-        description: ${spec.values.iamRole.roleDescription}
-        maxSessionDuration: ${spec.values.iamRole.maxSessionDuration}
+        name: ${schema.spec.name}-iam-role
+        description: ${schema.spec.values.iamRole.roleDescription}
+        maxSessionDuration: ${schema.spec.values.iamRole.maxSessionDuration}
         policies:
         - ${eksControllerIamPolicy.status.ackResourceMetadata.arn}
         assumeRolePolicyDocument: >
@@ -93,10 +93,10 @@ spec:
             "Version":"2012-10-17",
             "Statement": [{
               "Effect":"Allow",
-              "Principal": {"Federated": "arn:aws:iam::${spec.values.aws.accountID}:oidc-provider/${spec.values.iamRole.oidcProvider}"},
+              "Principal": {"Federated": "arn:aws:iam::${schema.spec.values.aws.accountID}:oidc-provider/${schema.spec.values.iamRole.oidcProvider}"},
               "Action": ["sts:AssumeRoleWithWebIdentity"],
               "Condition": {
-                "StringEquals": {"${spec.values.iamRole.oidcProvider}:sub": "system:serviceaccount:${spec.namespace}:${spec.values.serviceAccount.name}"}
+                "StringEquals": {"${schema.spec.values.iamRole.oidcProvider}:sub": "system:serviceaccount:${schema.spec.namespace}:${schema.spec.values.serviceAccount.name}"}
               }
             }]
           }
@@ -105,8 +105,8 @@ spec:
       apiVersion: v1
       kind: ServiceAccount
       metadata:
-        name: ${spec.values.serviceAccount.name}
-        namespace: ${spec.namespace}
+        name: ${schema.spec.values.serviceAccount.name}
+        namespace: ${schema.spec.namespace}
         annotations:
           eks.amazonaws.com/role-arn : ${eksControllerIamRole.status.ackResourceMetadata.arn}
   - name: deployment
@@ -114,22 +114,22 @@ spec:
       apiVersion: apps/v1
       kind: Deployment
       metadata:
-        name: ${spec.name}-deployment
-        namespace: ${spec.namespace}
+        name: ${schema.spec.name}-deployment
+        namespace: ${schema.spec.namespace}
         labels:
-          app.kubernetes.io.name: ${spec.name}-deployment
-          app.kubernetes.io.instance: ${spec.name}
+          app.kubernetes.io.name: ${schema.spec.name}-deployment
+          app.kubernetes.io.instance: ${schema.spec.name}
       spec:
-        replicas: ${spec.values.deployment.replicas}
+        replicas: ${schema.spec.values.deployment.replicas}
         selector:
           matchLabels:
-            app.kubernetes.io.name: ${spec.name}-deployment
-            app.kubernetes.io.instance: ${spec.name}
+            app.kubernetes.io.name: ${schema.spec.name}-deployment
+            app.kubernetes.io.instance: ${schema.spec.name}
         template:
           metadata:
             labels:
-              app.kubernetes.io.name: ${spec.name}-deployment
-              app.kubernetes.io.instance: ${spec.name}
+              app.kubernetes.io.name: ${schema.spec.name}-deployment
+              app.kubernetes.io.instance: ${schema.spec.name}
           spec:
             serviceAccountName: ${serviceAccount.metadata.name}
             containers:
@@ -137,35 +137,35 @@ spec:
               - ./bin/controller
               args:
               - --aws-region
-              - ${spec.values.aws.region}
-              - --enable-development-logging=${spec.values.log.enabled}
+              - ${schema.spec.values.aws.region}
+              - --enable-development-logging=${schema.spec.values.log.enabled}
               - --log-level
-              - ${spec.values.log.level}
+              - ${schema.spec.values.log.level}
               - --deletion-policy
-              - ${spec.values.image.deletePolicy}
+              - ${schema.spec.values.image.deletePolicy}
               - --watch-namespace
-              - ${spec.namespace}
-              image: ${spec.values.image.repository}:${spec.values.image.tag}
+              - ${schema.spec.namespace}
+              image: ${schema.spec.values.image.repository}:${schema.spec.values.image.tag}
               name: controller
               ports:
                 - name: http
-                  containerPort: ${spec.values.deployment.containerPort}
+                  containerPort: ${schema.spec.values.deployment.containerPort}
               resources:
                 requests:
-                  memory: ${spec.values.image.resources.requests.memory}
-                  cpu: ${spec.values.image.resources.requests.cpu}
+                  memory: ${schema.spec.values.image.resources.requests.memory}
+                  cpu: ${schema.spec.values.image.resources.requests.cpu}
                 limits:
-                    memory: ${spec.values.image.resources.limits.memory}
-                    cpu: ${spec.values.image.resources.limits.cpu}
+                    memory: ${schema.spec.values.image.resources.limits.memory}
+                    cpu: ${schema.spec.values.image.resources.limits.cpu}
               env:
               - name: ACK_SYSTEM_NAMESPACE
-                value: ${spec.namespace}
+                value: ${schema.spec.namespace}
               - name: AWS_REGION
-                value: ${spec.values.aws.region}
+                value: ${schema.spec.values.aws.region}
               - name: DELETE_POLICY
-                value: ${spec.values.image.deletePolicy}
+                value: ${schema.spec.values.image.deletePolicy}
               - name: ACK_LOG_LEVEL
-                value: ${spec.values.log.level}              
+                value: ${schema.spec.values.log.level}              
               ports:
               - containerPort: 80
   - name: clusterRoleBinding
@@ -173,7 +173,7 @@ spec:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: ${spec.name}-clusterrolebinding
+        name: ${schema.spec.name}-clusterrolebinding
       roleRef:
         kind: ClusterRole
         apiGroup: rbac.authorization.k8s.io
@@ -187,7 +187,7 @@ spec:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: ${spec.name}-clusterrole
+        name: ${schema.spec.name}-clusterrole
       rules:
       - apiGroups:
         - ""

--- a/examples/ack-controller/iam-controller/iam-controller.yaml
+++ b/examples/ack-controller/iam-controller/iam-controller.yaml
@@ -38,39 +38,39 @@ spec:
       apiVersion: kro.run/v1alpha1
       kind: IAMCRDGroup
       metadata:
-        name: ${spec.name}-crd-group
+        name: ${schema.spec.name}-crd-group
       spec:
-        name: ${spec.name}-crd-group
+        name: ${schema.spec.name}-crd-group
   - name: serviceAccount
     template:
       apiVersion: v1
       kind: ServiceAccount
       metadata:
-        name: ${spec.values.serviceAccount.name}
-        namespace: ${spec.namespace}
+        name: ${schema.spec.values.serviceAccount.name}
+        namespace: ${schema.spec.namespace}
         annotations:
-          eks.amazonaws.com/role-arn: ${spec.values.serviceAccount.roleArn}
+          eks.amazonaws.com/role-arn: ${schema.spec.values.serviceAccount.roleArn}
   - name: deployment
     template:
       apiVersion: apps/v1
       kind: Deployment
       metadata:
-        name: ${spec.name}-deployment
-        namespace: ${spec.namespace}
+        name: ${schema.spec.name}-deployment
+        namespace: ${schema.spec.namespace}
         labels:
-          app.kubernetes.io.name: ${spec.name}-deployment
-          app.kubernetes.io.instance: ${spec.name}
+          app.kubernetes.io.name: ${schema.spec.name}-deployment
+          app.kubernetes.io.instance: ${schema.spec.name}
       spec:
-        replicas: ${spec.values.deployment.replicas}
+        replicas: ${schema.spec.values.deployment.replicas}
         selector:
           matchLabels:
-            app.kubernetes.io.name: ${spec.name}-deployment
-            app.kubernetes.io.instance: ${spec.name}
+            app.kubernetes.io.name: ${schema.spec.name}-deployment
+            app.kubernetes.io.instance: ${schema.spec.name}
         template:
           metadata:
             labels:
-              app.kubernetes.io.name: ${spec.name}-deployment
-              app.kubernetes.io.instance: ${spec.name}
+              app.kubernetes.io.name: ${schema.spec.name}-deployment
+              app.kubernetes.io.instance: ${schema.spec.name}
           spec:
             serviceAccountName: ${serviceAccount.metadata.name}
             containers:
@@ -78,35 +78,35 @@ spec:
               - ./bin/controller
               args:
               - --aws-region
-              - ${spec.values.aws.region}
-              - --enable-development-logging=${spec.values.log.enabled}
+              - ${schema.spec.values.aws.region}
+              - --enable-development-logging=${schema.spec.values.log.enabled}
               - --log-level
-              - ${spec.values.log.level}
+              - ${schema.spec.values.log.level}
               - --deletion-policy
-              - ${spec.values.image.deletePolicy}
+              - ${schema.spec.values.image.deletePolicy}
               - --watch-namespace
-              - ${spec.namespace}
-              image: ${spec.values.image.repository}:${spec.values.image.tag}
+              - ${schema.spec.namespace}
+              image: ${schema.spec.values.image.repository}:${schema.spec.values.image.tag}
               name: controller
               ports:
                 - name: http
-                  containerPort: ${spec.values.deployment.containerPort}
+                  containerPort: ${schema.spec.values.deployment.containerPort}
               resources:
                 requests:
-                  memory: ${spec.values.image.resources.requests.memory}
-                  cpu: ${spec.values.image.resources.requests.cpu}
+                  memory: ${schema.spec.values.image.resources.requests.memory}
+                  cpu: ${schema.spec.values.image.resources.requests.cpu}
                 limits:
-                    memory: ${spec.values.image.resources.limits.memory}
-                    cpu: ${spec.values.image.resources.limits.cpu}
+                    memory: ${schema.spec.values.image.resources.limits.memory}
+                    cpu: ${schema.spec.values.image.resources.limits.cpu}
               env:
               - name: ACK_SYSTEM_NAMESPACE
-                value: ${spec.namespace}
+                value: ${schema.spec.namespace}
               - name: AWS_REGION
-                value: ${spec.values.aws.region}
+                value: ${schema.spec.values.aws.region}
               - name: DELETE_POLICY
-                value: ${spec.values.image.deletePolicy}
+                value: ${schema.spec.values.image.deletePolicy}
               - name: ACK_LOG_LEVEL
-                value: ${spec.values.log.level}              
+                value: ${schema.spec.values.log.level}              
               ports:
               - containerPort: 80
   - name: clusterRoleBinding
@@ -114,7 +114,7 @@ spec:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: ${spec.name}-clusterrolebinding
+        name: ${schema.spec.name}-clusterrolebinding
       roleRef:
         kind: ClusterRole
         apiGroup: rbac.authorization.k8s.io
@@ -128,7 +128,7 @@ spec:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: ${spec.name}-clusterrole
+        name: ${schema.spec.name}-clusterrole
       rules:
       - apiGroups:
         - ""

--- a/examples/ack-eks-cluster/eks-cluster.yaml
+++ b/examples/ack-eks-cluster/eks-cluster.yaml
@@ -179,13 +179,13 @@ spec:
       apiVersion: eks.services.k8s.aws/v1alpha1
       kind: Cluster
       metadata:
-        name: ${spec.name}
+        name: ${schema.spec.name}
       spec:
-        name: ${spec.name}
+        name: ${schema.spec.name}
         accessConfig:
           authenticationMode: API_AND_CONFIG_MAP
         roleARN: ${clusterRole.status.ackResourceMetadata.arn}
-        version: ${spec.version}
+        version: ${schema.spec.version}
         resourcesVPCConfig:
           endpointPrivateAccess: false
           endpointPublicAccess: true

--- a/examples/ack-eks-cluster/eks-reused.yaml
+++ b/examples/ack-eks-cluster/eks-reused.yaml
@@ -20,16 +20,16 @@ spec:
       apiVersion: eks.services.k8s.aws/v1alpha1
       kind: EKSCluster
       metadata:
-        name: cluster1-${spec.name}
+        name: cluster1-${schema.spec.name}
       spec:
-        name: cluster1-${spec.name}
+        name: cluster1-${schema.spec.name}
         version: ${spc.version}
   - name: cluster2
     template:
       apiVersion: eks.services.k8s.aws/v1alpha1
       kind: EKSCluster
       metadata:
-        name: cluster2-${spec.name}
+        name: cluster2-${schema.spec.name}
       spec:
-        name: cluster2-${spec.name}
+        name: cluster2-${schema.spec.name}
         version: ${spc.version}

--- a/examples/cachecluster/cachecluster.yaml
+++ b/examples/cachecluster/cachecluster.yaml
@@ -18,18 +18,18 @@ spec:
       apiVersion: kro.run/v1alpha1
       kind: NetworkingStack
       metadata:
-        name: ${spec.name}-networking-stack
+        name: ${schema.spec.name}-networking-stack
       spec:
-        name: ${spec.name}-networking-stack
+        name: ${schema.spec.name}-networking-stack
   - name: cacheSubnetGroup
     template:
       apiVersion: elasticache.services.k8s.aws/v1alpha1
       kind: CacheSubnetGroup
       metadata:
-        name: ${spec.name}-redis-subnet-group
+        name: ${schema.spec.name}-redis-subnet-group
       spec:
         cacheSubnetGroupDescription: "Redis ElastiCache subnet group"
-        cacheSubnetGroupName: ${spec.name}-redis-subnet-group
+        cacheSubnetGroupName: ${schema.spec.name}-redis-subnet-group
         subnetIDs:
         - ${networkingStack.status.networkingInfo.subnetAZA}
         - ${networkingStack.status.networkingInfo.subnetAZB}
@@ -39,9 +39,9 @@ spec:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: SecurityGroup
       metadata:
-        name: ${spec.name}-redis-sg
+        name: ${schema.spec.name}-redis-sg
       spec:
-        name: ${spec.name}-redis-sg
+        name: ${schema.spec.name}-redis-sg
         description: "Redis ElastiCache security group"
         vpcID: ${networkingStack.status.networkingInfo.vpcID}
         ingressRules:
@@ -55,11 +55,11 @@ spec:
       apiVersion: elasticache.services.k8s.aws/v1alpha1
       kind: CacheCluster
       metadata:
-        name: ${spec.name}-redis
+        name: ${schema.spec.name}-redis
       spec:
         cacheClusterID: vote-redis-cluster
         cacheNodeType: cache.t3.micro
-        cacheSubnetGroupName: ${spec.name}-redis-subnet-group
+        cacheSubnetGroupName: ${schema.spec.name}-redis-subnet-group
         engine: redis
         engineVersion: "7.1"
         numCacheNodes: 1

--- a/examples/cachecluster/simple-cachecluster.yaml
+++ b/examples/cachecluster/simple-cachecluster.yaml
@@ -18,8 +18,8 @@ spec:
       apiVersion: elasticache.services.k8s.aws/v1alpha1
       kind: CacheSubnetGroup
       metadata:
-        name: ${spec.name}-redis-subnet-group
+        name: ${schema.spec.name}-redis-subnet-group
       spec:
         cacheSubnetGroupDescription: "Redis ElastiCache subnet group"
-        cacheSubnetGroupName: ${spec.name}-redis-subnet-group
-        subnetIDs: ${spec.subnetIDs}
+        cacheSubnetGroupName: ${schema.spec.name}-redis-subnet-group
+        subnetIDs: ${schema.spec.subnetIDs}

--- a/examples/cel-functions/rg.yaml
+++ b/examples/cel-functions/rg.yaml
@@ -18,7 +18,7 @@ spec:
       apiVersion: apps/v1
       kind: Deployment
       metadata:
-        name: ${spec.name}
+        name: ${schema.spec.name}
       spec:
         replicas: 1
         selector:
@@ -30,28 +30,28 @@ spec:
               app: deployment
           spec:
             containers:
-            - name: ${spec.name}-deployment
+            - name: ${schema.spec.name}-deployment
               image: nginx
               ports:
               - containerPort: 80
               env:
               - name: FULL_DNS_NAME
-                value: ${spec.fullDNSName}
+                value: ${schema.spec.fullDNSName}
               - name: DNS_FIRST_PART
-                value: ${spec.fullDNSName.split('.')[0]}
+                value: ${schema.spec.fullDNSName.split('.')[0]}
               - name: DNS_PARTIALS
-                value: ${spec.fullDNSName.split('.').slice(0, 1).join('.')}
+                value: ${schema.spec.fullDNSName.split('.').slice(0, 1).join('.')}
   - name: service
     template:
       apiVersion: v1
       kind: Service
       metadata:
-        name: ${spec.name}
+        name: ${schema.spec.name}
         labels:
           app: deployment
-          dns: ${spec.fullDNSName}
-          partials: "${size(spec.fullDNSName.split('.')) > 2 ? spec.fullDNSName.split('.').slice(0, 3).join('.') : spec.fullDNSName}"
-          first_part: ${spec.fullDNSName.split('.')[0]}
+          dns: ${schema.spec.fullDNSName}
+          partials: "${size(schema.spec.fullDNSName.split('.')) > 2 ? schema.spec.fullDNSName.split('.').slice(0, 3).join('.') : schema.spec.fullDNSName}"
+          first_part: ${schema.schema.spec.fullDNSName.split('.')[0]}
       spec:
         selector:
           app: deployment

--- a/examples/core-dns/core-dns.yaml
+++ b/examples/core-dns/core-dns.yaml
@@ -45,8 +45,8 @@ spec:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: ${spec.name}
-        labels: ${spec.values.clusterRole.labels}
+        name: ${schema.spec.name}
+        labels: ${schema.spec.values.clusterRole.labels}
       rules:
       - apiGroups:
         - ""
@@ -76,9 +76,9 @@ spec:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: ${spec.name}
-        labels: ${spec.values.clusterRole.labels}
-        annotations: ${spec.values.clusterRoleBinding.annotations}
+        name: ${schema.spec.name}
+        labels: ${schema.spec.values.clusterRole.labels}
+        annotations: ${schema.spec.values.clusterRoleBinding.annotations}
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
@@ -92,8 +92,8 @@ spec:
       apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: ${spec.name}
-        labels: ${spec.values.configMap.labels}
+        name: ${schema.spec.name}
+        labels: ${schema.spec.values.configMap.labels}
       data:
         Corefile: |-
           .:53 {
@@ -115,30 +115,30 @@ spec:
       apiVersion: apps/v1
       kind: Deployment
       metadata:
-        annotations: ${spec.values.deployment.annotations}
-        labels: ${spec.values.deployment.labels}
-        name: ${spec.name}
+        annotations: ${schema.spec.values.deployment.annotations}
+        labels: ${schema.spec.values.deployment.labels}
+        name: ${schema.spec.name}
       spec:
-        replicas: ${spec.values.deployment.replicas}
+        replicas: ${schema.spec.values.deployment.replicas}
         selector:
-          matchLabels: ${spec.values.configMap.labels}
+          matchLabels: ${schema.spec.values.configMap.labels}
         template:
           metadata:
-            labels: ${spec.values.configMap.labels}
+            labels: ${schema.spec.values.configMap.labels}
           spec:
             serviceAccountName: ${serviceAccount.metadata.name}
             containers:
             - name: "coredns"
-              image: ${spec.values.image.repository}:${spec.values.image.tag}
+              image: ${schema.spec.values.image.repository}:${schema.spec.values.image.tag}
               args: ["-conf", "/etc/coredns/Corefile"]
-              resources: ${spec.values.resources}
+              resources: ${schema.spec.values.resources}
               volumeMounts:
               - name: config-volume
                 mountPath: /etc/coredns
             volumes:
               - name: config-volume
                 configMap:
-                  name: ${spec.name}
+                  name: ${schema.spec.name}
                   items:
                   - key: Corefile
                     path: Corefile
@@ -147,16 +147,16 @@ spec:
       apiVersion: v1
       kind: Service
       metadata:
-        name: ${spec.name}
-        labels: ${spec.values.service.labels}
-        annotations: ${spec.values.service.annotations}
+        name: ${schema.spec.name}
+        labels: ${schema.spec.values.service.labels}
+        annotations: ${schema.spec.values.service.annotations}
       spec:
         selector:
           k8s-app: kube-dns
-        clusterIP: ${spec.values.service.clusterIP}
-        clusterIPs: ${spec.values.service.clusterIPs}
+        clusterIP: ${schema.spec.values.service.clusterIP}
+        clusterIPs: ${schema.spec.values.service.clusterIPs}
         internalTrafficPolicy: Cluster
-        ipFamilies: ${spec.values.service.ipFamilies}
+        ipFamilies: ${schema.spec.values.service.ipFamilies}
         ports:
         - name: dns
           port: 53
@@ -174,9 +174,9 @@ spec:
       apiVersion: v1
       kind: ServiceAccount
       metadata:
-        name: ${spec.name}
-        namespace: ${spec.namespace}
-        labels: ${spec.values.configMap.labels}
+        name: ${schema.spec.name}
+        namespace: ${schema.spec.namespace}
+        labels: ${schema.spec.values.configMap.labels}
       secrets: 
-      - ${spec.values.serviceAccount.secrets}
+      - ${schema.spec.values.serviceAccount.secrets}
         

--- a/examples/deployment-service-ingress/deployment-service-ingress.yaml
+++ b/examples/deployment-service-ingress/deployment-service-ingress.yaml
@@ -19,43 +19,43 @@ spec:
       apiVersion: apps/v1
       kind: Deployment
       metadata:
-        name: ${spec.name}
-        namespace: ${spec.namespace}
+        name: ${schema.spec.name}
+        namespace: ${schema.spec.namespace}
         labels:
-          app: ${spec.name}
+          app: ${schema.spec.name}
       spec:
         replicas: 3
         selector:
           matchLabels:
-            app: ${spec.name}
+            app: ${schema.spec.name}
         template:
           metadata:
             labels:
-              app: ${spec.name}
+              app: ${schema.spec.name}
           spec:
             containers:
-            - name: ${spec.name}
-              image: ${spec.image}
+            - name: ${schema.spec.name}
+              image: ${schema.spec.image}
               imagePullPolicy: IfNotPresent
               ports:
-              - containerPort: ${spec.port}
+              - containerPort: ${schema.spec.port}
 
   - name: service
     template:
       apiVersion: v1
       kind: Service
       metadata:
-        name: ${spec.name}
-        namespace: ${spec.namespace}
+        name: ${schema.spec.name}
+        namespace: ${schema.spec.namespace}
         labels:
-          app: ${spec.name}
+          app: ${schema.spec.name}
       spec:
         type: NodePort
         selector:
-          app: ${spec.name}
+          app: ${schema.spec.name}
         ports:
-        - port: ${spec.port}
-          targetPort: ${spec.port}
+        - port: ${schema.spec.port}
+          targetPort: ${schema.spec.port}
           protocol: TCP
 
   - name: ingress
@@ -63,13 +63,13 @@ spec:
       apiVersion: networking.k8s.io/v1
       kind: Ingress
       metadata:
-        name: ${spec.name}
-        namespace: ${spec.namespace}
+        name: ${schema.spec.name}
+        namespace: ${schema.spec.namespace}
         annotations:
           kubernetes.io/ingress.class: alb
           alb.ingress.kubernetes.io/scheme: internet-facing
         labels:
-          app: ${spec.name}
+          app: ${schema.spec.name}
       spec:
       spec:
         rules:
@@ -79,6 +79,6 @@ spec:
                   pathType: Prefix
                   backend:
                     service:
-                      name: ${spec.name}
+                      name: ${schema.spec.name}
                       port:
-                        number: ${spec.port}
+                        number: ${schema.spec.port}

--- a/examples/deployment-service/deployment-service.yaml
+++ b/examples/deployment-service/deployment-service.yaml
@@ -22,7 +22,7 @@ spec:
       apiVersion: apps/v1
       kind: Deployment
       metadata:
-        name: ${spec.name}
+        name: ${schema.spec.name}
       spec:
         replicas: 5
         selector:
@@ -34,13 +34,13 @@ spec:
               app: deployment
           spec:
             containers:
-            - name: ${spec.name}-deployment
+            - name: ${schema.spec.name}-deployment
               image: nginx
               ports:
               - containerPort: 80
   - name: service
     includeWhen:
-    - ${spec.service.enabled}
+    - ${schema.spec.service.enabled}
     template:
       apiVersion: v1
       kind: Service

--- a/examples/eks-cluster-mgmt/clusters/rg/eks-w-vpc.yaml
+++ b/examples/eks-cluster-mgmt/clusters/rg/eks-w-vpc.yaml
@@ -27,25 +27,25 @@ spec:
       apiVersion: kro.run/v1alpha1
       kind: Vpc
       metadata:
-        name: ${spec.name}
+        name: ${schema.spec.name}
       spec:
-        name: ${spec.name}
-        region: ${spec.region}
+        name: ${schema.spec.name}
+        region: ${schema.spec.region}
         cidr:
-          vpcCidr: ${spec.cidr.vpcCidr}
-          publicSubnet1Cidr: ${spec.cidr.publicSubnet1Cidr}
-          publicSubnet2Cidr: ${spec.cidr.publicSubnet2Cidr}
-          privateSubnet1Cidr: ${spec.cidr.privateSubnet1Cidr}
-          privateSubnet2Cidr: ${spec.cidr.privateSubnet2Cidr}
+          vpcCidr: ${schema.spec.cidr.vpcCidr}
+          publicSubnet1Cidr: ${schema.spec.cidr.publicSubnet1Cidr}
+          publicSubnet2Cidr: ${schema.spec.cidr.publicSubnet2Cidr}
+          privateSubnet1Cidr: ${schema.spec.cidr.privateSubnet1Cidr}
+          privateSubnet2Cidr: ${schema.spec.cidr.privateSubnet2Cidr}
   - name: eks
     template:
       apiVersion: kro.run/v1alpha1
       kind: EksCluster
       metadata:
-        name: ${spec.name}
+        name: ${schema.spec.name}
       spec:
-          name: ${spec.name}
-          region: ${spec.region}
+          name: ${schema.spec.name}
+          region: ${schema.spec.region}
           subnets:
             controlplane:
               subnet1ID: ${vpc.status.privateSubnet1ID}
@@ -53,6 +53,6 @@ spec:
             workers:
               subnet1ID: ${vpc.status.privateSubnet1ID}
               subnet2ID: ${vpc.status.privateSubnet2ID}
-          accountId: ${spec.accountId}
-          k8sVersion: ${spec.k8sVersion}
-          nodesCount: ${spec.nodesCount}
+          accountId: ${schema.spec.accountId}
+          k8sVersion: ${schema.spec.k8sVersion}
+          nodesCount: ${schema.spec.nodesCount}

--- a/examples/eks-cluster-mgmt/clusters/rg/eks.yaml
+++ b/examples/eks-cluster-mgmt/clusters/rg/eks.yaml
@@ -28,10 +28,10 @@ spec:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Role
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-cluster-role
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-cluster-role
       spec:
-        name: ${spec.name}-cluster-role
+        name: ${schema.spec.name}-cluster-role
         policies:
         - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
         assumeRolePolicyDocument: |
@@ -52,10 +52,10 @@ spec:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Role
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-cluster-node-role
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-cluster-node-role
       spec:
-        name: ${spec.name}-cluster-node-role
+        name: ${schema.spec.name}-cluster-node-role
         policies:
         - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
@@ -78,10 +78,10 @@ spec:
       apiVersion: eks.services.k8s.aws/v1alpha1
       kind: Cluster
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}
       spec:
-        name: ${spec.name}
+        name: ${schema.spec.name}
         roleARN: ${clusterRole.status.ackResourceMetadata.arn}
         accessConfig:
           authenticationMode: "API_AND_CONFIG_MAP"
@@ -89,37 +89,37 @@ spec:
           endpointPrivateAccess: false
           endpointPublicAccess: true
           subnetIDs:
-            - ${spec.subnets.controlplane.subnet1ID}
-            - ${spec.subnets.controlplane.subnet2ID}
-        #version: ${spec.k8sVersion} a bug needs to be fixed for this to work
+            - ${schema.spec.subnets.controlplane.subnet1ID}
+            - ${schema.spec.subnets.controlplane.subnet2ID}
+        #version: ${schema.spec.k8sVersion} a bug needs to be fixed for this to work
   - name: nodegroup
     template:
       apiVersion: eks.services.k8s.aws/v1alpha1
       kind: Nodegroup
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-nodegroup
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-nodegroup
       spec:
-        name: ${spec.name}-nodegroup
-        clusterName: ${spec.name}
+        name: ${schema.spec.name}-nodegroup
+        clusterName: ${schema.spec.name}
         subnets:
-          - ${spec.subnets.workers.subnet1ID}
-          - ${spec.subnets.workers.subnet2ID}
+          - ${schema.spec.subnets.workers.subnet1ID}
+          - ${schema.spec.subnets.workers.subnet2ID}
         nodeRole: ${nodeRole.status.ackResourceMetadata.arn}
         updateConfig:
           maxUnavailable: 1
         scalingConfig:
-          minSize: 3 #${spec.nodesCount} a bug needs to be fixed for this to work
-          maxSize: 3 #${spec.nodesCount} a bug needs to be fixed for this to work
-          desiredSize: 3 #${spec.nodesCount} a bug needs to be fixed for this to work
+          minSize: 3 #${schema.spec.nodesCount} a bug needs to be fixed for this to work
+          maxSize: 3 #${schema.spec.nodesCount} a bug needs to be fixed for this to work
+          desiredSize: 3 #${schema.spec.nodesCount} a bug needs to be fixed for this to work
   - name: argocdRole
     template:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Role
       metadata:
-        name: ${spec.name}-argocd-role
+        name: ${schema.spec.name}-argocd-role
       spec:
-        name: ${spec.name}-argocd-role
+        name: ${schema.spec.name}-argocd-role
         assumeRolePolicyDocument: |
           {
             "Version": "2012-10-17",
@@ -141,22 +141,22 @@ spec:
       apiVersion: v1
       kind: Secret
       metadata:
-        name: ${spec.name}
+        name: ${schema.spec.name}
         namespace: argocd
         labels:
           argocd.argoproj.io/secret-type: cluster
         annotations:
-          accountId: ${spec.accountId}
-          region: ${spec.region}
+          accountId: ${schema.spec.accountId}
+          region: ${schema.spec.region}
           oidcProvider: ${ekscluster.status.identity.oidc.issuer}
       type: Opaque
       stringData:
-        name: ${spec.name}
+        name: ${schema.spec.name}
         server: "${ekscluster.status.endpoint}"
         config: |
           {
             "awsAuthConfig": {
-              "clusterName": "${spec.name}",
+              "clusterName": "${schema.spec.name}",
               "roleARN": "${argocdRole.status.ackResourceMetadata.arn}"
             },
             "tlsClientConfig": {
@@ -169,10 +169,10 @@ spec:
       apiVersion: eks.services.k8s.aws/v1alpha1
       kind: AccessEntry
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-accessentry
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-accessentry
       spec:
-        clusterName: ${spec.name}
+        clusterName: ${schema.spec.name}
         accessPolicies:
         - accessScope:
             type: "cluster"
@@ -183,8 +183,8 @@ spec:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: OpenIDConnectProvider
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-odic
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-odic
       spec:
         url: ${ekscluster.status.identity.oidc.issuer}
         clientIDs:

--- a/examples/eks-cluster-mgmt/clusters/rg/vpc.yaml
+++ b/examples/eks-cluster-mgmt/clusters/rg/vpc.yaml
@@ -30,83 +30,83 @@ spec:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: VPC
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-vpc
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-vpc
       spec:
         cidrBlocks: 
-        - ${spec.cidr.vpcCidr}
+        - ${schema.spec.cidr.vpcCidr}
         enableDNSSupport: true
         enableDNSHostnames: true
         tags:
           - key: "Name"
-            value: ${spec.name}-vpc
+            value: ${schema.spec.name}-vpc
   - name: internetGateway
     template:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: InternetGateway
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-igw
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-igw
       spec:
         vpc: ${vpc.status.vpcID}
         tags:
           - key: "Name"
-            value: ${spec.name}-igw
+            value: ${schema.spec.name}-igw
   - name: natGateway1
     template:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: NATGateway
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-nat-gateway1
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-nat-gateway1
       spec:
         subnetID: ${publicSubnet1.status.subnetID}
         allocationID: ${eip1.status.allocationID}
         tags:
           - key: "Name"
-            value: ${spec.name}-nat-gateway1
+            value: ${schema.spec.name}-nat-gateway1
   - name: natGateway2
     template:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: NATGateway
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-nat-gateway2
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-nat-gateway2
       spec:
         subnetID: ${publicSubnet2.status.subnetID}
         allocationID: ${eip2.status.allocationID}
         tags:
           - key: "Name"
-            value: ${spec.name}-nat-gateway2
+            value: ${schema.spec.name}-nat-gateway2
   - name: eip1
     template:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: ElasticIPAddress
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-eip1
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-eip1
       spec:
         tags:
           - key: "Name"
-            value: ${spec.name}-eip1
+            value: ${schema.spec.name}-eip1
   - name: eip2
     template:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: ElasticIPAddress
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-eip2
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-eip2
       spec:
         tags:
           - key: "Name"
-            value: ${spec.name}-eip2
+            value: ${schema.spec.name}-eip2
   - name: publicRoutetable
     template:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: RouteTable
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-public-routetable
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-public-routetable
       spec:
         vpcID: ${vpc.status.vpcID}
         routes:
@@ -114,14 +114,14 @@ spec:
           gatewayID: ${internetGateway.status.internetGatewayID}
         tags:
           - key: "Name"
-            value: ${spec.name}-public-routetable
+            value: ${schema.spec.name}-public-routetable
   - name: privateRoutetable1
     template:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: RouteTable
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-private-routetable1
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-private-routetable1
       spec:
         vpcID: ${vpc.status.vpcID}
         routes:
@@ -129,14 +129,14 @@ spec:
           natGatewayID: ${natGateway1.status.natGatewayID}
         tags:
           - key: "Name"
-            value: ${spec.name}-private-routetable1
+            value: ${schema.spec.name}-private-routetable1
   - name: privateRoutetable2
     template:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: RouteTable
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-private-routetable2
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-private-routetable2
       spec:
         vpcID: ${vpc.status.vpcID}
         routes:
@@ -144,24 +144,24 @@ spec:
           natGatewayID: ${natGateway2.status.natGatewayID}
         tags:
           - key: "Name"
-            value: ${spec.name}-private-routetable2
+            value: ${schema.spec.name}-private-routetable2
   - name: publicSubnet1
     template:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: Subnet
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-public-subnet1
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-public-subnet1
       spec:
-        availabilityZone: ${spec.region}a
-        cidrBlock: ${spec.cidr.publicSubnet1Cidr}
+        availabilityZone: ${schema.spec.region}a
+        cidrBlock: ${schema.spec.cidr.publicSubnet1Cidr}
         mapPublicIPOnLaunch: true
         vpcID: ${vpc.status.vpcID}
         routeTables:
         - ${publicRoutetable.status.routeTableID}
         tags:
           - key: "Name"
-            value: ${spec.name}-public-subnet1
+            value: ${schema.spec.name}-public-subnet1
           - key: kubernetes.io/role/elb
             value: '1'
   - name: publicSubnet2
@@ -169,18 +169,18 @@ spec:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: Subnet
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-public-subnet2
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-public-subnet2
       spec:
-        availabilityZone: ${spec.region}b
-        cidrBlock: ${spec.cidr.publicSubnet2Cidr}
+        availabilityZone: ${schema.spec.region}b
+        cidrBlock: ${schema.spec.cidr.publicSubnet2Cidr}
         mapPublicIPOnLaunch: true
         vpcID: ${vpc.status.vpcID}
         routeTables:
         - ${publicRoutetable.status.routeTableID}
         tags:
           - key: "Name"
-            value: ${spec.name}-public-subnet2
+            value: ${schema.spec.name}-public-subnet2
           - key: kubernetes.io/role/elb
             value: '1'
   - name: privateSubnet1
@@ -188,17 +188,17 @@ spec:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: Subnet
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-private-subnet1
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-private-subnet1
       spec:
-        availabilityZone: ${spec.region}a
-        cidrBlock: ${spec.cidr.privateSubnet1Cidr}
+        availabilityZone: ${schema.spec.region}a
+        cidrBlock: ${schema.spec.cidr.privateSubnet1Cidr}
         vpcID: ${vpc.status.vpcID}
         routeTables:
         - ${privateRoutetable1.status.routeTableID}
         tags:
           - key: "Name"
-            value: ${spec.name}-private-subnet1
+            value: ${schema.spec.name}-private-subnet1
           - key: kubernetes.io/role/internal-elb
             value: '1'
   - name: privateSubnet2
@@ -206,16 +206,16 @@ spec:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: Subnet
       metadata:
-        namespace: ${spec.name}
-        name: ${spec.name}-private-subnet2
+        namespace: ${schema.spec.name}
+        name: ${schema.spec.name}-private-subnet2
       spec:
-        availabilityZone: ${spec.region}b
-        cidrBlock: ${spec.cidr.privateSubnet2Cidr}
+        availabilityZone: ${schema.spec.region}b
+        cidrBlock: ${schema.spec.cidr.privateSubnet2Cidr}
         vpcID: ${vpc.status.vpcID}
         routeTables:
         - ${privateRoutetable2.status.routeTableID}
         tags:
           - key: "Name"
-            value: ${spec.name}-private-subnet2
+            value: ${schema.spec.name}-private-subnet2
           - key: kubernetes.io/role/internal-elb
             value: '1'

--- a/examples/networkstack/network-stack.yaml
+++ b/examples/networkstack/network-stack.yaml
@@ -23,7 +23,7 @@ spec:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: VPC
       metadata:
-        name: vpc-${spec.name}
+        name: vpc-${schema.spec.name}
       spec:
         cidrBlocks:
         - 192.168.0.0/16
@@ -34,7 +34,7 @@ spec:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: Subnet
       metadata:
-        name: subnet-a-${spec.name}
+        name: subnet-a-${schema.spec.name}
       spec:
         availabilityZone: us-west-2a
         cidrBlock: 192.168.0.0/18
@@ -44,7 +44,7 @@ spec:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: Subnet
       metadata:
-        name: subnet-b-${spec.name}
+        name: subnet-b-${schema.spec.name}
       spec:
         availabilityZone: us-west-2b
         cidrBlock: 192.168.64.0/18
@@ -54,7 +54,7 @@ spec:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: Subnet
       metadata:
-        name: subnet-c-${spec.name}
+        name: subnet-c-${schema.spec.name}
       spec:
         availabilityZone: us-west-2c
         cidrBlock: 192.168.128.0/18
@@ -64,8 +64,8 @@ spec:
       apiVersion: ec2.services.k8s.aws/v1alpha1
       kind: SecurityGroup
       metadata:
-        name: cluster-security-group-${spec.name}
+        name: cluster-security-group-${schema.spec.name}
       spec:
         vpcID: ${vpc.status.vpcID}
-        name: my-sg-${spec.name}
+        name: my-sg-${schema.spec.name}
         description: something something

--- a/examples/serverless-microservice/microservice.yaml
+++ b/examples/serverless-microservice/microservice.yaml
@@ -29,7 +29,7 @@ spec:
       apiVersion: dynamodb.services.k8s.aws/v1alpha1
       kind: Table
       metadata:
-        name: ${spec.namePrefix}-items-table
+        name: ${schema.spec.namePrefix}-items-table
       spec:
         keySchema:
           - attributeName: id
@@ -38,15 +38,15 @@ spec:
           - attributeName: id
             attributeType: S
         billingMode: PAY_PER_REQUEST
-        tableName: ${spec.namePrefix}-items-table
+        tableName: ${schema.spec.namePrefix}-items-table
   - name: lambdaDDBAccessPolicy
     template:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Policy
       metadata:
-          name: ${spec.namePrefix}-lambda-ddb-access-policy
+          name: ${schema.spec.namePrefix}-lambda-ddb-access-policy
       spec:
-        name: ${spec.namePrefix}-lambda-ddb-access-policy
+        name: ${schema.spec.namePrefix}-lambda-ddb-access-policy
         policyDocument: |
           {
             "Version": "2012-10-17",
@@ -79,9 +79,9 @@ spec:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Policy
       metadata:
-          name: ${spec.namePrefix}-lambda-basic-policy
+          name: ${schema.spec.namePrefix}-lambda-basic-policy
       spec:
-        name: ${spec.namePrefix}-lambda-basic-policy
+        name: ${schema.spec.namePrefix}-lambda-basic-policy
         policyDocument: |
           {
             "Version": "2012-10-17",
@@ -104,9 +104,9 @@ spec:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Role
       metadata:
-        name: ${spec.namePrefix}-logic-role
+        name: ${schema.spec.namePrefix}-logic-role
       spec:
-        name: ${spec.namePrefix}-logic-role
+        name: ${schema.spec.namePrefix}-logic-role
         assumeRolePolicyDocument: |
           {
             "Version": "2012-10-17",
@@ -130,18 +130,18 @@ spec:
       apiVersion: lambda.services.k8s.aws/v1alpha1
       kind: Function
       metadata:
-        name: ${spec.namePrefix}-logic
+        name: ${schema.spec.namePrefix}-logic
       spec:
-        name: ${spec.namePrefix}-logic
+        name: ${schema.spec.namePrefix}-logic
         packageType: Zip
         code:
-          s3Bucket: ${spec.lambda.codeBucketName}
-          s3Key: ${spec.lambda.logicLambdaCode}
+          s3Bucket: ${schema.spec.lambda.codeBucketName}
+          s3Key: ${schema.spec.lambda.logicLambdaCode}
         environment:
           variables: 
             TABLE_NAME: ${itemsTable.spec.tableName}
-        handler: ${spec.lambda.logicLambdaHandler}
-        runtime: ${spec.lambda.logicLambdaRunTime}
+        handler: ${schema.spec.lambda.logicLambdaHandler}
+        runtime: ${schema.spec.lambda.logicLambdaRunTime}
         role: ${logicLambdaRole.status.ackResourceMetadata.arn}
 
 # Lambda authorizer along with permissions required to retrieve password from AWS Secrets Manager
@@ -150,9 +150,9 @@ spec:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Policy
       metadata:
-          name: ${spec.namePrefix}-lambda-secrets-access-policy
+          name: ${schema.spec.namePrefix}-lambda-secrets-access-policy
       spec:
-        name: ${spec.namePrefix}-lambda-secrets-access-policy
+        name: ${schema.spec.namePrefix}-lambda-secrets-access-policy
         policyDocument: |
           {
             "Version": "2012-10-17",
@@ -163,7 +163,7 @@ spec:
                   "secretsmanager:GetSecretValue"
                   ],
                   "Resource": [
-                      "${spec.lambda.authorizerPasswordParameterARN}"
+                      "${schema.spec.lambda.authorizerPasswordParameterARN}"
                   ]
               }
             ]
@@ -173,9 +173,9 @@ spec:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Role
       metadata:
-        name: ${spec.namePrefix}-authorizer-role
+        name: ${schema.spec.namePrefix}-authorizer-role
       spec:
-        name: ${spec.namePrefix}-authorizer-role
+        name: ${schema.spec.namePrefix}-authorizer-role
         assumeRolePolicyDocument: |
           {
             "Version": "2012-10-17",
@@ -199,18 +199,18 @@ spec:
       apiVersion: lambda.services.k8s.aws/v1alpha1
       kind: Function
       metadata:
-        name: ${spec.namePrefix}-authorizer
+        name: ${schema.spec.namePrefix}-authorizer
       spec:
-        name: ${spec.namePrefix}-authorizer
+        name: ${schema.spec.namePrefix}-authorizer
         packageType: Zip
         code:
-          s3Bucket: ${spec.lambda.codeBucketName}
-          s3Key: ${spec.lambda.authorizerLambdaCode}
+          s3Bucket: ${schema.spec.lambda.codeBucketName}
+          s3Key: ${schema.spec.lambda.authorizerLambdaCode}
         environment:
           variables: 
-            AUTHORIZER_PASSWORD_ARN: ${spec.lambda.authorizerPasswordParameterARN}
-        handler: ${spec.lambda.authorizerLambdaHandler}
-        runtime: ${spec.lambda.authorizerLambdaRunTime}
+            AUTHORIZER_PASSWORD_ARN: ${schema.spec.lambda.authorizerPasswordParameterARN}
+        handler: ${schema.spec.lambda.authorizerLambdaHandler}
+        runtime: ${schema.spec.lambda.authorizerLambdaRunTime}
         role: ${authorizerLambdaRole.status.ackResourceMetadata.arn}
 
 # ACK Lambda controller does not support Lambda resource policies typically used by API Gateway - https://github.com/aws-controllers-k8s/community/issues/1405
@@ -220,9 +220,9 @@ spec:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Policy
       metadata:
-        name: ${spec.namePrefix}-api-logic-invoke-policy
+        name: ${schema.spec.namePrefix}-api-logic-invoke-policy
       spec:
-        name: ${spec.namePrefix}-api-logic-invoke-policy
+        name: ${schema.spec.namePrefix}-api-logic-invoke-policy
         policyDocument: |
           {
             "Version": "2012-10-17",
@@ -241,9 +241,9 @@ spec:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Role
       metadata:
-        name: ${spec.namePrefix}-apigw-logic-execution-role
+        name: ${schema.spec.namePrefix}-apigw-logic-execution-role
       spec:
-        name: ${spec.namePrefix}-apigw-logic-execution-role
+        name: ${schema.spec.namePrefix}-apigw-logic-execution-role
         assumeRolePolicyDocument: |
           {
             "Version": "2012-10-17",
@@ -266,9 +266,9 @@ spec:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Policy
       metadata:
-        name: ${spec.namePrefix}-api-authorizer-invoke-policy
+        name: ${schema.spec.namePrefix}-api-authorizer-invoke-policy
       spec:
-        name: ${spec.namePrefix}-api-authorizer-invoke-policy
+        name: ${schema.spec.namePrefix}-api-authorizer-invoke-policy
         policyDocument: |
           {
             "Version": "2012-10-17",
@@ -287,9 +287,9 @@ spec:
       apiVersion: iam.services.k8s.aws/v1alpha1
       kind: Role
       metadata:
-        name: ${spec.namePrefix}-apigw-authorizer-execution-role
+        name: ${schema.spec.namePrefix}-apigw-authorizer-execution-role
       spec:
-        name: ${spec.namePrefix}-apigw-authorizer-execution-role
+        name: ${schema.spec.namePrefix}-apigw-authorizer-execution-role
         assumeRolePolicyDocument: |
           {
             "Version": "2012-10-17",
@@ -314,21 +314,21 @@ spec:
       apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
       kind: API
       metadata:
-        name: ${spec.namePrefix}-${spec.api.apiName}
+        name: ${schema.spec.namePrefix}-${schema.spec.api.apiName}
       spec:
-        name: ${spec.namePrefix}-${spec.api.apiName}
+        name: ${schema.spec.namePrefix}-${schema.spec.api.apiName}
         protocolType: HTTP
   - name: apigwLambdaIntegration
     template:
       apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
       kind: Integration
       metadata:
-        name: ${spec.namePrefix}-${spec.api.apiName}-integration
+        name: ${schema.spec.namePrefix}-${schema.spec.api.apiName}-integration
       spec:
         apiID: ${apigw.status.apiID}
         credentialsARN: ${apigwLogicLambdaExecutionRole.status.ackResourceMetadata.arn}
         integrationType: AWS_PROXY
-        integrationURI: "arn:aws:apigateway:${spec.region}:lambda:path/2015-03-31/functions/${logicLambda.status.ackResourceMetadata.arn}/invocations"
+        integrationURI: "arn:aws:apigateway:${schema.spec.region}:lambda:path/2015-03-31/functions/${logicLambda.status.ackResourceMetadata.arn}/invocations"
         integrationMethod: POST
         payloadFormatVersion: "2.0"
   - name: apigwItemsIdRoute
@@ -336,7 +336,7 @@ spec:
       apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
       kind: Route
       metadata:
-        name: ${spec.namePrefix}-${spec.api.apiName}-route-item
+        name: ${schema.spec.namePrefix}-${schema.spec.api.apiName}-route-item
       spec:
         apiID: ${apigw.status.apiID}
         routeKey: "ANY /items/{id}"
@@ -348,7 +348,7 @@ spec:
       apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
       kind: Route
       metadata:
-        name: ${spec.namePrefix}-${spec.api.apiName}-route-items
+        name: ${schema.spec.namePrefix}-${schema.spec.api.apiName}-route-items
       spec:
         apiID: ${apigw.status.apiID}
         routeKey: "ANY /items"
@@ -360,7 +360,7 @@ spec:
       apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
       kind: Stage
       metadata:
-        name: ${spec.namePrefix}-${spec.api.apiName}-stage
+        name: ${schema.spec.namePrefix}-${schema.spec.api.apiName}-stage
       spec:
         apiID: ${apigw.status.apiID}
         stageName: "$default"
@@ -370,7 +370,7 @@ spec:
       apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
       kind: Authorizer
       metadata:
-        name: ${spec.namePrefix}-${spec.api.apiName}-authorizer
+        name: ${schema.spec.namePrefix}-${schema.spec.api.apiName}-authorizer
       spec:
         apiID: ${apigw.status.apiID}
         authorizerCredentialsARN: ${apigwAuthorizerLambdaExecutionRole.status.ackResourceMetadata.arn}
@@ -378,5 +378,5 @@ spec:
         authorizerType: REQUEST
         identitySource:
           - $request.header.Authorization
-        authorizerURI: "arn:aws:apigateway:${spec.region}:lambda:path/2015-03-31/functions/${authorizerLambda.status.ackResourceMetadata.arn}/invocations"
-        name: ${spec.namePrefix}-${spec.api.apiName}-authorizer
+        authorizerURI: "arn:aws:apigateway:${schema.spec.region}:lambda:path/2015-03-31/functions/${authorizerLambda.status.ackResourceMetadata.arn}/invocations"
+        name: ${schema.spec.namePrefix}-${schema.spec.api.apiName}-authorizer

--- a/internal/controller/resourcegroup/errors/resourcegroup.go
+++ b/internal/controller/resourcegroup/errors/resourcegroup.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. A copy of the
 // License is located at
 //
-//     http://aws.amazon.com/apache2.0/
+//	http://aws.amazon.com/apache2.0/
 //
 // or in the "license" file accompanying this file. This file is distributed
 // on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either

--- a/internal/dynamiccontroller/dynamic_controller_test.go
+++ b/internal/dynamiccontroller/dynamic_controller_test.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. A copy of the
 // License is located at
 //
-//     http://aws.amazon.com/apache2.0/
+//	http://aws.amazon.com/apache2.0/
 //
 // or in the "license" file accompanying this file. This file is distributed
 // on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either

--- a/internal/graph/schema/schema.go
+++ b/internal/graph/schema/schema.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. A copy of the
 // License is located at
 //
-//     http://aws.amazon.com/apache2.0/
+//	http://aws.amazon.com/apache2.0/
 //
 // or in the "license" file accompanying this file. This file is distributed
 // on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either

--- a/internal/graph/variable/variable.go
+++ b/internal/graph/variable/variable.go
@@ -48,7 +48,7 @@ type FieldDescriptor struct {
 // value a.k.a contains one or multiple expressions. For example
 //
 //	spec:
-//	  replicas: ${spec.mycustomReplicasField + 5}
+//	  replicas: ${schema.spec.mycustomReplicasField + 5}
 //
 // Contains a variable named "spec.mycustomReplicasField". Variables can be
 // static or dynamic. Static variables are resolved at the beginning of the
@@ -92,7 +92,7 @@ const (
 	//
 	// For example:
 	//   spec:
-	//      replicas: ${spec.replicas + 5}
+	//      replicas: ${schema.spec.replicas + 5}
 	ResourceVariableKindStatic ResourceVariableKind = "static"
 	// ResourceVariableKindDynamic represents a dynamic variable. Dynamic variables
 	// are resolved at runtime and their value can change during the execution. Dynamic
@@ -122,7 +122,7 @@ const (
 	// For example:
 	//   name: deployment
 	//   includeWhen:
-	//   - ${spec.replicas > 1}
+	//   - ${schema.spec.replicas > 1}
 	ResourceVariableKindIncludeWhen ResourceVariableKind = "includeWhen"
 )
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -302,13 +302,13 @@ func (rt *ResourceGroupRuntime) resourceVariablesResolved(resource string) bool 
 // depending only on the initial configuration. This function is usually
 // called once during runtime initialization to set up the baseline state
 func (rt *ResourceGroupRuntime) evaluateStaticVariables() error {
-	env, err := scel.DefaultEnvironment(scel.WithResourceNames([]string{"spec"}))
+	env, err := scel.DefaultEnvironment(scel.WithResourceNames([]string{"schema"}))
 	if err != nil {
 		return err
 	}
 
 	evalContext := map[string]interface{}{
-		"spec": rt.instance.Unstructured().Object["spec"],
+		"schema": rt.instance.Unstructured().Object,
 	}
 	for _, variable := range rt.expressionsCache {
 		if variable.Kind.IsStatic() {
@@ -530,13 +530,13 @@ func (rt *ResourceGroupRuntime) WantToCreateResource(resourceID string) (bool, e
 
 	// we should not expect errors here since we already compiled it
 	// in the dryRun
-	env, err := scel.DefaultEnvironment(scel.WithResourceNames([]string{"spec"}))
+	env, err := scel.DefaultEnvironment(scel.WithResourceNames([]string{"schema"}))
 	if err != nil {
 		return false, nil
 	}
 
 	context := map[string]interface{}{
-		"spec": rt.instance.Unstructured().Object["spec"],
+		"schema": rt.instance.Unstructured().Object,
 	}
 
 	for _, condition := range conditions {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -55,7 +55,7 @@ func Test_RuntimeWorkflow(t *testing.T) {
 	secret := newTestResource(
 		withObject(map[string]interface{}{
 			"metadata": map[string]interface{}{
-				"name": "${spec.appName}-secret",
+				"name": "${schema.spec.appName}-secret",
 			},
 			"stringData": map[string]interface{}{
 				"DB_URL": "${dburl_expr}",
@@ -65,7 +65,7 @@ func Test_RuntimeWorkflow(t *testing.T) {
 			{
 				FieldDescriptor: variable.FieldDescriptor{
 					Path:                 "metadata.name",
-					Expressions:          []string{"spec.appName + '-secret'"},
+					Expressions:          []string{"schema.spec.appName + '-secret'"},
 					StandaloneExpression: true,
 				},
 				Kind: variable.ResourceVariableKindStatic,
@@ -96,7 +96,7 @@ func Test_RuntimeWorkflow(t *testing.T) {
 			{
 				FieldDescriptor: variable.FieldDescriptor{
 					Path:                 "metadata.name",
-					Expressions:          []string{"spec.appName + '-config'"},
+					Expressions:          []string{"schema.spec.appName + '-config'"},
 					StandaloneExpression: true,
 				},
 				Kind: variable.ResourceVariableKindStatic,
@@ -104,7 +104,7 @@ func Test_RuntimeWorkflow(t *testing.T) {
 			{
 				FieldDescriptor: variable.FieldDescriptor{
 					Path:                 "data.DB_NAME",
-					Expressions:          []string{"spec.config.dbName"},
+					Expressions:          []string{"schema.spec.config.dbName"},
 					StandaloneExpression: true,
 				},
 				Kind: variable.ResourceVariableKindStatic,
@@ -112,7 +112,7 @@ func Test_RuntimeWorkflow(t *testing.T) {
 			{
 				FieldDescriptor: variable.FieldDescriptor{
 					Path:                 "data.DB_PORT",
-					Expressions:          []string{"spec.config.port"},
+					Expressions:          []string{"schema.spec.config.port"},
 					StandaloneExpression: true,
 				},
 				Kind: variable.ResourceVariableKindStatic,
@@ -123,16 +123,16 @@ func Test_RuntimeWorkflow(t *testing.T) {
 	deployment := newTestResource(
 		withObject(map[string]interface{}{
 			"metadata": map[string]interface{}{
-				"name": "${spec.appName}",
+				"name": "${schema.spec.appName}",
 			},
 			"spec": map[string]interface{}{
 				"selector": map[string]interface{}{
-					"app": "${spec.appName}",
+					"app": "${schema.spec.appName}",
 				},
 				"template": map[string]interface{}{
 					"metadata": map[string]interface{}{
 						"labels": map[string]interface{}{
-							"app": "${spec.appName}",
+							"app": "${schema.spec.appName}",
 						},
 					},
 					"spec": map[string]interface{}{
@@ -155,7 +155,7 @@ func Test_RuntimeWorkflow(t *testing.T) {
 			{
 				FieldDescriptor: variable.FieldDescriptor{
 					Path:                 "metadata.name",
-					Expressions:          []string{"spec.appName"},
+					Expressions:          []string{"schema.spec.appName"},
 					StandaloneExpression: true,
 				},
 				Kind: variable.ResourceVariableKindStatic,
@@ -175,7 +175,7 @@ func Test_RuntimeWorkflow(t *testing.T) {
 	service := newTestResource(
 		withObject(map[string]interface{}{
 			"metadata": map[string]interface{}{
-				"name": "${spec.appName}-svc",
+				"name": "${schema.spec.appName}-svc",
 			},
 			"spec": map[string]interface{}{
 				"selector": map[string]interface{}{
@@ -187,7 +187,7 @@ func Test_RuntimeWorkflow(t *testing.T) {
 			{
 				FieldDescriptor: variable.FieldDescriptor{
 					Path:                 "metadata.name",
-					Expressions:          []string{"spec.appName"},
+					Expressions:          []string{"schema.spec.appName"},
 					StandaloneExpression: true,
 				},
 				Kind: variable.ResourceVariableKindStatic,
@@ -381,12 +381,12 @@ func Test_NewResourceGroupRuntime(t *testing.T) {
 	deployment := newTestResource(
 		withObject(map[string]interface{}{
 			"spec": map[string]interface{}{
-				"replicas": "${spec.replicas}",
+				"replicas": "${schema.spec.replicas}",
 				"template": map[string]interface{}{
 					"spec": map[string]interface{}{
 						"containers": []interface{}{
 							map[string]interface{}{
-								"image": "${spec.image}",
+								"image": "${schema.spec.image}",
 							},
 						},
 					},
@@ -397,7 +397,7 @@ func Test_NewResourceGroupRuntime(t *testing.T) {
 			{
 				FieldDescriptor: variable.FieldDescriptor{
 					Path:                 "spec.replicas",
-					Expressions:          []string{"spec.replicas"},
+					Expressions:          []string{"schema.spec.replicas"},
 					StandaloneExpression: true,
 				},
 				Kind: variable.ResourceVariableKindStatic,
@@ -405,7 +405,7 @@ func Test_NewResourceGroupRuntime(t *testing.T) {
 			{
 				FieldDescriptor: variable.FieldDescriptor{
 					Path:                 "spec.template.spec.containers[0].image",
-					Expressions:          []string{"spec.image"},
+					Expressions:          []string{"schema.spec.image"},
 					StandaloneExpression: true,
 				},
 				Kind: variable.ResourceVariableKindStatic,
@@ -447,8 +447,8 @@ func Test_NewResourceGroupRuntime(t *testing.T) {
 	// Test 1: Check expressionsCache initialization
 	expectedExpressions := map[string]struct{}{
 		"deployment.spec.replicas": {},
-		"spec.replicas":            {},
-		"spec.image":               {},
+		"schema.spec.replicas":     {},
+		"schema.spec.image":        {},
 		"deployment.spec.selector": {},
 	}
 
@@ -1367,14 +1367,14 @@ func Test_evaluateStaticVariables(t *testing.T) {
 			),
 			expressionsCache: map[string]*expressionEvaluationState{
 				"expr1": {
-					Expression: "spec.value",
+					Expression: "schema.spec.value",
 					Kind:       variable.ResourceVariableKindStatic,
 					Resolved:   false,
 				},
 			},
 			wantCache: map[string]*expressionEvaluationState{
 				"expr1": {
-					Expression:    "spec.value",
+					Expression:    "schema.spec.value",
 					Kind:          variable.ResourceVariableKindStatic,
 					Resolved:      true,
 					ResolvedValue: int64(42),
@@ -1392,7 +1392,7 @@ func Test_evaluateStaticVariables(t *testing.T) {
 			),
 			expressionsCache: map[string]*expressionEvaluationState{
 				"expr1": {
-					Expression: "spec.value",
+					Expression: "schema.spec.value",
 					Kind:       variable.ResourceVariableKindStatic,
 					Resolved:   false,
 				},
@@ -1404,7 +1404,7 @@ func Test_evaluateStaticVariables(t *testing.T) {
 			},
 			wantCache: map[string]*expressionEvaluationState{
 				"expr1": {
-					Expression:    "spec.value",
+					Expression:    "schema.spec.value",
 					Kind:          variable.ResourceVariableKindStatic,
 					Resolved:      true,
 					ResolvedValue: int64(42),
@@ -2312,7 +2312,7 @@ func Test_WantToCreateResource(t *testing.T) {
 		{
 			name: "spec based condition",
 			resource: newTestResource(
-				withConditions([]string{"spec.enabled == true"}),
+				withConditions([]string{"schema.spec.enabled == true"}),
 			),
 			instanceSpec: map[string]interface{}{
 				"enabled": true,

--- a/test/integration/suites/ackekscluster/generator.go
+++ b/test/integration/suites/ackekscluster/generator.go
@@ -281,16 +281,16 @@ func clusterDef(namespace string) map[string]interface{} {
 		"apiVersion": "eks.services.k8s.aws/v1alpha1",
 		"kind":       "Cluster",
 		"metadata": map[string]interface{}{
-			"name":      "${spec.name}",
+			"name":      "${schema.spec.name}",
 			"namespace": namespace,
 		},
 		"spec": map[string]interface{}{
-			"name": "${spec.name}",
+			"name": "${schema.spec.name}",
 			"accessConfig": map[string]interface{}{
 				"authenticationMode": "API_AND_CONFIG_MAP",
 			},
 			"roleARN": "${clusterRole.status.ackResourceMetadata.arn}",
-			"version": "${spec.version}",
+			"version": "${schema.spec.version}",
 			"resourcesVPCConfig": map[string]interface{}{
 				"endpointPrivateAccess": false,
 				"endpointPublicAccess":  true,

--- a/test/integration/suites/core/conditional_test.go
+++ b/test/integration/suites/core/conditional_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Conditions", func() {
 				"apiVersion": "apps/v1",
 				"kind":       "Deployment",
 				"metadata": map[string]interface{}{
-					"name": "${spec.name}-a",
+					"name": "${schema.spec.name}-a",
 				},
 				"spec": map[string]interface{}{
 					"replicas": 1,
@@ -89,7 +89,7 @@ var _ = Describe("Conditions", func() {
 						"spec": map[string]interface{}{
 							"containers": []interface{}{
 								map[string]interface{}{
-									"name":  "${spec.name}-deployment",
+									"name":  "${schema.spec.name}-deployment",
 									"image": "nginx",
 									"ports": []interface{}{
 										map[string]interface{}{
@@ -101,13 +101,13 @@ var _ = Describe("Conditions", func() {
 						},
 					},
 				},
-			}, nil, []string{"${spec.deploymentAenabled}"}),
+			}, nil, []string{"${schema.spec.deploymentAenabled}"}),
 			// Depends on serviceAccountA
 			generator.WithResource("deploymentB", map[string]interface{}{
 				"apiVersion": "apps/v1",
 				"kind":       "Deployment",
 				"metadata": map[string]interface{}{
-					"name": "${spec.name}-b",
+					"name": "${schema.spec.name}-b",
 				},
 				"spec": map[string]interface{}{
 					"replicas": 1,
@@ -126,7 +126,7 @@ var _ = Describe("Conditions", func() {
 							"serviceAccountName": "${serviceAccountA.metadata.name}",
 							"containers": []interface{}{
 								map[string]interface{}{
-									"name":  "${spec.name}-deployment",
+									"name":  "${schema.spec.name}-deployment",
 									"image": "nginx",
 									"ports": []interface{}{
 										map[string]interface{}{
@@ -138,15 +138,15 @@ var _ = Describe("Conditions", func() {
 						},
 					},
 				},
-			}, nil, []string{"${spec.deploymentBenabled}"}),
+			}, nil, []string{"${schema.spec.deploymentBenabled}"}),
 			// serviceAccountA - no dependencies
 			generator.WithResource("serviceAccountA", map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "ServiceAccount",
 				"metadata": map[string]interface{}{
-					"name": "${spec.name}-a",
+					"name": "${schema.spec.name}-a",
 				},
-			}, nil, []string{"${spec.serviceAccountAenabled}"}),
+			}, nil, []string{"${schema.spec.serviceAccountAenabled}"}),
 			// ServiceAccount - depends on service
 			generator.WithResource("serviceAccountB", map[string]interface{}{
 				"apiVersion": "v1",
@@ -154,7 +154,7 @@ var _ = Describe("Conditions", func() {
 				"metadata": map[string]interface{}{
 					"name": "${serviceA.metadata.name}",
 				},
-			}, nil, []string{"${spec.serviceAccountBenabled}"}),
+			}, nil, []string{"${schema.spec.serviceAccountBenabled}"}),
 			// ServiceA - depends on DeploymentA
 			generator.WithResource("serviceA", map[string]interface{}{
 				"apiVersion": "v1",
@@ -192,7 +192,7 @@ var _ = Describe("Conditions", func() {
 						},
 					},
 				},
-			}, nil, []string{"${spec.serviceBenabled}"}),
+			}, nil, []string{"${schema.spec.serviceBenabled}"}),
 		)
 
 		// Create ResourceGroup

--- a/test/integration/suites/core/crd_test.go
+++ b/test/integration/suites/core/crd_test.go
@@ -63,11 +63,11 @@ var _ = Describe("CRD", func() {
 					"apiVersion": "v1",
 					"kind":       "ConfigMap",
 					"metadata": map[string]interface{}{
-						"name": "${spec.field1}",
+						"name": "${schema.spec.field1}",
 					},
 					"data": map[string]interface{}{
 						"key":  "value",
-						"key2": "${spec.field2}",
+						"key2": "${schema.spec.field2}",
 					},
 				}, nil, nil),
 			)

--- a/test/integration/suites/core/readiness_test.go
+++ b/test/integration/suites/core/readiness_test.go
@@ -68,10 +68,10 @@ var _ = Describe("Readiness", func() {
 				"apiVersion": "apps/v1",
 				"kind":       "Deployment",
 				"metadata": map[string]interface{}{
-					"name": "${spec.name}",
+					"name": "${schema.spec.name}",
 				},
 				"spec": map[string]interface{}{
-					"replicas": "${spec.replicas}",
+					"replicas": "${schema.spec.replicas}",
 					"selector": map[string]interface{}{
 						"matchLabels": map[string]interface{}{
 							"app": "deployment",
@@ -86,7 +86,7 @@ var _ = Describe("Readiness", func() {
 						"spec": map[string]interface{}{
 							"containers": []interface{}{
 								map[string]interface{}{
-									"name":  "${spec.name}-deployment",
+									"name":  "${schema.spec.name}-deployment",
 									"image": "nginx",
 									"ports": []interface{}{
 										map[string]interface{}{

--- a/test/integration/suites/core/status_test.go
+++ b/test/integration/suites/core/status_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Status", func() {
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
 				"metadata": map[string]interface{}{
-					"name": "${spec.field1}",
+					"name": "${schema.spec.field1}",
 				},
 			}, nil, nil),
 		)

--- a/test/integration/suites/core/topology_test.go
+++ b/test/integration/suites/core/topology_test.go
@@ -119,12 +119,12 @@ var _ = Describe("Topology", func() {
 				"apiVersion": "eks.services.k8s.aws/v1alpha1",
 				"kind":       "Cluster",
 				"metadata": map[string]interface{}{
-					"name": "${spec.name}",
+					"name": "${schema.spec.name}",
 				},
 				"spec": map[string]interface{}{
-					"name":    "${spec.name}",
+					"name":    "${schema.spec.name}",
 					"roleARN": "${clusterRole.status.ackResourceMetadata.arn}",
-					"version": "${spec.version}",
+					"version": "${schema.spec.version}",
 					"resourcesVPCConfig": map[string]interface{}{
 						"subnetIDs": []interface{}{
 							"${subnetA.status.subnetID}",

--- a/test/integration/suites/deploymentservice/generator.go
+++ b/test/integration/suites/deploymentservice/generator.go
@@ -68,7 +68,7 @@ func deploymentDef() map[string]interface{} {
 		"apiVersion": "apps/v1",
 		"kind":       "Deployment",
 		"metadata": map[string]interface{}{
-			"name": "${spec.name}",
+			"name": "${schema.spec.name}",
 		},
 		"spec": map[string]interface{}{
 			"replicas": 1,
@@ -86,11 +86,11 @@ func deploymentDef() map[string]interface{} {
 				"spec": map[string]interface{}{
 					"containers": []interface{}{
 						map[string]interface{}{
-							"name":  "${spec.name}-deployment",
+							"name":  "${schema.spec.name}-deployment",
 							"image": "nginx",
 							"ports": []interface{}{
 								map[string]interface{}{
-									"containerPort": "${spec.port}",
+									"containerPort": "${schema.spec.port}",
 								},
 							},
 						},
@@ -106,7 +106,7 @@ func serviceDef() map[string]interface{} {
 		"apiVersion": "v1",
 		"kind":       "Service",
 		"metadata": map[string]interface{}{
-			"name": "${spec.name}",
+			"name": "${schema.spec.name}",
 		},
 		"spec": map[string]interface{}{
 			"selector": map[string]interface{}{
@@ -114,8 +114,8 @@ func serviceDef() map[string]interface{} {
 			},
 			"ports": []interface{}{
 				map[string]interface{}{
-					"port":       "${spec.port}",
-					"targetPort": "${spec.port}",
+					"port":       "${schema.spec.port}",
+					"targetPort": "${schema.spec.port}",
 				},
 			},
 		},

--- a/test/integration/suites/networkingstack/generator.go
+++ b/test/integration/suites/networkingstack/generator.go
@@ -74,7 +74,7 @@ func vpcDef() map[string]interface{} {
 		"apiVersion": "ec2.services.k8s.aws/v1alpha1",
 		"kind":       "VPC",
 		"metadata": map[string]interface{}{
-			"name": "vpc-${spec.name}",
+			"name": "vpc-${schema.spec.name}",
 		},
 		"spec": map[string]interface{}{
 			"cidrBlocks": []interface{}{
@@ -91,7 +91,7 @@ func subnetDef(suffix, az, cidr string) map[string]interface{} {
 		"apiVersion": "ec2.services.k8s.aws/v1alpha1",
 		"kind":       "Subnet",
 		"metadata": map[string]interface{}{
-			"name": "subnet-" + suffix + "-${spec.name}",
+			"name": "subnet-" + suffix + "-${schema.spec.name}",
 		},
 		"spec": map[string]interface{}{
 			"availabilityZone": az,
@@ -106,11 +106,11 @@ func securityGroupDef() map[string]interface{} {
 		"apiVersion": "ec2.services.k8s.aws/v1alpha1",
 		"kind":       "SecurityGroup",
 		"metadata": map[string]interface{}{
-			"name": "security-group-${spec.name}",
+			"name": "security-group-${schema.spec.name}",
 		},
 		"spec": map[string]interface{}{
 			"vpcID":       "${vpc.status.vpcID}",
-			"name":        "my-sg-${spec.name}",
+			"name":        "my-sg-${schema.spec.name}",
 			"description": "something something",
 		},
 	}

--- a/website/docs/docs/concepts/00-resource-groups.md
+++ b/website/docs/docs/concepts/00-resource-groups.md
@@ -52,29 +52,29 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         metadata:
-          name: ${spec.appName}-deployment
+          name: ${schema.spec.appName}-deployment
         spec:
-          replicas: ${spec.replicas}
+          replicas: ${schema.spec.replicas}
           selector:
             matchLabels:
-              app: ${spec.appName}
+              app: ${schema.spec.appName}
           template:
             metadata:
               labels:
-                app: ${spec.appName}
+                app: ${schema.spec.appName}
             spec:
               containers:
-                - name: ${spec.appName}-container
-                  image: ${spec.image}
+                - name: ${schema.spec.appName}-container
+                  image: ${schema.spec.image}
     - name: service
       definition:
         apiVersion: v1
         kind: Service
         metadata:
-          name: ${spec.appName}-service
+          name: ${schema.spec.appName}-service
         spec:
           selector:
-            app: ${spec.appName}
+            app: ${schema.spec.appName}
           ports:
             - port: 80
               targetPort: 80

--- a/website/docs/docs/concepts/20-collections.md
+++ b/website/docs/docs/concepts/20-collections.md
@@ -36,7 +36,7 @@ spec:
   resources:
     - name: nodesCollection
       collection:
-        index: ${range(0, spec.podCount)}
+        index: ${range(0, schema.spec.podCount)}
         definition:
           apiVersion: v1
           kind: Pod
@@ -105,7 +105,7 @@ spec:
     - name: nodes
       strategy: RollingUpdate
       collection:
-        index: ${range(0, spec.podCount)}
+        index: ${range(0, schema.spec.podCount)}
         definition:
           apiVersion: v1
           kind: Pod

--- a/website/docs/docs/getting-started/02-deploy-a-resource-group.md
+++ b/website/docs/docs/getting-started/02-deploy-a-resource-group.md
@@ -35,7 +35,7 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         metadata:
-          name: ${spec.name}
+          name: ${schema.spec.name}
         spec:
           replicas: 1
           selector:
@@ -47,7 +47,7 @@ spec:
                 app: deployment
             spec:
               containers:
-                - name: ${spec.name}-deployment
+                - name: ${schema.spec.name}-deployment
                   image: nginx
                   ports:
                     - containerPort: 80
@@ -56,7 +56,7 @@ spec:
         apiVersion: v1
         kind: Service
         metadata:
-          name: ${spec.name}
+          name: ${schema.spec.name}
         spec:
           selector:
             app: deployment

--- a/website/docs/examples/deploymentdbinstance.md
+++ b/website/docs/examples/deploymentdbinstance.md
@@ -27,11 +27,11 @@ spec:
         apiVersion: rds.saervices.k8s.aws/v1alpha1
         kind: DBInstance
         metadata:
-          name: ${spec.applicationName}-dbinstance
+          name: ${schema.spec.applicationName}-dbinstance
         spec:
           # need to specify the required fields (e.g masterUsername, masterPassword)
           engine: postgres
-          dbInstanceIdentifier: ${spec.applicationName}-dbinstance
+          dbInstanceIdentifier: ${schema.spec.applicationName}-dbinstance
           allocatedStorage: 20
           dbInstanceClass: db.t3.micro
 
@@ -40,11 +40,11 @@ spec:
         apiVersion: v1
         kind: Pod
         metadata:
-          name: ${spec.applicationName}-pod
+          name: ${schema.spec.applicationName}-pod
         spec:
           containers:
             - name: container1
-              image: ${spec.image}
+              image: ${schema.spec.image}
               env:
                 - name: POSTGRESS_ENDPOINT
                   value: ${dbinstance.status.endpoint.address}

--- a/website/docs/examples/deploymentservice.md
+++ b/website/docs/examples/deploymentservice.md
@@ -21,7 +21,7 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         metadata:
-          name: ${spec.name}
+          name: ${schema.spec.name}
         spec:
           replicas: 1
           selector:
@@ -33,7 +33,7 @@ spec:
                 app: deployment
             spec:
               containers:
-                - name: ${spec.name}-deployment
+                - name: ${schema.spec.name}-deployment
                   image: nginx
                   ports:
                     - containerPort: 80
@@ -42,7 +42,7 @@ spec:
         apiVersion: v1
         kind: Service
         metadata:
-          name: ${spec.name}
+          name: ${schema.spec.name}
         spec:
           selector:
             app: deployment

--- a/website/docs/examples/ekscluster.md
+++ b/website/docs/examples/ekscluster.md
@@ -27,7 +27,7 @@ spec:
         apiVersion: ec2.services.k8s.aws/v1alpha1
         kind: VPC
         metadata:
-          name: cluster-vpc-${spec.name}
+          name: cluster-vpc-${schema.spec.name}
         spec:
           cidrBlocks:
             - 192.168.0.0/16
@@ -39,7 +39,7 @@ spec:
         apiVersion: ec2.services.k8s.aws/v1alpha1
         kind: Subnet
         metadata:
-          name: cluster-subnet-a-${spec.name}
+          name: cluster-subnet-a-${schema.spec.name}
         spec:
           availabilityZone: us-west-2a
           cidrBlock: 192.168.0.0/18
@@ -50,10 +50,10 @@ spec:
         apiVersion: ec2.services.k8s.aws/v1alpha1
         kind: SecurityGroup
         metadata:
-          name: cluster-security-group-${spec.name}
+          name: cluster-security-group-${schema.spec.name}
         spec:
           vpcID: ${clusterVPC.status.vpcID}
-          name: my-eks-cluster-sg-${spec.name}
+          name: my-eks-cluster-sg-${schema.spec.name}
           description: something something
 
     - name: subnetAZB
@@ -61,7 +61,7 @@ spec:
         apiVersion: ec2.services.k8s.aws/v1alpha1
         kind: Subnet
         metadata:
-          name: cluster-subnet-b-${spec.name}
+          name: cluster-subnet-b-${schema.spec.name}
         spec:
           availabilityZone: us-west-2b
           cidrBlock: 192.168.64.0/18
@@ -72,9 +72,9 @@ spec:
         apiVersion: iam.services.k8s.aws/v1alpha1
         kind: Role
         metadata:
-          name: cluster-role-${spec.name}
+          name: cluster-role-${schema.spec.name}
         spec:
-          name: cluster-role-${spec.name}
+          name: cluster-role-${schema.spec.name}
           policies:
             - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
           assumeRolePolicyDocument: |
@@ -96,9 +96,9 @@ spec:
         apiVersion: iam.services.k8s.aws/v1alpha1
         kind: Role
         metadata:
-          name: cluster-node-role-${spec.name}
+          name: cluster-node-role-${schema.spec.name}
         spec:
-          name: cluster-node-role-${spec.name}
+          name: cluster-node-role-${schema.spec.name}
           policies:
             - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
             - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
@@ -122,11 +122,11 @@ spec:
         apiVersion: eks.services.k8s.aws/v1alpha1
         kind: Cluster
         metadata:
-          name: cluster-${spec.name}
+          name: cluster-${schema.spec.name}
         spec:
-          name: cluster-${spec.name}
+          name: cluster-${schema.spec.name}
           roleARN: ${clusterRole.status.ackResourceMetadata.arn}
-          version: ${spec.version}
+          version: ${schema.spec.version}
           resourcesVPCConfig:
             subnetIDs:
               - ${subnetAZA.status.subnetID}
@@ -137,10 +137,10 @@ spec:
         apiVersion: eks.services.k8s.aws/v1alpha1
         kind: Nodegroup
         metadata:
-          name: nodegroup-${spec.name}
+          name: nodegroup-${schema.spec.name}
         spec:
-          name: nodegroup-${spec.name}
-          clusterName: cluster-${spec.name}
+          name: nodegroup-${schema.spec.name}
+          clusterName: cluster-${schema.spec.name}
           subnets:
             - ${subnetAZA.status.subnetID}
             - ${subnetAZB.status.subnetID}
@@ -148,7 +148,7 @@ spec:
           updateConfig:
             maxUnavailable: 1
           scalingConfig:
-            minSize: ${spec.numNodes}
-            maxSize: ${spec.numNodes}
-            desiredSize: ${spec.numNodes}
+            minSize: ${schema.spec.numNodes}
+            maxSize: ${schema.spec.numNodes}
+            desiredSize: ${schema.spec.numNodes}
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change is introduced to ensure we know which spec we're referencing. We are still only able to reference the `spec` and the `metadata` of the schema.

This change also affects how we reference schema variables when compiling `includeWhen` expressions

changing from
```yaml
name: ${spec.name}
```

to
```yaml
name: ${schema.spec.name}
```

more examples in files changed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
