### PR TITLE
parser: Add support for `x-kubernetes-preserve-unknown-fields` schema extension

### DIFF
--- a/internal/graph/parser/parser_test.go
+++ b/internal/graph/parser/parser_test.go
@@ -618,6 +618,21 @@ func TestParserEdgeCases(t *testing.T) {
 			},
 			expectedError: "",
 		},
+		{
+			name: "schema with x-kubernetes-preserve-unknown-fields",
+			schema: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type: []string{"object"},
+				},
+				VendorExtensible: spec.VendorExtensible{
+					Extensions: spec.Extensions{
+						"x-kubernetes-preserve-unknown-fields": true,
+					},
+				},
+			},
+			resource:      map[string]interface{}{"name": "John", "age": 30},
+			expectedError: "",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Add support for the `x-kubernetes-preserve-unknown-fields` Kubernetes schema extension.
When this extension is present and set to true in a schema, skip parsing the object
and return an empty list of expressions.

This extension is commonly used in Kubernetes CRDs to allow for arbitrary nested
fields that shouldn't be validated against the schema.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
