### PR TITLE
Convert ResourceGroup to ObjectReconciler

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -29,7 +29,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/awslabs/kro/api/v1alpha1"
 	xv1alpha1 "github.com/awslabs/kro/api/v1alpha1"
 	kroclient "github.com/awslabs/kro/internal/client"
 	resourcegroupctrl "github.com/awslabs/kro/internal/controller/resourcegroup"
@@ -176,7 +178,7 @@ func main() {
 		ctrlrtcontroller.Options{
 			MaxConcurrentReconciles: resourceGroupConcurrentReconciles,
 		},
-	).Complete(reconciler)
+	).Complete(reconcile.AsReconciler[*v1alpha1.ResourceGroup](mgr.GetClient(), reconciler))
 	if err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ResourceGroup")
 		os.Exit(1)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/awslabs/kro/api/v1alpha1"
 	xv1alpha1 "github.com/awslabs/kro/api/v1alpha1"
 	kroclient "github.com/awslabs/kro/internal/client"
 	resourcegroupctrl "github.com/awslabs/kro/internal/controller/resourcegroup"
@@ -178,7 +177,7 @@ func main() {
 		ctrlrtcontroller.Options{
 			MaxConcurrentReconciles: resourceGroupConcurrentReconciles,
 		},
-	).Complete(reconcile.AsReconciler[*v1alpha1.ResourceGroup](mgr.GetClient(), reconciler))
+	).Complete(reconcile.AsReconciler[*xv1alpha1.ResourceGroup](mgr.GetClient(), reconciler))
 	if err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ResourceGroup")
 		os.Exit(1)


### PR DESCRIPTION
By switching to the newer ObjectReconciler interface from controller-runtime we can remove some unnecessary logic to fetch/check that the resource we are reconciling actually exists.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
