### PR TITLE
add `anyof` support for parser

### DIFF
--- a/pkg/graph/emulator/emulator.go
+++ b/pkg/graph/emulator/emulator.go
@@ -84,13 +84,11 @@ func (e *Emulator) generateValue(schema *spec.Schema) (interface{}, error) {
 		if len(schema.Properties) > 0 {
 			return e.generateObject(schema)
 		}
-		// Check if it's a oneOf schema
+
+		// Check if it's a oneOf or anyOf schema
 		if len(schema.OneOf) > 0 {
 			return e.generateValue(&schema.OneOf[e.rand.Intn(len(schema.OneOf))])
-		}
-
-		// Check if its anyOf schema
-		if len(schema.AnyOf) > 0 {
+		} else if len(schema.AnyOf) > 0 {
 			return e.generateValue(&schema.AnyOf[e.rand.Intn(len(schema.AnyOf))])
 		}
 


### PR DESCRIPTION
*Issue #, if available:*
#### 181

*Description of changes:*
#### Recursively handle AnyOf logic
This allows us to store multiple valid types (e.g., ["string", "object"]) instead of a single string.

#### Update parsing and validation logic
- call parseAnyOf when AnyOf is defined. 
- Validate the schema
- Update expectedType to handle empty slice.

#### Added unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
