### PR TITLE
refactor: rename cel package alias from `scel` to `krocel`

### DIFF
--- a/internal/cel/ast/inspector.go
+++ b/internal/cel/ast/inspector.go
@@ -17,9 +17,10 @@ import (
 	"fmt"
 	"strings"
 
-	scel "github.com/awslabs/kro/internal/cel"
 	"github.com/google/cel-go/cel"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+
+	krocel "github.com/awslabs/kro/internal/cel"
 )
 
 // ResourceDependency represents a resource and its accessed path within a CEL expression.
@@ -117,7 +118,7 @@ func DefaultInspector(resources []string, functions []string) (*Inspector, error
 		functionMap[function] = struct{}{}
 	}
 
-	env, err := scel.DefaultEnvironment(scel.WithCustomDeclarations(declarations))
+	env, err := krocel.DefaultEnvironment(krocel.WithCustomDeclarations(declarations))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CEL environment: %v", err)
 	}

--- a/internal/graph/builder.go
+++ b/internal/graph/builder.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/awslabs/kro/api/v1alpha1"
-	scel "github.com/awslabs/kro/internal/cel"
+	krocel "github.com/awslabs/kro/internal/cel"
 	"github.com/awslabs/kro/internal/cel/ast"
 	"github.com/awslabs/kro/internal/graph/crd"
 	"github.com/awslabs/kro/internal/graph/dag"
@@ -356,7 +356,7 @@ func (b *Builder) buildDependencyGraph(
 	// We also want to allow users to refer to the instance spec in their expressions.
 	resourceNames = append(resourceNames, "schema")
 
-	env, err := scel.DefaultEnvironment(scel.WithResourceNames(resourceNames))
+	env, err := krocel.DefaultEnvironment(krocel.WithResourceNames(resourceNames))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
 	}
@@ -465,7 +465,7 @@ func (b *Builder) buildInstanceResource(
 	}
 
 	resourceNames := maps.Keys(resources)
-	env, err := scel.DefaultEnvironment(scel.WithResourceNames(resourceNames))
+	env, err := krocel.DefaultEnvironment(krocel.WithResourceNames(resourceNames))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
 	}
@@ -558,7 +558,7 @@ func buildStatusSchema(
 	// Inspection of the CEL expressions to infer the types of the status fields.
 	resourceNames := maps.Keys(resources)
 
-	env, err := scel.DefaultEnvironment(scel.WithResourceNames(resourceNames))
+	env, err := krocel.DefaultEnvironment(krocel.WithResourceNames(resourceNames))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create CEL environment: %w", err)
 	}
