### PR TITLE
fix: Correct env name in webstack instance-tmpl.yaml

### DIFF
--- a/examples/webstack/instance-tmpl.yaml
+++ b/examples/webstack/instance-tmpl.yaml
@@ -3,7 +3,7 @@ kind: WebStack
 metadata:
   name: test-app
 spec:
-  name: $WEB_STACK_NAME
+  name: $RESOURCES_NAME
   image: candonov/s3-demo-app
   s3bucket:
     enabled: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The instructions in README and variable name used in the `instance-tmpl.yaml` don't match. This PR matches what's in the readme.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
