### PR TITLE
Fix: update `edit this page` by updating docusaurus.config.ts

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -50,7 +50,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+            "https://github.com/awslabs/kro/tree/main/website",
         },
         blog: false,
         theme: {


### PR DESCRIPTION

*Description of changes:*

Fixes the `edit this page` link at the bottom of the kro.run website doc/examples.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
