### PR TITLE
Add support for multiple expected types by converting `expectedtype` from `string` to `[]string`

### DIFF
--- a/pkg/graph/parser/parser.go
+++ b/pkg/graph/parser/parser.go
@@ -15,6 +15,7 @@ package parser
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -47,22 +48,22 @@ func parseResource(resource interface{}, schema *spec.Schema, path string) ([]va
 		return nil, err
 	}
 
-	expectedType, err := getExpectedType(schema, resource)
+	expectedTypes, err := getExpectedTypes(schema)
 	if err != nil {
 		return nil, err
 	}
 
 	switch field := resource.(type) {
 	case map[string]interface{}:
-		return parseObject(field, schema, path, expectedType)
+		return parseObject(field, schema, path, expectedTypes)
 	case []interface{}:
-		return parseArray(field, schema, path, expectedType)
+		return parseArray(field, schema, path, expectedTypes)
 	case string:
-		return parseString(field, schema, path, expectedType)
+		return parseString(field, schema, path, expectedTypes)
 	case nil:
 		return nil, nil
 	default:
-		return parseScalarTypes(field, schema, path, expectedType)
+		return parseScalarTypes(field, schema, path, expectedTypes)
 	}
 }
 
@@ -80,40 +81,37 @@ func validateSchema(schema *spec.Schema, path string) error {
 	return nil
 }
 
