### PR TITLE
Temporarily disable noisy `ResourceSynced` conditions

### DIFF
--- a/internal/controller/instance/controller_status.go
+++ b/internal/controller/instance/controller_status.go
@@ -79,7 +79,7 @@ func (igr *instanceGraphReconciler) prepareConditions(status map[string]interfac
 		))
 	}
 
-	conditionType := "ResourceSynced"
+	/* conditionType := "ResourceSynced"
 	// Add conditions for each resource
 	for resourceID, resourceState := range resourceStates {
 		if resourceState.Err != nil {
@@ -99,7 +99,7 @@ func (igr *instanceGraphReconciler) prepareConditions(status map[string]interfac
 				generation,
 			))
 		}
-	}
+	} */
 
 	return conditions
 }


### PR DESCRIPTION
Comment out ResourceSynced condition updates in prepareConditions
to reduce status noise/churn. These will be re-enabled once we
determine a better approach for resource sync status reporting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
