### PR TITLE
ack-controller example: remove duplicate ports section

### DIFF
--- a/examples/ack-controller/ec2-controller/ec2-controller.yaml
+++ b/examples/ack-controller/ec2-controller/ec2-controller.yaml
@@ -136,8 +136,6 @@ spec:
                 value: ${schema.spec.values.image.deletePolicy}
               - name: ACK_LOG_LEVEL
                 value: ${schema.spec.values.log.level}              
-              ports:
-              - containerPort: 80
   - id: clusterRoleBinding
     template:
       apiVersion: rbac.authorization.k8s.io/v1

--- a/examples/ack-controller/eks-controller/eks-controller.yaml
+++ b/examples/ack-controller/eks-controller/eks-controller.yaml
@@ -166,8 +166,6 @@ spec:
                 value: ${schema.spec.values.image.deletePolicy}
               - name: ACK_LOG_LEVEL
                 value: ${schema.spec.values.log.level}              
-              ports:
-              - containerPort: 80
   - id: clusterRoleBinding
     template:
       apiVersion: rbac.authorization.k8s.io/v1

--- a/examples/ack-controller/iam-controller/iam-controller.yaml
+++ b/examples/ack-controller/iam-controller/iam-controller.yaml
@@ -107,8 +107,6 @@ spec:
                 value: ${schema.spec.values.image.deletePolicy}
               - name: ACK_LOG_LEVEL
                 value: ${schema.spec.values.log.level}              
-              ports:
-              - containerPort: 80
   - id: clusterRoleBinding
     template:
       apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Remove duplicate ports section in ack controller deployment resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
