### PR TITLE
feat(78): add simpleschema short spec types int and bool

### DIFF
--- a/pkg/graph/parser/parser.go
+++ b/pkg/graph/parser/parser.go
@@ -191,11 +191,11 @@ func parseScalarTypes(field interface{}, _ *spec.Schema, path, expectedType stri
 		if _, ok := field.(float64); !ok {
 			return nil, fmt.Errorf("expected number type for path %s, got %T", path, field)
 		}
-	case "integer":
+	case "integer", "int":
 		if !isInteger(field) {
 			return nil, fmt.Errorf("expected integer type for path %s, got %T", path, field)
 		}
-	case "boolean":
+	case "boolean", "bool":
 		if _, ok := field.(bool); !ok {
 			return nil, fmt.Errorf("expected boolean type for path %s, got %T", path, field)
 		}

--- a/pkg/graph/parser/parser_test.go
+++ b/pkg/graph/parser/parser_test.go
@@ -711,3 +711,23 @@ func TestJoinPathAndFieldName(t *testing.T) {
 		})
 	}
 }
+
+func TestPartScalerTypesShortSpecTypes(t *testing.T) {
+	tests := []struct {
+		name          string
+		shortSpecType string
+		field         interface{}
+	}{
+		{"int short type for integer", "int", 42},
+		{"bool short type for boolean", "bool", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseScalarTypes(tt.field, nil, "spec.someitem", tt.shortSpecType)
+			if err != nil {
+				t.Errorf("Expected %T resolved for %s, but got error: %s", tt.field, tt.shortSpecType, err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Issue #78:*

*Description of changes:*

Added parsing of simple types int and bool to parseScalarTypes method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
