### PR TITLE
github: add issue templates for bug, feature, and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,46 @@
+name: Bug
+description: Report a bug
+labels:
+  - kind/bug
+  - needs-triage
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      value: |
+        <!-- Please craft a detailed description of the documentation issue or suggestion -->
+        <!-- Below are some suggestions but feel free to modify or remove them -->
+
+        **Observed Behavior**:
+
+        **Expected Behavior**:
+
+        **Reproduction Steps** (Please include `ResourceGroup` and `Instances` files):
+
+        **Versions**:
+        - KRO Version:
+        - Kubernetes Version (`kubectl version`):
+
+        **Involved Controllers**:
+        - Controller URLs and Versions (if applicable):
+
+        **Error Logs** (if applicable)**:
+        ```
+        Paste any relevant logs here
+        ```
+
+        * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+        * Please do not leave "+1" or "me too" comments, they generate extra noise for issue followers and do not help prioritize the request
+        * If you are interested in working on this issue or have submitted a pull request, please leave a comment
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Which option describes the most your issue?
+      multiple: true
+      options:
+        - ResourceGroup (Create, Update, Deletion)
+        - Instance (Create, Update, Deletion)
+        - Directed Acyclic Graph inference
+        - Common Expression Language (CEL)
+        - Schema Validation
+        - Others (please specify)

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,24 @@
+name: Documentation
+description: Report documentation issues or suggest improvements
+labels:
+  - kind/documentation
+  - needs-triage
+body:
+  - type: textarea
+    attributes:
+      label: Documentation Issue
+      value: |
+        <!-- Please craft a detailed description of the documentation issue or suggestion -->
+        <!-- Below are some suggestions but feel free to modify or remove them -->
+
+        **Location**:
+        <!-- Specify where the documentation issue is (URL, file path, etc.) -->
+
+        **Current State**:
+        <!-- What does the current documentation say? -->
+
+        **Suggested Changes**:
+        <!-- How should it be improved? -->
+
+        **Additional Context**:
+        <!-- Any additional information that might be helpful -->

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,24 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels:
+  - kind/feature
+  - needs-triage
+body:
+  - type: textarea
+    attributes:
+      label: Feature Description
+      value: |
+        **Problem Statement**:
+        <!-- What problem are you trying to solve? -->
+
+        **Proposed Solution**:
+        <!-- Describe your proposed solution -->
+
+        **Alternatives Considered**:
+        <!-- What alternatives have you considered? -->
+
+        **Additional Context**:
+        <!-- Add any other context about the feature request here -->
+
+        * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue
+        * If you are interested in working on this feature, please leave a comment


### PR DESCRIPTION
Add structured github issue templates to help users provide necessary
information when creating new issues:
- bug template with sections for reproduction steps, versions, logs
- feature request template for capturing requirements and alternatives
- documentation template for tracking doc improvements

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
