### PR TITLE
refactor(schema): remove unused custom types from `SimpleSchema`

### DIFF
--- a/api/v1alpha1/resource_group.go
+++ b/api/v1alpha1/resource_group.go
@@ -66,9 +66,6 @@ type Schema struct {
 	// that the resourcegroup is managing. This is adhering to the
 	// SimpleSchema spec.
 	Status runtime.RawExtension `json:"status,omitempty"`
-	// Types are custom types that are used to simplify the spec and
-	// status.
-	Types runtime.RawExtension `json:"types,omitempty"`
 	// Validation is a list of validation rules that are applied to the
 	// resourcegroup.
 	// Not implemented yet.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -247,7 +247,6 @@ func (in *Schema) DeepCopyInto(out *Schema) {
 	*out = *in
 	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
-	in.Types.DeepCopyInto(&out.Types)
 	if in.Validation != nil {
 		in, out := &in.Validation, &out.Validation
 		*out = make([]string, len(*in))

--- a/config/crd/bases/kro.run_resourcegroups.yaml
+++ b/config/crd/bases/kro.run_resourcegroups.yaml
@@ -119,12 +119,6 @@ spec:
                       SimpleSchema spec.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
-                  types:
-                    description: |-
-                      Types are custom types that are used to simplify the spec and
-                      status.
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
                   validation:
                     description: |-
                       Validation is a list of validation rules that are applied to the

--- a/internal/graph/builder.go
+++ b/internal/graph/builder.go
@@ -509,22 +509,16 @@ func (b *Builder) buildInstanceResource(
 // used to generate the CRD for the instance resource. The instance spec
 // schema is expected to be defined using the "SimpleSchema" format.
 func buildInstanceSpecSchema(rgSchema *v1alpha1.Schema) (*extv1.JSONSchemaProps, error) {
-	customTypes := map[string]interface{}{}
-	err := yaml.UnmarshalStrict(rgSchema.Types.Raw, &customTypes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal types schema: %w", err)
-	}
-
 	// We need to unmarshal the instance schema to a map[string]interface{} to
 	// make it easier to work with.
-	unstructuredInstance := map[string]interface{}{}
-	err = yaml.UnmarshalStrict(rgSchema.Spec.Raw, &unstructuredInstance)
+	instanceSpec := map[string]interface{}{}
+	err := yaml.UnmarshalStrict(rgSchema.Spec.Raw, &instanceSpec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal spec schema: %w", err)
 	}
 
 	// The instance resource has a schema defined using the "SimpleSchema" format.
-	instanceSchema, err := simpleschema.NewTransformer().BuildOpenAPISchema(unstructuredInstance)
+	instanceSchema, err := simpleschema.ToOpenAPISpec(instanceSpec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build OpenAPI schema for instance: %v", err)
 	}

--- a/internal/simpleschema/simplerschema.go
+++ b/internal/simpleschema/simplerschema.go
@@ -1,0 +1,34 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package simpleschema
+
+import (
+	"fmt"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// ToOpenAPISpec converts a SimpleSchema object to an OpenAPI schema.
+//
+// The input object is a map[string]interface{} where the key is the field name
+// and the value is the field type.
+func ToOpenAPISpec(obj map[string]interface{}) (*extv1.JSONSchemaProps, error) {
+	tf := newTransformer()
+	return tf.buildOpenAPISchema(obj)
+}
+
+// FromOpenAPISpec converts an OpenAPI schema to a SimpleSchema object.
+func FromOpenAPISpec(schema *extv1.JSONSchemaProps) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/internal/simpleschema/transform_test.go
+++ b/internal/simpleschema/transform_test.go
@@ -21,10 +21,10 @@ import (
 )
 
 func TestBuildOpenAPISchema(t *testing.T) {
-	transformer := NewTransformer()
+	transformer := newTransformer()
 
 	// Load pre-defined types
-	err := transformer.LoadPreDefinedTypes(map[string]interface{}{
+	err := transformer.loadPreDefinedTypes(map[string]interface{}{
 		"Address": map[string]interface{}{
 			"street":  "string",
 			"city":    "string",
@@ -283,7 +283,7 @@ func TestBuildOpenAPISchema(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := transformer.BuildOpenAPISchema(tt.obj)
+			got, err := transformer.buildOpenAPISchema(tt.obj)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildOpenAPISchema() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -296,7 +296,7 @@ func TestBuildOpenAPISchema(t *testing.T) {
 }
 
 func TestLoadPreDefinedTypes(t *testing.T) {
-	transformer := NewTransformer()
+	transformer := newTransformer()
 
 	preDefinedTypes := map[string]interface{}{
 		"Person": map[string]interface{}{
@@ -313,7 +313,7 @@ func TestLoadPreDefinedTypes(t *testing.T) {
 		},
 	}
 
-	err := transformer.LoadPreDefinedTypes(preDefinedTypes)
+	err := transformer.loadPreDefinedTypes(preDefinedTypes)
 	if err != nil {
 		t.Fatalf("LoadPreDefinedTypes() error = %v", err)
 	}


### PR DESCRIPTION
This patch removes the `Types` field has been removed from the `Schema`
struct as it's currently not supported in KRO. This change include:

- Removing the `Types` field from the `v1alpha1.Schema` struct
- Making the transformer type and its methods private since they're package
  implementation details
- Adding a new public `ToOpenAPISpec` function for external usage

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
