### PR TITLE
feat(core): track and apply resource changes through deep diffing

### DIFF
--- a/pkg/controller/instance/delta/delta.go
+++ b/pkg/controller/instance/delta/delta.go
@@ -1,0 +1,181 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package delta
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Difference represents a single field-level difference between two objects.
+// Path is the full path to the differing field (e.g. "spec.containers[0].image")
+// Desired and Observed contain the actual values that differ at that path.
+type Difference struct {
+	// Path is the full path to the differing field (e.g. "spec.x.y.z"
+	Path string `json:"path"`
+	// Desired is the desired value at the path
+	Desired interface{} `json:"desired"`
+	// Observed is the observed value at the path
+	Observed interface{} `json:"observed"`
+}
+
+// Compare takes desired and observed unstructured objects and returns a list of
+// their differences. It performs a deep comparison while being aware of Kubernetes
+// metadata specifics. The comparison:
+//
+// - Cleans metadata from both objects to avoid spurious differences
+// - Walks object trees in parallel to find actual value differences
+// - Builds path strings to precisely identify where differences occurs
+// - Handles type mismatches, nil values, and empty vs nil collections
+func Compare(desired, observed *unstructured.Unstructured) ([]Difference, error) {
+	desiredCopy := desired.DeepCopy()
+	observedCopy := observed.DeepCopy()
+
+	cleanMetadata(desiredCopy)
+	cleanMetadata(observedCopy)
+
+	var differences []Difference
+	walkCompare(desiredCopy.Object, observedCopy.Object, "", &differences)
+	return differences, nil
+}
+
+// ignoredMetadataFields are Kubernetes metadata fields that should not trigger updates.
+var ignoredMetadataFields = []string{
+	"creationTimestamp",
+	"deletionTimestamp",
+	"generation",
+	"resourceVersion",
+	"selfLink",
+	"uid",
+	"managedFields",
+	"ownerReferences",
+	"finalizers",
+}
+
+// cleanMetadata removes Kubernetes metadata fields that should not trigger updates
+// like resourceVersion, creationTimestamp, etc. Also handles empty maps in
+// annotations and labels. This ensures we don't detect spurious changes based on
+// Kubernetes-managed fields.
+func cleanMetadata(obj *unstructured.Unstructured) {
+	metadata, ok := obj.Object["metadata"].(map[string]interface{})
+	if !ok {
+		// Maybe we should panic here, but for now just return
+		return
+	}
+
+	if annotations, exists := metadata["annotations"].(map[string]interface{}); exists {
+		if len(annotations) == 0 {
+			delete(metadata, "annotations")
+		}
+	}
+
+	if labels, exists := metadata["labels"].(map[string]interface{}); exists {
+		if len(labels) == 0 {
+			delete(metadata, "labels")
+		}
+	}
+
+	for _, field := range ignoredMetadataFields {
+		delete(metadata, field)
+	}
+}
+
+// walkCompare recursively compares desired and observed values, recording any
+// differences found. It handles different types appropriately:
+// - For maps: recursively compares all keys/values
+// - For slices: checks length and recursively compares elements
+// - For primitives: directly compares values
+//
+// Records a Difference if values don't match or are of different types.
+func walkCompare(desired, observed interface{}, path string, differences *[]Difference) {
+	switch d := desired.(type) {
+	case map[string]interface{}:
+		e, ok := observed.(map[string]interface{})
+		if !ok {
+			*differences = append(*differences, Difference{
+				Path:     path,
+				Observed: observed,
+				Desired:  desired,
+			})
+			return
+		}
+		walkMap(d, e, path, differences)
+
+	case []interface{}:
+		e, ok := observed.([]interface{})
+		if !ok {
+			*differences = append(*differences, Difference{
+				Path:     path,
+				Observed: observed,
+				Desired:  desired,
+			})
+			return
+		}
+		walkSlice(d, e, path, differences)
+
+	default:
+		if desired != observed {
+			*differences = append(*differences, Difference{
+				Path:     path,
+				Observed: observed,
+				Desired:  desired,
+			})
+		}
+	}
+}
+
+// walkMap compares two maps recursively. For each key in desired:
+//
+// - If key missing in observed: records a difference
+// - If key exists: recursively compares values
+func walkMap(desired, observed map[string]interface{}, path string, differences *[]Difference) {
+	for k, desiredVal := range desired {
+		newPath := k
+		if path != "" {
+			newPath = fmt.Sprintf("%s.%s", path, k)
+		}
+
+		observedVal, exists := observed[k]
+		if !exists && desiredVal != nil {
+			*differences = append(*differences, Difference{
+				Path:     newPath,
+				Observed: nil,
+				Desired:  desiredVal,
+			})
+			continue
+		}
+
+		walkCompare(desiredVal, observedVal, newPath, differences)
+	}
+}
+
+// walkSlice compares two slices recursively:
+// - If lengths differ: records entire slice as different
+// - If lengths match: recursively compares elements
+func walkSlice(desired, observed []interface{}, path string, differences *[]Difference) {
+	if len(desired) != len(observed) {
+		*differences = append(*differences, Difference{
+			Path:     path,
+			Observed: observed,
+			Desired:  desired,
+		})
+		return
+	}
+
+	for i := range desired {
+		newPath := fmt.Sprintf("%s[%d]", path, i)
+		walkCompare(desired[i], observed[i], newPath, differences)
+	}
+}