-func getExpectedType(schema *spec.Schema, resource interface{}) (string, error) {
+func getExpectedTypes(schema *spec.Schema) ([]string, error) {
 	// handle "x-kubernetes-int-or-string"
 	if ext, ok := schema.VendorExtensible.Extensions[xKubernetesIntOrString]; ok {
 		enabled, ok := ext.(bool)
 		if !ok {
-			return "", fmt.Errorf("xKubernetesIntOrString extension is not a boolean")
+			return nil, fmt.Errorf("xKubernetesIntOrString extension is not a boolean")
 		}
 		if enabled {
-			switch resourceType := resource.(type) {
-			case string:
-				return "string", nil
-			case int:
-				return "integer", nil
-			default:
-				return "", fmt.Errorf("found `xKubernetesIntOrString` extension but field value is neither a string nor an integer: %v", resourceType)
-			}
+			return []string{"string", "integer"}, nil
 		}
 	}
 
 	if schema.Type[0] != "" {
-		return schema.Type[0], nil
+		return schema.Type, nil
 	}
 	if schema.AdditionalProperties != nil && schema.AdditionalProperties.Allows {
 		// NOTE(a-hilaly): I don't like the type "any", we might want to change this to "object"
 		// in the future; just haven't really thought about it yet.
 		// Basically "any" means that the field can be of any type, and we have to check
 		// the ExpectedSchema field.
-		return schemaTypeAny, nil
+		return []string{schemaTypeAny}, nil
 	}
-	return "", fmt.Errorf("unknown schema type")
+	return nil, fmt.Errorf("unknown schema type")
 }
 
-func parseObject(field map[string]interface{}, schema *spec.Schema, path, expectedType string) ([]variable.FieldDescriptor, error) {
-	if expectedType != "object" && (schema.AdditionalProperties == nil || !schema.AdditionalProperties.Allows) {
+func sliceInclude(expectedTypes []string, expectedType string) bool {
+	return slices.Contains(expectedTypes, expectedType)
+}
+
+func parseObject(field map[string]interface{}, schema *spec.Schema, path string, expectedTypes []string) ([]variable.FieldDescriptor, error) {
+	if !sliceInclude(expectedTypes, "object") && (schema.AdditionalProperties == nil || !schema.AdditionalProperties.Allows) {
 		return nil, fmt.Errorf("expected object type or AdditionalProperties allowed for path %s, got %v", path, field)
 	}
 
@@ -149,8 +147,8 @@ func parseObject(field map[string]interface{}, schema *spec.Schema, path, expect
 	return expressionsFields, nil
 }
 
-func parseArray(field []interface{}, schema *spec.Schema, path, expectedType string) ([]variable.FieldDescriptor, error) {
-	if expectedType != "array" {
+func parseArray(field []interface{}, schema *spec.Schema, path string, expectedTypes []string) ([]variable.FieldDescriptor, error) {
+	if !sliceInclude(expectedTypes, "array") {
 		return nil, fmt.Errorf("expected array type for path %s, got %v", path, field)
 	}
 
@@ -171,22 +169,23 @@ func parseArray(field []interface{}, schema *spec.Schema, path, expectedType str
 	return expressionsFields, nil
 }
 
-func parseString(field string, schema *spec.Schema, path, expectedType string) ([]variable.FieldDescriptor, error) {
+func parseString(field string, schema *spec.Schema, path string, expectedTypes []string) ([]variable.FieldDescriptor, error) {
 	ok, err := isStandaloneExpression(field)
 	if err != nil {
 		return nil, err
 	}
+
 	if ok {
 		return []variable.FieldDescriptor{{
 			Expressions:          []string{strings.Trim(field, "${}")},
-			ExpectedType:         expectedType,
+			ExpectedTypes:        expectedTypes,
 			ExpectedSchema:       schema,
 			Path:                 path,
 			StandaloneExpression: true,
 		}}, nil
 	}
 
-	if expectedType != "string" && expectedType != schemaTypeAny {
+	if !sliceInclude(expectedTypes, "string") && !sliceInclude(expectedTypes, schemaTypeAny) {
 		return nil, fmt.Errorf("expected string type or AdditionalProperties for path %s, got %v", path, field)
 	}
 
@@ -196,29 +195,26 @@ func parseString(field string, schema *spec.Schema, path, expectedType string) (
 	}
 	if len(expressions) > 0 {
 		return []variable.FieldDescriptor{{
-			Expressions:  expressions,
-			ExpectedType: expectedType,
-			Path:         path,
+			Expressions:   expressions,
+			ExpectedTypes: expectedTypes,
+			Path:          path,
 		}}, nil
 	}
 	return nil, nil
 }
 
-func parseScalarTypes(field interface{}, _ *spec.Schema, path, expectedType string) ([]variable.FieldDescriptor, error) {
-	if expectedType == schemaTypeAny {
-		return nil, nil
-	}
+func parseScalarTypes(field interface{}, _ *spec.Schema, path string, expectedTypes []string) ([]variable.FieldDescriptor, error) {
 	// perform type checks for scalar types
-	switch expectedType {
-	case "number":
+	switch {
+	case sliceInclude(expectedTypes, "number"):
 		if _, ok := field.(float64); !ok {
 			return nil, fmt.Errorf("expected number type for path %s, got %T", path, field)
 		}
-	case "integer", "int":
+	case sliceInclude(expectedTypes, "int"), sliceInclude(expectedTypes, "integer"):
 		if !isInteger(field) {
 			return nil, fmt.Errorf("expected integer type for path %s, got %T", path, field)
 		}
-	case "boolean", "bool":
+	case sliceInclude(expectedTypes, "boolean"), sliceInclude(expectedTypes, "bool"):
 		if _, ok := field.(bool); !ok {
 			return nil, fmt.Errorf("expected boolean type for path %s, got %T", path, field)
 		}

--- a/pkg/graph/parser/parser_test.go
+++ b/pkg/graph/parser/parser_test.go
@@ -130,21 +130,21 @@ func TestParseResource(t *testing.T) {
 		}
 
 		expectedExpressions := []variable.FieldDescriptor{
-			{Path: "stringField", Expressions: []string{"string.value"}, ExpectedType: "string", StandaloneExpression: true},
-			{Path: "intField", Expressions: []string{"int.value"}, ExpectedType: "integer", StandaloneExpression: true},
-			{Path: "boolField", Expressions: []string{"bool.value"}, ExpectedType: "boolean", StandaloneExpression: true},
-			{Path: "nestedObject.nestedString", Expressions: []string{"nested.string"}, ExpectedType: "string", StandaloneExpression: true},
-			{Path: "nestedObject.nestedStringMultiple", Expressions: []string{"nested.string1", "nested.string2"}, ExpectedType: "string", StandaloneExpression: false},
-			{Path: "simpleArray[0]", Expressions: []string{"array[0]"}, ExpectedType: "string", StandaloneExpression: true},
-			{Path: "simpleArray[1]", Expressions: []string{"array[1]"}, ExpectedType: "string", StandaloneExpression: true},
-			{Path: "mapField.key1", Expressions: []string{"map.key1"}, ExpectedType: "string", StandaloneExpression: true},
-			{Path: "mapField.key2", Expressions: []string{"map.key2"}, ExpectedType: "string", StandaloneExpression: true},
-			{Path: "specialCharacters.simpleAnnotation", Expressions: []string{"simpleannotation"}, ExpectedType: "string", StandaloneExpression: true},
-			{Path: "specialCharacters[\"doted.annotation.key\"]", Expressions: []string{"dotedannotationvalue"}, ExpectedType: "string", StandaloneExpression: true},
-			{Path: "specialCharacters[\"\"]", Expressions: []string{"emptyannotation"}, ExpectedType: "string", StandaloneExpression: true},
-			{Path: "specialCharacters[\"array.name.with.dots\"][0]", Expressions: []string{"value"}, ExpectedType: "string", StandaloneExpression: true},
-			{Path: "schemalessField.something", Expressions: []string{"schemaless.value"}, ExpectedType: "string", StandaloneExpression: true},
-			{Path: "schemalessField.nestedSomething.nested", Expressions: []string{"schemaless.nested.value"}, ExpectedType: "string", StandaloneExpression: true},
+			{Path: "stringField", Expressions: []string{"string.value"}, ExpectedTypes: []string{"string"}, StandaloneExpression: true},
+			{Path: "intField", Expressions: []string{"int.value"}, ExpectedTypes: []string{"integer"}, StandaloneExpression: true},
+			{Path: "boolField", Expressions: []string{"bool.value"}, ExpectedTypes: []string{"boolean"}, StandaloneExpression: true},
+			{Path: "nestedObject.nestedString", Expressions: []string{"nested.string"}, ExpectedTypes: []string{"string"}, StandaloneExpression: true},
+			{Path: "nestedObject.nestedStringMultiple", Expressions: []string{"nested.string1", "nested.string2"}, ExpectedTypes: []string{"string"}, StandaloneExpression: false},
+			{Path: "simpleArray[0]", Expressions: []string{"array[0]"}, ExpectedTypes: []string{"string"}, StandaloneExpression: true},
+			{Path: "simpleArray[1]", Expressions: []string{"array[1]"}, ExpectedTypes: []string{"string"}, StandaloneExpression: true},
+			{Path: "mapField.key1", Expressions: []string{"map.key1"}, ExpectedTypes: []string{"string"}, StandaloneExpression: true},
+			{Path: "mapField.key2", Expressions: []string{"map.key2"}, ExpectedTypes: []string{"string"}, StandaloneExpression: true},
+			{Path: "specialCharacters.simpleAnnotation", Expressions: []string{"simpleannotation"}, ExpectedTypes: []string{"string"}, StandaloneExpression: true},
+			{Path: "specialCharacters[\"doted.annotation.key\"]", Expressions: []string{"dotedannotationvalue"}, ExpectedTypes: []string{"string"}, StandaloneExpression: true},
+			{Path: "specialCharacters[\"\"]", Expressions: []string{"emptyannotation"}, ExpectedTypes: []string{"string"}, StandaloneExpression: true},
+			{Path: "specialCharacters[\"array.name.with.dots\"][0]", Expressions: []string{"value"}, ExpectedTypes: []string{"string"}, StandaloneExpression: true},
+			{Path: "schemalessField.something", Expressions: []string{"schemaless.value"}, ExpectedTypes: []string{"string"}, StandaloneExpression: true},
+			{Path: "schemalessField.nestedSomething.nested", Expressions: []string{"schemaless.nested.value"}, ExpectedTypes: []string{"string"}, StandaloneExpression: true},
 		}
 
 		expressions, err := ParseResource(resource, schema)
@@ -456,12 +456,12 @@ func TestParseWithExpectedSchema(t *testing.T) {
 	}
 
 	expectedExpressions := map[string]variable.FieldDescriptor{
-		"stringField":                               {Path: "stringField", Expressions: []string{"string.value"}, ExpectedType: "string", ExpectedSchema: &stringFieldSchema, StandaloneExpression: true},
-		"objectField":                               {Path: "objectField", Expressions: []string{"object.value"}, ExpectedType: "object", ExpectedSchema: &objectFieldSchema, StandaloneExpression: true},
-		"nestedObjectField.nestedString":            {Path: "nestedObjectField.nestedString", Expressions: []string{"nested.string"}, ExpectedType: "string", ExpectedSchema: &nestedObjectNestedStringSchema, StandaloneExpression: true},
-		"nestedObjectField.nestedObject.deepNested": {Path: "nestedObjectField.nestedObject.deepNested", Expressions: []string{"deep.nested"}, ExpectedType: "string", ExpectedSchema: &deepNestedSchema, StandaloneExpression: true},
-		"arrayField[0]":                             {Path: "arrayField[0]", Expressions: []string{"array[0]"}, ExpectedType: "object", ExpectedSchema: arrayFieldSchema.Items.Schema, StandaloneExpression: true},
-		"arrayField[1].objectInArray":               {Path: "arrayField[1].objectInArray", Expressions: []string{"object.in.array"}, ExpectedType: "string", ExpectedSchema: &objectInArraySchema, StandaloneExpression: true},
+		"stringField":                               {Path: "stringField", Expressions: []string{"string.value"}, ExpectedTypes: []string{"string"}, ExpectedSchema: &stringFieldSchema, StandaloneExpression: true},
+		"objectField":                               {Path: "objectField", Expressions: []string{"object.value"}, ExpectedTypes: []string{"object"}, ExpectedSchema: &objectFieldSchema, StandaloneExpression: true},
+		"nestedObjectField.nestedString":            {Path: "nestedObjectField.nestedString", Expressions: []string{"nested.string"}, ExpectedTypes: []string{"string"}, ExpectedSchema: &nestedObjectNestedStringSchema, StandaloneExpression: true},
+		"nestedObjectField.nestedObject.deepNested": {Path: "nestedObjectField.nestedObject.deepNested", Expressions: []string{"deep.nested"}, ExpectedTypes: []string{"string"}, ExpectedSchema: &deepNestedSchema, StandaloneExpression: true},
+		"arrayField[0]":                             {Path: "arrayField[0]", Expressions: []string{"array[0]"}, ExpectedTypes: []string{"object"}, ExpectedSchema: arrayFieldSchema.Items.Schema, StandaloneExpression: true},
+		"arrayField[1].objectInArray":               {Path: "arrayField[1].objectInArray", Expressions: []string{"object.in.array"}, ExpectedTypes: []string{"string"}, ExpectedSchema: &objectInArraySchema, StandaloneExpression: true},
 	}
 
 	if len(expressions) != len(expectedExpressions) {
@@ -478,8 +478,8 @@ func TestParseWithExpectedSchema(t *testing.T) {
 		if !reflect.DeepEqual(expr.Expressions, expected.Expressions) {
 			t.Errorf("Path %s: expected expressions %v, got %v", expr.Path, expected.Expressions, expr.Expressions)
 		}
-		if expr.ExpectedType != expected.ExpectedType {
-			t.Errorf("Path %s: expected type %s, got %s", expr.Path, expected.ExpectedType, expr.ExpectedType)
+		if !areEqualSlices(expr.ExpectedTypes, expected.ExpectedTypes) {
+			t.Errorf("Path %s: expected type %s, got %s", expr.Path, expected.ExpectedTypes, expr.ExpectedTypes)
 		}
 		if expr.StandaloneExpression != expected.StandaloneExpression {
 			t.Errorf("Path %s: expected OneShotCEL %v, got %v", expr.Path, expected.StandaloneExpression, expr.StandaloneExpression)
@@ -714,11 +714,11 @@ func TestJoinPathAndFieldName(t *testing.T) {
 func TestPartScalerTypesShortSpecTypes(t *testing.T) {
 	tests := []struct {
 		name          string
-		shortSpecType string
+		shortSpecType []string
 		field         interface{}
 	}{
-		{"int short type for integer", "int", 42},
-		{"bool short type for boolean", "bool", true},
+		{"int short type for integer", []string{"int"}, 42},
+		{"bool short type for boolean", []string{"bool"}, true},
 	}
 
 	dummySchema := &spec.Schema{}
@@ -780,7 +780,7 @@ func TestXKubernetesIntOrString(t *testing.T) {
 				"myField": true,
 			},
 			wantErr:    true,
-			wantErrMsg: "found `xKubernetesIntOrString` extension but field value is neither a string nor an integer: true",
+			wantErrMsg: "expected integer type for path myField, got bool",
 		},
 	}
 
@@ -861,7 +861,7 @@ func TestNestedXKubernetesIntOrString(t *testing.T) {
 					},
 				},
 				wantErr:       true,
-				expectedError: "found `xKubernetesIntOrString` extension but field value is neither a string nor an integer: true",
+				expectedError: "expected integer type for path outerObject.nestedField, got bool",
 			},
 		}
 

--- a/pkg/graph/parser/schemaless.go
+++ b/pkg/graph/parser/schemaless.go
@@ -58,7 +58,7 @@ func parseSchemalessResource(resource interface{}, path string) ([]variable.Fiel
 		if ok {
 			expressionsFields = append(expressionsFields, variable.FieldDescriptor{
 				Expressions:          []string{strings.Trim(field, "${}")},
-				ExpectedType:         "any",
+				ExpectedTypes:        []string{"any"},
 				Path:                 path,
 				StandaloneExpression: true,
 			})
@@ -69,9 +69,9 @@ func parseSchemalessResource(resource interface{}, path string) ([]variable.Fiel
 			}
 			if len(expressions) > 0 {
 				expressionsFields = append(expressionsFields, variable.FieldDescriptor{
-					Expressions:  expressions,
-					ExpectedType: "any",
-					Path:         path,
+					Expressions:   expressions,
+					ExpectedTypes: []string{"any"},
+					Path:          path,
 				})
 			}
 		}

--- a/pkg/graph/parser/schemaless_test.go
+++ b/pkg/graph/parser/schemaless_test.go
@@ -30,13 +30,44 @@ func areEqualExpressionFields(a, b []variable.FieldDescriptor) bool {
 
 	for i := range a {
 		if !equalStrings(a[i].Expressions, b[i].Expressions) ||
-			a[i].ExpectedType != b[i].ExpectedType ||
+			!areEqualSlices(a[i].ExpectedTypes, b[i].ExpectedTypes) ||
 			a[i].Path != b[i].Path ||
 			a[i].StandaloneExpression != b[i].StandaloneExpression {
 			return false
 		}
 	}
 	return true
+}
+
+// areEqualSlices checks if two string slices contain the same elements, regardless of order.
+// It returns true if both slices have the same length and contain the same set of unique elements,
+// and false otherwise. This function treats the slices as sets, so duplicate elements are ignored.
+//
+// Parameters:
+//   - slice1
+//   - slice2
+//
+// Returns:
+//   - bool: true if the slices contain the same elements, false otherwise
+func areEqualSlices(slice1, slice2 []string) bool {
+	if len(slice1) != len(slice2) {
+		return false
+	}
+
+	elementSet := make(map[string]bool)
+	for _, s := range slice1 {
+		elementSet[s] = true
+	}
+
+	// Check if all elements from slice2 are in the set
+	for _, s := range slice2 {
+		if !elementSet[s] {
+			return false
+		}
+		// Remove the element to ensure uniqueness
+		delete(elementSet, s)
+	}
+	return len(elementSet) == 0
 }
 
 func TestParseSchemalessResource(t *testing.T) {
@@ -54,7 +85,7 @@ func TestParseSchemalessResource(t *testing.T) {
 			want: []variable.FieldDescriptor{
 				{
 					Expressions:          []string{"resource.value"},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "field",
 					StandaloneExpression: true,
 				},
@@ -71,7 +102,7 @@ func TestParseSchemalessResource(t *testing.T) {
 			want: []variable.FieldDescriptor{
 				{
 					Expressions:          []string{"nested.value"},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "outer.inner",
 					StandaloneExpression: true,
 				},
@@ -89,13 +120,13 @@ func TestParseSchemalessResource(t *testing.T) {
 			want: []variable.FieldDescriptor{
 				{
 					Expressions:          []string{"array[0]"},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "array[0]",
 					StandaloneExpression: true,
 				},
 				{
 					Expressions:          []string{"array[1]"},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "array[1]",
 					StandaloneExpression: true,
 				},
@@ -109,9 +140,9 @@ func TestParseSchemalessResource(t *testing.T) {
 			},
 			want: []variable.FieldDescriptor{
 				{
-					Expressions:  []string{"expr1", "expr2"},
-					ExpectedType: "any",
-					Path:         "field",
+					Expressions:   []string{"expr1", "expr2"},
+					ExpectedTypes: []string{"any"},
+					Path:          "field",
 				},
 			},
 			wantErr: false,
@@ -132,13 +163,13 @@ func TestParseSchemalessResource(t *testing.T) {
 			want: []variable.FieldDescriptor{
 				{
 					Expressions:          []string{"string.value"},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "string",
 					StandaloneExpression: true,
 				},
 				{
 					Expressions:          []string{"array.value"},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "nested.array[0]",
 					StandaloneExpression: true,
 				},
@@ -196,7 +227,7 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 			want: []variable.FieldDescriptor{
 				{
 					Expressions:          []string{"deeply.nested.value"},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "level1.level2.level3.level4",
 					StandaloneExpression: true,
 				},
@@ -218,13 +249,13 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 			want: []variable.FieldDescriptor{
 				{
 					Expressions:          []string{"expr1"},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "array[0]",
 					StandaloneExpression: true,
 				},
 				{
 					Expressions:          []string{"expr2"},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "array[3].nested",
 					StandaloneExpression: true,
 				},
@@ -240,13 +271,13 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 			want: []variable.FieldDescriptor{
 				{
 					Expressions:          []string{""},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "empty1",
 					StandaloneExpression: true,
 				},
 				{
 					Expressions:          []string{"    "},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "empty2",
 					StandaloneExpression: true,
 				},
@@ -290,36 +321,36 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 			want: []variable.FieldDescriptor{
 				{
 					Expressions:          []string{"string.value"},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "string",
 					StandaloneExpression: true,
 				},
 				{
 					Expressions:          []string{"array.value"},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "nested.array[0]",
 					StandaloneExpression: true,
 				},
 				{
-					Expressions:  []string{"expr1", "expr2"},
-					ExpectedType: "any",
-					Path:         "complex.field",
+					Expressions:   []string{"expr1", "expr2"},
+					ExpectedTypes: []string{"any"},
+					Path:          "complex.field",
 				},
 				{
 					Expressions:          []string{"nested.value"},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "complex.nested.inner",
 					StandaloneExpression: true,
 				},
 				{
 					Expressions:          []string{"expr4"},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "complex.array[1]",
 					StandaloneExpression: true,
 				},
 				{
 					Expressions:          []string{"expr5"},
-					ExpectedType:         "any",
+					ExpectedTypes:        []string{"any"},
 					Path:                 "complex.array[2]",
 					StandaloneExpression: true,
 				},

--- a/pkg/graph/variable/variable.go
+++ b/pkg/graph/variable/variable.go
@@ -32,7 +32,7 @@ type FieldDescriptor struct {
 	// Expressions is a list of CEL expressions in the field.
 	Expressions []string
 	// ExpectedType is the expected type of the field.
-	ExpectedType string
+	ExpectedTypes []string
 	// ExpectedSchema is the expected schema of the field if it is a complex type.
 	// This is only set if the field is a OneShotCEL expression, and the schema
 	// is expected to be a complex type (object or array).


### PR DESCRIPTION
fixes #181 

*Description of changes:*
- In`FieldDescriptor` convert `ExpectedType` to `ExpectedTypes` of type `[]string` 
- `getExpectedType` returns `[]string` of all valid types
- `isExpectedType` utility function verifies is the type is valid


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
