### PR TITLE
made group name configurable within resourcegroup

### DIFF
--- a/api/v1alpha1/resource_group.go
+++ b/api/v1alpha1/resource_group.go
@@ -60,6 +60,12 @@ type Schema struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="apiVersion is immutable"
 	APIVersion string `json:"apiVersion,omitempty"`
+	// The group of the resourcegroup. This is used to set the API group
+	// of the generated CRD. If omitted, it defaults to "kro.run".
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="kro.run"
+	Group string `json:"group,omitempty"`
 	// The spec of the resourcegroup. Typically, this is the spec of
 	// the CRD that the resourcegroup is managing. This is adhering
 	// to the SimpleSchema spec

--- a/config/crd/bases/kro.run_resourcegroups.yaml
+++ b/config/crd/bases/kro.run_resourcegroups.yaml
@@ -103,6 +103,12 @@ spec:
                     x-kubernetes-validations:
                     - message: apiVersion is immutable
                       rule: self == oldSelf
+                  group:
+                    default: kro.run
+                    description: |-
+                      The group of the resourcegroup. This is used to set the API group
+                      of the generated CRD. If omitted, it defaults to "kro.run".
+                    type: string
                   kind:
                     description: |-
                       The kind of the resourcegroup. This is used to generate

--- a/helm/crds/kro.run_resourcegroups.yaml
+++ b/helm/crds/kro.run_resourcegroups.yaml
@@ -103,6 +103,12 @@ spec:
                     x-kubernetes-validations:
                     - message: apiVersion is immutable
                       rule: self == oldSelf
+                  group:
+                    default: kro.run
+                    description: |-
+                      The group of the resourcegroup. This is used to set the API group
+                      of the generated CRD. If omitted, it defaults to "kro.run".
+                    type: string
                   kind:
                     description: |-
                       The kind of the resourcegroup. This is used to generate