--- a/pkg/controller/instance/delta/delta_test.go
+++ b/pkg/controller/instance/delta/delta_test.go
@@ -1,0 +1,460 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package delta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestCompare_Simple(t *testing.T) {
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"replicas": int64(3),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "app",
+								"image": "nginx:1.19",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	observed := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"replicas": int64(2),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "app",
+								"image": "nginx:1.18",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	differences, err := Compare(desired, observed)
+	assert.NoError(t, err)
+
+	// Find differences by path
+	replicasDiff := findDiffByPath(differences, "spec.replicas")
+	assert.NotNil(t, replicasDiff)
+	assert.Equal(t, int64(2), replicasDiff.Observed)
+	assert.Equal(t, int64(3), replicasDiff.Desired)
+
+	imageDiff := findDiffByPath(differences, "spec.template.spec.containers[0].image")
+	assert.NotNil(t, imageDiff)
+	assert.Equal(t, "nginx:1.18", imageDiff.Observed)
+	assert.Equal(t, "nginx:1.19", imageDiff.Desired)
+}
+
+func TestCompare_Arrays(t *testing.T) {
+	tests := []struct {
+		name         string
+		desired      []interface{}
+		observed     []interface{}
+		expectDiff   bool
+		expectedPath string
+		expectedOld  interface{}
+		expectedNew  interface{}
+	}{
+		{
+			name:         "different lengths",
+			desired:      []interface{}{int64(1), int64(2), int64(3)},
+			observed:     []interface{}{int64(1), int64(2)},
+			expectDiff:   true,
+			expectedPath: "spec.numbers",
+			expectedOld:  []interface{}{int64(1), int64(2)},
+			expectedNew:  []interface{}{int64(1), int64(2), int64(3)},
+		},
+		{
+			name:       "same content",
+			desired:    []interface{}{int64(1), int64(2), int64(3)},
+			observed:   []interface{}{int64(1), int64(2), int64(3)},
+			expectDiff: false,
+		},
+		{
+			name:         "different content same length",
+			desired:      []interface{}{int64(1), int64(2), int64(3)},
+			observed:     []interface{}{int64(1), int64(2), int64(4)},
+			expectDiff:   true,
+			expectedPath: "spec.numbers[2]",
+			expectedOld:  int64(4),
+			expectedNew:  int64(3),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desired := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"numbers": tt.desired,
+					},
+				},
+			}
+			observed := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"numbers": tt.observed,
+					},
+				},
+			}
+
+			differences, err := Compare(desired, observed)
+			assert.NoError(t, err)
+
+			if tt.expectDiff {
+				diff := findDiffByPath(differences, tt.expectedPath)
+				assert.NotNil(t, diff)
+				assert.Equal(t, tt.expectedOld, diff.Observed)
+				assert.Equal(t, tt.expectedNew, diff.Desired)
+			} else {
+				assert.Empty(t, differences)
+			}
+		})
+	}
+}
+
+func TestCompare_NewField(t *testing.T) {
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"newField": "value",
+			},
+		},
+	}
+
+	observed := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{},
+		},
+	}
+
+	differences, err := Compare(desired, observed)
+	assert.NoError(t, err)
+
+	diff := findDiffByPath(differences, "spec.newField")
+	assert.NotNil(t, diff)
+	assert.Nil(t, diff.Observed)
+	assert.Equal(t, "value", diff.Desired)
+}
+
+func findDiffByPath(diffs []Difference, path string) *Difference {
+	for _, diff := range diffs {
+		if diff.Path == path {
+			return &diff
+		}
+	}
+	return nil
+}
+
+func TestCompare_Comprehensive(t *testing.T) {
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "test",
+				"labels": map[string]interface{}{
+					"env": "prod",
+					"new": "label",
+				},
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(3),
+				"selector": map[string]interface{}{
+					"app": "test",
+				},
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app": "test",
+						},
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "app",
+								"image": "nginx:1.19",
+								"env": []interface{}{
+									map[string]interface{}{
+										"name":  "DEBUG",
+										"value": "true",
+									},
+									map[string]interface{}{
+										"name":  "PORT",
+										"value": "8080",
+									},
+								},
+							},
+						},
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "config",
+								"configMap": map[string]interface{}{
+									"name": "app-config",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	observed := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "test",
+				"labels": map[string]interface{}{
+					"env": "dev",      // changed value
+					"old": "obsolete", // removed label
+				},
+				"resourceVersion":   "12345", // should be ignored
+				"creationTimestamp": "NOTNIL",
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(2), // changed value
+				"selector": map[string]interface{}{
+					"app": "test", // unchanged
+				},
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app": "test",
+						},
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "app",
+								"image": "nginx:1.18", // changed value
+								"env": []interface{}{
+									map[string]interface{}{
+										"name":  "DEBUG",
+										"value": "false", // changed value
+									},
+									// removed env var PORT
+								},
+								"resources": map[string]interface{}{
+									"limits": map[string]interface{}{
+										"cpu": "100m",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	differences, err := Compare(desired, observed)
+	assert.NoError(t, err)
+
+	expectedChanges := map[string]struct {
+		old interface{}
+		new interface{}
+	}{
+		"metadata.labels.env":                    {old: "dev", new: "prod"},
+		"metadata.labels.new":                    {old: nil, new: "label"},
+		"spec.replicas":                          {old: int64(2), new: int64(3)},
+		"spec.template.spec.containers[0].image": {old: "nginx:1.18", new: "nginx:1.19"},
+		"spec.template.spec.containers[0].env": {
+			old: []interface{}{
+				map[string]interface{}{
+					"name":  "DEBUG",
+					"value": "false",
+				},
+			},
+			new: []interface{}{
+				map[string]interface{}{
+					"name":  "DEBUG",
+					"value": "true",
+				},
+				map[string]interface{}{
+					"name":  "PORT",
+					"value": "8080",
+				},
+			},
+		},
+		"spec.template.spec.volumes": {
+			old: nil,
+			new: []interface{}{
+				map[string]interface{}{
+					"name": "config",
+					"configMap": map[string]interface{}{
+						"name": "app-config",
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, len(expectedChanges), len(differences), "number of differences should match")
+
+	for _, diff := range differences {
+		expected, ok := expectedChanges[diff.Path]
+		assert.True(t, ok, "unexpected difference at path: %s", diff.Path)
+		assert.Equal(t, expected.old, diff.Observed, "old value mismatch at path: %s", diff.Path)
+		assert.Equal(t, expected.new, diff.Desired, "new value mismatch at path: %s", diff.Path)
+	}
+}
+
+func TestCompare_EmptyMaps(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  *unstructured.Unstructured
+		observed *unstructured.Unstructured
+		wantDiff bool
+	}{
+		{
+			name: "empty maps in spec should not diff",
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"tags": map[string]interface{}{},
+					},
+				},
+			},
+			observed: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"tags": map[string]interface{}{},
+					},
+				},
+			},
+			wantDiff: false,
+		},
+		{
+			name: "empty map in desired, no field in observed should diff",
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"tags": map[string]interface{}{},
+					},
+				},
+			},
+			observed: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{},
+				},
+			},
+			wantDiff: true,
+		},
+		{
+			name: "nil map in desired, no field in observed should not diff",
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"tags": nil,
+					},
+				},
+			},
+			observed: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{},
+				},
+			},
+			wantDiff: false,
+		},
+		{
+			name: "non-empty map should diff when values differ",
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"tags": map[string]interface{}{
+							"environment": "prod",
+						},
+					},
+				},
+			},
+			observed: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"tags": map[string]interface{}{
+							"environment": "dev",
+						},
+					},
+				},
+			},
+			wantDiff: true,
+		},
+		{
+			name: "nested empty maps should diff",
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"config": map[string]interface{}{
+							"settings": map[string]interface{}{},
+						},
+					},
+				},
+			},
+			observed: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"config": map[string]interface{}{},
+					},
+				},
+			},
+			wantDiff: true,
+		},
+		{
+			name: "non-empty map vs nil map should diff",
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"tags": map[string]interface{}{
+							"environment": "prod",
+						},
+					},
+				},
+			},
+			observed: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"tags": nil,
+					},
+				},
+			},
+			wantDiff: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			differences, err := Compare(tt.desired, tt.observed)
+			assert.NoError(t, err)
+			if tt.wantDiff {
+				assert.NotEmpty(t, differences)
+			} else {
+				assert.Empty(t, differences,
+					"expected no differences but got: %+v", differences)
+			}
+		})
+	}
+}