@@ -688,7 +688,7 @@ func validateResourceCELExpressions(resources map[string]*Resource, instance *Re
 	resourceNames = append(resourceNames, "schema")
 	conditionFieldNames := []string{"schema"}
 
-	env, err := scel.DefaultEnvironment(scel.WithResourceNames(resourceNames))
+	env, err := krocel.DefaultEnvironment(krocel.WithResourceNames(resourceNames))
 	if err != nil {
 		return fmt.Errorf("failed to create CEL environment: %w", err)
 	}
@@ -737,7 +737,7 @@ func validateResourceCELExpressions(resources map[string]*Resource, instance *Re
 			// I would also suggest separating the dryRuns of readyWhenExpressions
 			// and the resourceExpressions.
 			for _, readyWhenExpression := range resource.readyWhenExpressions {
-				fieldEnv, err := scel.DefaultEnvironment(scel.WithResourceNames([]string{resource.id}))
+				fieldEnv, err := krocel.DefaultEnvironment(krocel.WithResourceNames([]string{resource.id}))
 				if err != nil {
 					return fmt.Errorf("failed to create CEL environment: %w", err)
 				}
@@ -762,13 +762,13 @@ func validateResourceCELExpressions(resources map[string]*Resource, instance *Re
 				if err != nil {
 					return fmt.Errorf("failed to dry-run expression %s: %w", readyWhenExpression, err)
 				}
-				if !scel.IsBoolType(output) {
+				if !krocel.IsBoolType(output) {
 					return fmt.Errorf("output of readyWhen expression %s can only be of type bool", readyWhenExpression)
 				}
 			}
 
 			for _, includeWhenExpression := range resource.includeWhenExpressions {
-				instanceEnv, err := scel.DefaultEnvironment(scel.WithResourceNames(resourceNames))
+				instanceEnv, err := krocel.DefaultEnvironment(krocel.WithResourceNames(resourceNames))
 				if err != nil {
 					return fmt.Errorf("failed to create CEL environment: %w", err)
 				}
@@ -792,7 +792,7 @@ func validateResourceCELExpressions(resources map[string]*Resource, instance *Re
 				if err != nil {
 					return fmt.Errorf("failed to dry-run expression %s: %w", includeWhenExpression, err)
 				}
-				if !scel.IsBoolType(output) {
+				if !krocel.IsBoolType(output) {
 					return fmt.Errorf("output of condition expression %s can only be of type bool", includeWhenExpression)
 				}
 			}

--- a/internal/graph/schema/conversion_cel.go
+++ b/internal/graph/schema/conversion_cel.go
@@ -19,7 +19,7 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
-	scel "github.com/awslabs/kro/internal/cel"
+	krocel "github.com/awslabs/kro/internal/cel"
 )
 
 // inferSchemaFromCELValue infers a JSONSchemaProps from a CEL value.
@@ -27,7 +27,7 @@ func inferSchemaFromCELValue(val ref.Val) (*extv1.JSONSchemaProps, error) {
 	if val == nil {
 		return nil, fmt.Errorf("value is nil")
 	}
-	goRuntimeVal, err := scel.GoNativeType(val)
+	goRuntimeVal, err := krocel.GoNativeType(val)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert CEL value to Go: %w", err)
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	scel "github.com/awslabs/kro/internal/cel"
+	krocel "github.com/awslabs/kro/internal/cel"
 	"github.com/awslabs/kro/internal/graph/variable"
 	"github.com/awslabs/kro/internal/runtime/resolver"
 )
@@ -302,7 +302,7 @@ func (rt *ResourceGroupRuntime) resourceVariablesResolved(resource string) bool 
 // depending only on the initial configuration. This function is usually
 // called once during runtime initialization to set up the baseline state
 func (rt *ResourceGroupRuntime) evaluateStaticVariables() error {
-	env, err := scel.DefaultEnvironment(scel.WithResourceNames([]string{"schema"}))
+	env, err := krocel.DefaultEnvironment(krocel.WithResourceNames([]string{"schema"}))
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ func (rt *ResourceGroupRuntime) evaluateDynamicVariables() error {
 	// and are resolved after all the dependencies are resolved.
 
 	resolvedResources := maps.Keys(rt.resolvedResources)
-	env, err := scel.DefaultEnvironment(scel.WithResourceNames(resolvedResources))
+	env, err := krocel.DefaultEnvironment(krocel.WithResourceNames(resolvedResources))
 	if err != nil {
 		return err
 	}
@@ -474,7 +474,7 @@ func (rt *ResourceGroupRuntime) IsResourceReady(resourceID string) (bool, string
 
 	// we should not expect errors here since we already compiled it
 	// in the dryRun
-	env, err := scel.DefaultEnvironment(scel.WithResourceNames([]string{resourceID}))
+	env, err := krocel.DefaultEnvironment(krocel.WithResourceNames([]string{resourceID}))
 	if err != nil {
 		return false, "", fmt.Errorf("failed creating new Environment: %w", err)
 	}
@@ -530,7 +530,7 @@ func (rt *ResourceGroupRuntime) WantToCreateResource(resourceID string) (bool, e
 
 	// we should not expect errors here since we already compiled it
 	// in the dryRun
-	env, err := scel.DefaultEnvironment(scel.WithResourceNames([]string{"schema"}))
+	env, err := krocel.DefaultEnvironment(krocel.WithResourceNames([]string{"schema"}))
 	if err != nil {
 		return false, nil
 	}
@@ -572,7 +572,7 @@ func evaluateExpression(env *cel.Env, context map[string]interface{}, expression
 		return nil, fmt.Errorf("failed evaluating expression %s: %w", expression, err)
 	}
 
-	return scel.GoNativeType(val)
+	return krocel.GoNativeType(val)
 }
 
 // containsAllElements checks if all elements in the inner slice are present

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	scel "github.com/awslabs/kro/internal/cel"
+	krocel "github.com/awslabs/kro/internal/cel"
 	"github.com/awslabs/kro/internal/graph/variable"
 )
 
@@ -2463,7 +2463,7 @@ func Test_areDependenciesIgnored(t *testing.T) {
 }
 
 func setupTestEnv(names []string) (*cel.Env, error) {
-	return scel.DefaultEnvironment(scel.WithResourceNames(names))
+	return krocel.DefaultEnvironment(krocel.WithResourceNames(names))
 }
 
 func Test_evaluateExpression(t *testing.T) {


### PR DESCRIPTION
Renames the internal/cel package alias from `scel` to `krocel` throughout
the codebase for better clarity and consistency with the project's naming
conventions. The 'kro' prefix better indicates this is Kro's CEL helper
methods.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