--- a/pkg/controller/resourcegroup/controller_cleanup.go
+++ b/pkg/controller/resourcegroup/controller_cleanup.go
@@ -35,13 +35,13 @@ func (r *ResourceGroupReconciler) cleanupResourceGroup(ctx context.Context, rg *
 	log.V(1).Info("cleaning up resource group", "name", rg.Name)
 
 	// shutdown microcontroller
-	gvr := metadata.GetResourceGroupInstanceGVR(rg.Spec.Schema.APIVersion, rg.Spec.Schema.Kind)
+	gvr := metadata.GetResourceGroupInstanceGVR(rg.Spec.Schema.Group, rg.Spec.Schema.APIVersion, rg.Spec.Schema.Kind)
 	if err := r.shutdownResourceGroupMicroController(ctx, &gvr); err != nil {
 		return fmt.Errorf("failed to shutdown microcontroller: %w", err)
 	}
 
 	// cleanup CRD
-	crdName := extractCRDName(rg.Spec.Schema.Kind)
+	crdName := extractCRDName(rg.Spec.Schema.Group, rg.Spec.Schema.Kind)
 	if err := r.cleanupResourceGroupCRD(ctx, crdName); err != nil {
 		return fmt.Errorf("failed to cleanup CRD %s: %w", crdName, err)
 	}
@@ -75,8 +75,8 @@ func (r *ResourceGroupReconciler) cleanupResourceGroupCRD(ctx context.Context, c
 
 // extractCRDName generates the CRD name from a given kind by converting it to plural form
 // and appending the Kro domain name.
-func extractCRDName(kind string) string {
+func extractCRDName(group, kind string) string {
 	return fmt.Sprintf("%s.%s",
 		flect.Pluralize(strings.ToLower(kind)),
-		v1alpha1.KroDomainName)
+		group)
 }

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -163,7 +163,7 @@ func (b *Builder) NewResourceGroup(originalCR *v1alpha1.ResourceGroup) (*Graph, 
 	// That's because the instance status schema is inferred from the CEL expressions
 	// in the status field of the instance resource. Those CEL expressions refer to
 	// the resources defined in the resource group. Hence, we need to build the resources
-	// first, to be able ot generate a proper schema for the instance status.
+	// first, to be able to generate a proper schema for the instance status.
 
 	//
 
@@ -190,6 +190,7 @@ func (b *Builder) NewResourceGroup(originalCR *v1alpha1.ResourceGroup) (*Graph, 
 	// 4. Infer the status schema based on the CEL expressions.
 
 	instance, err := b.buildInstanceResource(
+		rg.Spec.Schema.Group,
 		rg.Spec.Schema.APIVersion,
 		rg.Spec.Schema.Kind,
 		rg.Spec.Schema,
@@ -415,7 +416,7 @@ func (b *Builder) buildDependencyGraph(
 // Since instances are defined using the "SimpleSchema" format, we use a different
 // approach to build the instance resource. We need to:
 func (b *Builder) buildInstanceResource(
-	apiVersion, kind string,
+	group, apiVersion, kind string,
 	rgDefinition *v1alpha1.Schema,
 	resources map[string]*Resource,
 ) (*Resource, error) {
@@ -428,7 +429,7 @@ func (b *Builder) buildInstanceResource(
 	// CRD declarations.
 
 	// The instance resource is a Kubernetes resource, so it has a GroupVersionKind.
-	gvk := metadata.GetResourceGroupInstanceGVK(apiVersion, kind)
+	gvk := metadata.GetResourceGroupInstanceGVK(group, apiVersion, kind)
 
 	// We need to unmarshal the instance schema to a map[string]interface{} to
 	// make it easier to work with.
@@ -451,7 +452,7 @@ func (b *Builder) buildInstanceResource(
 
 	// Synthesize the CRD for the instance resource.
 	overrideStatusFields := true
-	instanceCRD := crd.SynthesizeCRD(apiVersion, kind, *instanceSpecSchema, *instanceStatusSchema, overrideStatusFields)
+	instanceCRD := crd.SynthesizeCRD(group, apiVersion, kind, *instanceSpecSchema, *instanceStatusSchema, overrideStatusFields)
 
 	// Emulate the CRD
 	instanceSchemaExt := instanceCRD.Spec.Versions[0].Schema.OpenAPIV3Schema

--- a/pkg/graph/crd/crd.go
+++ b/pkg/graph/crd/crd.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/awslabs/kro/api/v1alpha1"
 	"github.com/gobuffalo/flect"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,19 +24,19 @@ import (
 
 // SynthesizeCRD generates a CustomResourceDefinition for a given API version and kind
 // with the provided spec and status schemas~
-func SynthesizeCRD(apiVersion, kind string, spec, status extv1.JSONSchemaProps, statusFieldsOverride bool) *extv1.CustomResourceDefinition {
-	return newCRD(apiVersion, kind, newCRDSchema(spec, status, statusFieldsOverride))
+func SynthesizeCRD(group, apiVersion, kind string, spec, status extv1.JSONSchemaProps, statusFieldsOverride bool) *extv1.CustomResourceDefinition {
+	return newCRD(group, apiVersion, kind, newCRDSchema(spec, status, statusFieldsOverride))
 }
 
-func newCRD(apiVersion, kind string, schema *extv1.JSONSchemaProps) *extv1.CustomResourceDefinition {
+func newCRD(group, apiVersion, kind string, schema *extv1.JSONSchemaProps) *extv1.CustomResourceDefinition {
 	pluralKind := flect.Pluralize(strings.ToLower(kind))
 	return &extv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf("%s.%s", pluralKind, v1alpha1.KroDomainName),
+			Name:            fmt.Sprintf("%s.%s", pluralKind, group),
 			OwnerReferences: nil, // Injecting owner references is the responsibility of the caller.
 		},
 		Spec: extv1.CustomResourceDefinitionSpec{
-			Group: v1alpha1.KroDomainName,
+			Group: group,
 			Names: extv1.CustomResourceDefinitionNames{
 				Kind:     kind,
 				ListKind: kind + "List",

--- a/pkg/metadata/groupversion.go
+++ b/pkg/metadata/groupversion.go
@@ -58,20 +58,20 @@ func ExtractGVKFromUnstructured(unstructured map[string]interface{}) (schema.Gro
 	}, nil
 }
 
-func GetResourceGroupInstanceGVK(apiVersion, kind string) schema.GroupVersionKind {
+func GetResourceGroupInstanceGVK(group, apiVersion, kind string) schema.GroupVersionKind {
 	//pluralKind := flect.Pluralize(strings.ToLower(kind))
 
 	return schema.GroupVersionKind{
-		Group:   KroInstancesGroupSuffix,
+		Group:   group,
 		Version: apiVersion,
 		Kind:    kind,
 	}
 }
 
-func GetResourceGroupInstanceGVR(apiVersion, kind string) schema.GroupVersionResource {
+func GetResourceGroupInstanceGVR(group, apiVersion, kind string) schema.GroupVersionResource {
 	pluralKind := flect.Pluralize(strings.ToLower(kind))
 	return schema.GroupVersionResource{
-		Group:    fmt.Sprintf("%s.%s", pluralKind, KroInstancesGroupSuffix),
+		Group:    fmt.Sprintf("%s.%s", pluralKind, group),
 		Version:  apiVersion,
 		Resource: pluralKind,
 	}


### PR DESCRIPTION
*Issue #, if available:* #164

*Description of changes:* 

- Adding `Group string` to the schema in [kro/api/v1alpha1/resource_group.go](https://github.com/awslabs/kro/blob/main/api/v1alpha1/resource_group.go#L50)
- Passing this information to the `buildInstanceResource` function in [kro/internal/graph /builder.go](https://github.com/awslabs/kro/blob/main/internal/graph/builder.go#L192)
- Further passing this info to `SynthesizeCRD` in [kro/internal/graph /builder.go](https://github.com/awslabs/kro/blob/main/internal/graph/builder.go#L454) to get the new CRD which would have the group info.
- Updating the [extractCRDName](https://github.com/awslabs/kro/blob/main/internal/controller/resourcegroup/controller_cleanup.go) function to accomodate the newly added Group field during deletion.
- Updating the `GetResourceGroupInstanceGVK` and `GetResourceGroupInstanceGVR` functions in [kro/internal/metadata/groupversion.go](https://github.com/awslabs/kro/blob/main/internal/metadata/groupversion.go#L71-L87)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
