### PR TITLE
resourcegroup: use default KroDomainName when group is empty

### DIFF
--- a/pkg/controller/resourcegroup/controller_cleanup.go
+++ b/pkg/controller/resourcegroup/controller_cleanup.go
@@ -40,8 +40,12 @@ func (r *ResourceGroupReconciler) cleanupResourceGroup(ctx context.Context, rg *
 		return fmt.Errorf("failed to shutdown microcontroller: %w", err)
 	}
 
+	group := rg.Spec.Schema.Group
+	if group == "" {
+		group = v1alpha1.KroDomainName
+	}
 	// cleanup CRD
-	crdName := extractCRDName(rg.Spec.Schema.Group, rg.Spec.Schema.Kind)
+	crdName := extractCRDName(group, rg.Spec.Schema.Kind)
 	if err := r.cleanupResourceGroupCRD(ctx, crdName); err != nil {
 		return fmt.Errorf("failed to cleanup CRD %s: %w", crdName, err)
 	}

--- a/pkg/graph/crd/crd.go
+++ b/pkg/graph/crd/crd.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/awslabs/kro/api/v1alpha1"
 	"github.com/gobuffalo/flect"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +26,11 @@ import (
 // SynthesizeCRD generates a CustomResourceDefinition for a given API version and kind
 // with the provided spec and status schemas~
 func SynthesizeCRD(group, apiVersion, kind string, spec, status extv1.JSONSchemaProps, statusFieldsOverride bool) *extv1.CustomResourceDefinition {
-	return newCRD(group, apiVersion, kind, newCRDSchema(spec, status, statusFieldsOverride))
+	crdGroup := group
+	if crdGroup == "" {
+		crdGroup = v1alpha1.KroDomainName
+	}
+	return newCRD(crdGroup, apiVersion, kind, newCRDSchema(spec, status, statusFieldsOverride))
 }
 
 func newCRD(group, apiVersion, kind string, schema *extv1.JSONSchemaProps) *extv1.CustomResourceDefinition {


### PR DESCRIPTION
Add fallback to KroDomainName when group is not specified in
resource group controller and CRD synthesis. This ensures
consistent behavior when creating CRDs without an explicit group name.

The change affects two components:
- ResourceGroup reconciler: Set default group during cleanup
- CRD synthesis: Use default group when generating new CRDs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
