### PR TITLE
refactor(instance): improve controller state management and code organization

### DIFF
--- a/internal/controller/instance/controller.go
+++ b/internal/controller/instance/controller.go
@@ -157,10 +157,13 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) error {
 		instanceLabeler:             c.instanceLabeler,
 		instanceSubResourcesLabeler: instanceSubResourcesLabeler,
 		reconcileConfig:             c.reconcileConfig,
+		// Fresh instance state at each reconciliation loop.
+		state: newInstanceState(),
 	}
 	return instanceGraphReconciler.reconcile(ctx)
 }
 
+// getNamespaceName extracts the namespace and name from the request.
 func getNamespaceName(req ctrl.Request) (string, string) {
 	parts := strings.Split(req.Name, "/")
 	name := parts[len(parts)-1]

--- a/internal/controller/instance/controller_status.go
+++ b/internal/controller/instance/controller_status.go
@@ -22,45 +22,57 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/awslabs/kro/api/v1alpha1"
+	"github.com/awslabs/kro/internal/requeue"
 )
 
-// ResourceState represents the state of a resource.
-type ResourceState struct {
-	State string
-	Err   error
+func createCondition(conditionType v1alpha1.ConditionType, status corev1.ConditionStatus, reason, message string, generation int64) map[string]interface{} {
+	return map[string]interface{}{
+		"type":               string(conditionType),
+		"status":             string(status),
+		"reason":             reason,
+		"message":            message,
+		"lastTransitionTime": time.Now().Format(time.RFC3339),
+		"observedGeneration": generation,
+	}
 }
 
-func (igr *instanceGraphReconciler) prepareStatus(instanceState string, reconcileErr error, resourceStates map[string]*ResourceState) map[string]interface{} {
-	// Get what ever is resolved in the status
-	instanceStatus := igr.getResolvedStatus()
+// prepareStatus creates the status object for the instance based on current state.
+func (igr *instanceGraphReconciler) prepareStatus() map[string]interface{} {
+	status := igr.getResolvedStatus()
 	generation := igr.runtime.GetInstance().GetGeneration()
 
-	// Update the instance status with the current state and conditions
-	instanceStatus["state"] = instanceState
-	instanceStatus["conditions"] = igr.prepareConditions(instanceStatus, reconcileErr, resourceStates, generation)
-	return instanceStatus
+	status["state"] = igr.state.State
+	status["conditions"] = igr.prepareConditions(igr.state.ReconcileErr, generation)
+
+	return status
 }
 
+// getResolvedStatus retrieves the current status while preserving non-condition fields.
 func (igr *instanceGraphReconciler) getResolvedStatus() map[string]interface{} {
 	status := map[string]interface{}{
 		"conditions": []interface{}{},
 	}
 
-	resolvedStatus, ok := igr.runtime.GetInstance().Object["status"].(map[string]interface{})
-	if !ok {
-		return status
+	if existingStatus, ok := igr.runtime.GetInstance().Object["status"].(map[string]interface{}); ok {
+		// Copy existing status but reset conditions
+		for k, v := range existingStatus {
+			if k != "conditions" {
+				status[k] = v
+			}
+		}
 	}
 
-	// clear conditions
-	resolvedStatus["conditions"] = []interface{}{}
-
-	return resolvedStatus
+	return status
 }
 
-func (igr *instanceGraphReconciler) prepareConditions(status map[string]interface{}, reconcileErr error, resourceStates map[string]*ResourceState, generation int64) []interface{} {
-	conditions := status["conditions"].([]interface{})
+// prepareConditions creates the conditions array for the instance status.
+func (igr *instanceGraphReconciler) prepareConditions(
+	reconcileErr error,
+	generation int64,
+) []interface{} {
+	var conditions []interface{}
 
-	// Add overall reconciliation condition
+	// Add primary reconciliation condition
 	if reconcileErr != nil {
 		conditions = append(conditions, createCondition(
 			"InstanceSynced",
@@ -79,49 +91,35 @@ func (igr *instanceGraphReconciler) prepareConditions(status map[string]interfac
 		))
 	}
 
-	/* conditionType := "ResourceSynced"
-	// Add conditions for each resource
-	for resourceID, resourceState := range resourceStates {
-		if resourceState.Err != nil {
-			conditions = append(conditions, createCondition(
-				v1alpha1.ConditionType(conditionType),
-				corev1.ConditionFalse,
-				"Resource sync failed",
-				fmt.Sprintf("Resource %s sync failed: %v", resourceID, resourceState.Err),
-				generation,
-			))
-		} else {
-			conditions = append(conditions, createCondition(
-				v1alpha1.ConditionType(conditionType),
-				corev1.ConditionTrue,
-				"Resource synced successfully",
-				fmt.Sprintf("Resource %s synced successfully. status: %s", resourceID, resourceState.State),
-				generation,
-			))
-		}
-	} */
-
 	return conditions
 }
 
+// patchInstanceStatus updates the status subresource of the instance.
 func (igr *instanceGraphReconciler) patchInstanceStatus(ctx context.Context, status map[string]interface{}) error {
-	instanceUnstructuredCopy := igr.runtime.GetInstance().DeepCopy()
-	instanceUnstructuredCopy.Object["status"] = status
+	instance := igr.runtime.GetInstance().DeepCopy()
+	instance.Object["status"] = status
 
-	_, err := igr.client.Resource(igr.gvr).Namespace(instanceUnstructuredCopy.GetNamespace()).UpdateStatus(ctx, instanceUnstructuredCopy, metav1.UpdateOptions{})
+	_, err := igr.client.Resource(igr.gvr).
+		Namespace(instance.GetNamespace()).
+		UpdateStatus(ctx, instance, metav1.UpdateOptions{})
+
 	if err != nil {
 		return fmt.Errorf("failed to update instance status: %w", err)
 	}
 	return nil
 }
 
-func createCondition(conditionType v1alpha1.ConditionType, status corev1.ConditionStatus, reason, message string, generation int64) map[string]interface{} {
-	return map[string]interface{}{
-		"type":               string(conditionType),
-		"status":             string(status),
-		"reason":             reason,
-		"message":            message,
-		"lastTransitionTime": time.Now().Format(time.RFC3339),
-		"observedGeneration": generation,
+// updateInstanceState updates the instance state based on reconciliation results
+func (igr *instanceGraphReconciler) updateInstanceState() {
+	switch igr.state.ReconcileErr.(type) {
+	case *requeue.NoRequeue, *requeue.RequeueNeeded, *requeue.RequeueNeededAfter:
+		// Keep current state for requeue errors
+		return
+	default:
+		if igr.state.ReconcileErr != nil {
+			igr.state.State = InstanceStateError
+		} else if igr.state.State != InstanceStateDeleting {
+			igr.state.State = InstanceStateActive
+		}
 	}
 }

--- a/internal/controller/instance/instance_state.go
+++ b/internal/controller/instance/instance_state.go
@@ -1,0 +1,49 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package instance
+
+const (
+	InstanceStateInProgress = "IN_PROGRESS"
+	InstanceStateFailed     = "FAILED"
+	InstanceStateActive     = "ACTIVE"
+	InstanceStateDeleting   = "DELETING"
+	InstanceStateError      = "ERROR"
+)
+
+// newInstanceState creates a new InstanceState with initialized fields
+func newInstanceState() *InstanceState {
+	return &InstanceState{
+		State:          "IN_PROGRESS",
+		ResourceStates: make(map[string]*ResourceState),
+	}
+}
+
+// ResourceState represents the state and any associated error of a resource
+// being managed by the controller.
+type ResourceState struct {
+	// State represents the current state of the resource
+	State string
+	// Err captures any error associated with the current state
+	Err error
+}
+
+// InstanceState tracks the overall state of resources being managed
+type InstanceState struct {
+	// Current state of the instance
+	State string
+	// Map of resource IDs to their current states
+	ResourceStates map[string]*ResourceState
+	// Any error encountered during reconciliation
+	ReconcileErr error
+}


### PR DESCRIPTION
Move instance state handling into a dedicated struct and reorganize the package
for better code maintainability. Key changes include:

- Create i`InstanceState` struct to centralize state management
- Improve error handling with better context and messages
- Add detailed logging for namespace resolution
- Split `status-related` code into `controller_status.go`
- Improve separation of concerns in reconciliation logic


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
