### PR TITLE
adding support for `x-kubernetes-int-or-string` in dummy CR

### DIFF
--- a/pkg/graph/emulator/emulator.go
+++ b/pkg/graph/emulator/emulator.go
@@ -79,6 +79,11 @@ func (e *Emulator) generateValue(schema *spec.Schema) (interface{}, error) {
 		return nil, fmt.Errorf("schema is nil")
 	}
 
+	if enabled, ok := schema.VendorExtensible.Extensions["x-kubernetes-int-or-string"]; ok && enabled.(bool) {
+		// Default to integer for dummy CRs
+		return e.generateInteger(schema), nil
+	}
+
 	if len(schema.Type) == 0 {
 		// If type is not set, check if it's an object
 		if len(schema.Properties) > 0 {

--- a/pkg/graph/emulator/emulator_test.go
+++ b/pkg/graph/emulator/emulator_test.go
@@ -482,6 +482,25 @@ func TestGenerateDummyCRErrors(t *testing.T) {
 	})
 }
 
+func TestGenerateValueWithIntOrString(t *testing.T) {
+	e := NewEmulator()
+
+	t.Run("x-kubernetes-int-or-string present, generates integer", func(t *testing.T) {
+		schema := &spec.Schema{
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: map[string]interface{}{
+					"x-kubernetes-int-or-string": true,
+				},
+			},
+		}
+
+		value, err := e.generateValue(schema)
+		require.NoError(t, err)
+		assert.IsType(t, int64(0), value, "Expected integer as default value for x-kubernetes-int-or-string")
+	})
+
+}
+
 func ptr[T comparable](v T) *T {
 	return &v
 }


### PR DESCRIPTION
Fixes #168 

*Description of changes:* Adding support for `x-kubernetes-int-or-string: true` in the dummy CR generator and a test case for that.  Based on discussion of changes [here](https://github.com/awslabs/kro/issues/168#issuecomment-2578021187)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