--- a/pkg/controller/resourcegroup/controller.go
+++ b/pkg/controller/resourcegroup/controller.go
@@ -21,6 +21,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/awslabs/kro/api/v1alpha1"
@@ -80,6 +81,7 @@ func NewResourceGroupReconciler(
 func (r *ResourceGroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.ResourceGroup{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(reconcile.AsReconciler[*v1alpha1.ResourceGroup](mgr.GetClient(), r))
 }
 

--- a/test/integration/suites/core/lifecycle_test.go
+++ b/test/integration/suites/core/lifecycle_test.go
@@ -12,3 +12,178 @@
 // permissions and limitations under the License.
 
 package core_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/awslabs/kro/api/v1alpha1"
+	"github.com/awslabs/kro/pkg/testutil/generator"
+)
+
+var _ = Describe("Update", func() {
+	It("should handle updates to instance resources correctly", func() {
+		ctx := context.Background()
+		namespace := fmt.Sprintf("test-%s", rand.String(5))
+
+		// Create namespace
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		Expect(env.Client.Create(ctx, ns)).To(Succeed())
+
+		// Create ResourceGroup for a simple deployment service
+		rg := generator.NewResourceGroup("test-update",
+			generator.WithNamespace(namespace),
+			generator.WithSchema(
+				"TestUpdate", "v1alpha1",
+				map[string]interface{}{
+					"replicas": "integer | default=1",
+					"image":    "string | default=nginx:latest",
+					"port":     "integer | default=80",
+				},
+				nil,
+			),
+			generator.WithResource("deployment", map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "deployment-${schema.metadata.name}",
+				},
+				"spec": map[string]interface{}{
+					"replicas": "${schema.spec.replicas}",
+					"selector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"app": "test",
+						},
+					},
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"app": "test",
+							},
+						},
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "app",
+									"image": "${schema.spec.image}",
+									"ports": []interface{}{
+										map[string]interface{}{
+											"containerPort": "${schema.spec.port}",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}, nil, nil),
+		)
+
+		Expect(env.Client.Create(ctx, rg)).To(Succeed())
+
+		// Verify ResourceGroup is ready
+		createdRG := &krov1alpha1.ResourceGroup{}
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      rg.Name,
+				Namespace: namespace,
+			}, createdRG)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(createdRG.Status.State).To(Equal(krov1alpha1.ResourceGroupStateActive))
+		}, 10*time.Second, time.Second).Should(Succeed())
+
+		// Create initial instance
+		instance := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KroDomainName, "v1alpha1"),
+				"kind":       "TestUpdate",
+				"metadata": map[string]interface{}{
+					"name":      "test-instance-for-updates",
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"image":    "nginx:1.19",
+					"port":     80,
+					"replicas": 1,
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		// Verify initial deployment
+		deployment := &appsv1.Deployment{}
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      "deployment-test-instance-for-updates",
+				Namespace: namespace,
+			}, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
+			g.Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("nginx:1.19"))
+			g.Expect(deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort).To(Equal(int32(80)))
+		}, 20*time.Second, time.Second).Should(Succeed())
+
+		// Mark deployment as ready
+		deployment.Status.Replicas = 1
+		deployment.Status.ReadyReplicas = 1
+		deployment.Status.AvailableReplicas = 1
+		Expect(env.Client.Status().Update(ctx, deployment)).To(Succeed())
+
+		// Update instance with new values
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      "test-instance-for-updates",
+				Namespace: namespace,
+			}, instance)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			instance.Object["spec"] = map[string]interface{}{
+				"replicas": int64(3),
+				"image":    "nginx:1.20",
+				"port":     int64(443),
+			}
+			err = env.Client.Update(ctx, instance)
+			g.Expect(err).ToNot(HaveOccurred())
+		}, 10*time.Second, time.Second).Should(Succeed())
+
+		// Verify deployment is updated with new values
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      "deployment-test-instance-for-updates",
+				Namespace: namespace,
+			}, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(*deployment.Spec.Replicas).To(Equal(int32(3)))
+			g.Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("nginx:1.20"))
+			g.Expect(deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort).To(Equal(int32(443)))
+		}, 20*time.Second, time.Second).Should(Succeed())
+
+		// Cleanup
+		Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+		Eventually(func() bool {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      "deployment-test-instance-for-updates",
+				Namespace: namespace,
+			}, deployment)
+			return errors.IsNotFound(err)
+		}, 20*time.Second, time.Second).Should(BeTrue())
+
+		Expect(env.Client.Delete(ctx, rg)).To(Succeed())
+		Expect(env.Client.Delete(ctx, ns)).To(Succeed())
+	})
+})

