### PR TITLE
feat: make ResourceGroup `schema.kind` and `schema.apiVersion` immutable

### DIFF
--- a/api/v1alpha1/resource_group.go
+++ b/api/v1alpha1/resource_group.go
@@ -52,11 +52,13 @@ type Schema struct {
 	// and create the CRD for the resourcegroup.
 	//
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="kind is immutable"
 	Kind string `json:"kind,omitempty"`
 	// The APIVersion of the resourcegroup. This is used to generate
 	// and create the CRD for the resourcegroup.
 	//
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="apiVersion is immutable"
 	APIVersion string `json:"apiVersion,omitempty"`
 	// The spec of the resourcegroup. Typically, this is the spec of
 	// the CRD that the resourcegroup is managing. This is adhering

--- a/config/crd/bases/kro.run_resourcegroups.yaml
+++ b/config/crd/bases/kro.run_resourcegroups.yaml
@@ -100,11 +100,17 @@ spec:
                       The APIVersion of the resourcegroup. This is used to generate
                       and create the CRD for the resourcegroup.
                     type: string
+                    x-kubernetes-validations:
+                    - message: apiVersion is immutable
+                      rule: self == oldSelf
                   kind:
                     description: |-
                       The kind of the resourcegroup. This is used to generate
                       and create the CRD for the resourcegroup.
                     type: string
+                    x-kubernetes-validations:
+                    - message: kind is immutable
+                      rule: self == oldSelf
                   spec:
                     description: |-
                       The spec of the resourcegroup. Typically, this is the spec of


### PR DESCRIPTION
Add CEL validation rules to prevent modifications to the schema `kind` and
`apiVersion` fields after a `ResourceGroup` is created. This ensures schema
stability and  prevents potential issues that could arise from changing
these fundamental identity fields.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
