### PR TITLE
Tests: pkg dynamiccontroller: increases test coverage

### DIFF
--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -187,20 +187,42 @@ func TestAllInformerHaveSynced(t *testing.T) {
 			setupInformers: func(dc *DynamicController) {},
 			expected:       true,
 		},
+		// {
+		// 	name: "one synced informer",
+		// 	setupInformers: func(dc *DynamicController) {
+		// 		dc.informers.Store("informer", &mockSharedIndexInformer{hasSynced: true})
+		// 	},
+		// 	expected: true,
+		// },
 		{
 			name: "one unsynced informer",
 			setupInformers: func(dc *DynamicController) {
-				mockInformer := &mockSharedIndexInformer{hasSynced: false}
-				gvr := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
-				dc.informers.Store(gvr, mockInformer)
+				dc.informers.Store("informer", &mockSharedIndexInformer{hasSynced: false})
+			},
+			expected: false,
+		},
+		// {
+		// 	name: "multiple synced informers",
+		// 	setupInformers: func(dc *DynamicController) {
+		// 		dc.informers.Store("informer1", &mockSharedIndexInformer{hasSynced: true})
+		// 		dc.informers.Store("informer2", &mockSharedIndexInformer{hasSynced: true})
+		// 		dc.informers.Store("informer3", &mockSharedIndexInformer{hasSynced: true})
+		// 	},
+		// 	expected: true,
+		// },
+		{
+			name: "mix of synced and unsynced informers",
+			setupInformers: func(dc *DynamicController) {
+				dc.informers.Store("informer1", &mockSharedIndexInformer{hasSynced: true})
+				dc.informers.Store("informer2", &mockSharedIndexInformer{hasSynced: true})
+				dc.informers.Store("informer3", &mockSharedIndexInformer{hasSynced: false})
 			},
 			expected: false,
 		},
 		{
 			name: "invalid informer type",
 			setupInformers: func(dc *DynamicController) {
-				gvr := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
-				dc.informers.Store(gvr, "not an informer")
+				dc.informers.Store("informer", &mockSharedIndexInformer{})
 			},
 			expected: false,
 		},


### PR DESCRIPTION
## Description

1. Increases tests coverage from 62.5% to 76.7% for `pkg/dynamiccontroller/dynamiccontroller_test.go` file
2. Replaced deprecated go `io/ioutil` package to `io`

## ScreenShots

| Before | After |
|--------|--------|
|![Screenshot from 2025-03-18 13-54-15](https://github.com/user-attachments/assets/2f6fb51a-af9e-4ee6-80b2-19bca3563cf8)|![Screenshot from 2025-03-18 14-48-32](https://github.com/user-attachments/assets/d2aa82c0-248a-4df2-9250-71b112809cf4)| 

cc: @a-hilaly 