--- a/test/integration/suites/core/setup_test.go
+++ b/test/integration/suites/core/setup_test.go
@@ -28,7 +28,7 @@ import (
 
 var env *environment.Environment
 
-func TestNetworkingStack(t *testing.T) {
+func TestCore(t *testing.T) {
 	RegisterFailHandler(Fail)
 	BeforeSuite(func() {
 		var err error
@@ -36,7 +36,7 @@ func TestNetworkingStack(t *testing.T) {
 			environment.ControllerConfig{
 				AllowCRDDeletion: true,
 				ReconcileConfig: ctrlinstance.ReconcileConfig{
-					DefaultRequeueDuration: 15 * time.Second,
+					DefaultRequeueDuration: 5 * time.Second,
 				},
 			},
 		)


### PR DESCRIPTION
Up until now, we weren't really doing proper diffing when deciding whether to update
managed resources - we just marked everything as "SYNCED". This patch adds a new delta
package that does a proper deep comparison between desired and observed resource
states, being careful about all the k8s metadata fields that we should ignore during
comparisons (e.g `metadata.generation`, `metadta.revision` etc...)

A key design aspect of this implementation is that `kro` only diffs fields that are
 explicitly defined in `ResourceGroup` - any field that is defaulted by other
controllers or mutating webhooks are ignored. This ensures `kro` coexists seamlessly
with other reconciliation systems without fighting over field ownership.

The delta `Compare` function takes the desired and observed `unstructured.Unstructured`
objects and returns a list of structured "differences", where each difference contains
the full path to the changed field and its desired/observed values. It recursively
walks both object trees in parallel, building pathstring like `spec.containers[0].image`
to precisely identify where values diverge. The comparison handles type mismatches,
nil vs empty maps/slices, value differences etc...

Also patch also adds integration tests in suites/core for generic resource
updates and in suites/ackekscluster for EKS-clutser-specific version updates. note that
in both tests we mainly rely on the `metadata.revision` to validate that indeed the
controller did make an spec update call.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
