### PR TITLE
Watchset: Watch child objects and trigger instance reconciliation on change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,9 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet ## Run tests. Use WHAT=unit or WHAT=integration
+test: manifests generate fmt vet envtest ## Run tests. Use WHAT=unit or WHAT=integration
 ifeq ($(WHAT),integration)
-	go test -v ./test/integration/suites/... -coverprofile integration-cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v ./test/integration/suites/... -coverprofile integration-cover.out
 else ifeq ($(WHAT),unit)
 	go test -v ./pkg/... -coverprofile unit-cover.out
 else
@@ -178,6 +178,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 KO_VERSION ?= v0.17.1
 KUSTOMIZE_VERSION ?= v5.2.1
 CONTROLLER_TOOLS_VERSION ?= v0.16.2
+ENVTEST_VERSION ?= 1.31.x
 
 .PHONY: ko
 ko: $(KO) ## Download ko locally if necessary. If wrong version is installed, it will be removed before downloading.
@@ -202,6 +203,11 @@ controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessar
 $(CONTROLLER_GEN): $(LOCALBIN)
 	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) $(GOPREFIX) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 .PHONY: image
 build-image: ko ## Build the kro controller images using ko build

--- a/examples/kubernetes/simple-deployment/Readme.md
+++ b/examples/kubernetes/simple-deployment/Readme.md
@@ -1,0 +1,89 @@
+# kro SimpleDeployment example
+
+This example creates a ResourceGraphDefinition called `SimpleDeployment` and then instantiates it with
+the default nginx container image.
+
+### Create ResourceGraphDefinition called SimpleDeployment
+
+Apply the RGD to your cluster:
+
+```
+kubectl apply -f rg.yaml
+```
+
+Validate the RGD status is Active:
+
+```
+kubectl get rgd simple-deployment.kro.run
+```
+
+Expected result:
+
+```
+NAME                        APIVERSION   KIND               STATE    AGE
+simple-deployment.kro.run   v1alpha1     SimpleDeployment   Active   2m13s
+```
+
+### Create an Instance of kind App
+
+Apply the provided instance.yaml
+
+```
+kubectl apply -f instance.yaml
+```
+
+Validate instance status:
+
+```
+kubectl get simpledeployments test-app
+```
+
+Expected result:
+
+```
+NAME       STATE    SYNCED   AGE
+test-app   ACTIVE   True     16m
+```
+
+### Validate the app is working
+
+Get the ingress url:
+
+```
+kubectl get ingress test-app -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+```
+
+Either navigate in the browser or curl it:
+
+```
+curl -s $(kubectl get ingress test-app -o jsonpath='{.status.loadBalancer.ingress[0].hostname}') | sed -n '/<body>/,/<\/body>/p' | sed -e 's/<[^>]*>//g'
+```
+
+Expected result:
+
+```
+Welcome to nginx!
+If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.
+
+For online documentation and support please refer to
+nginx.org.
+Commercial support is available at
+nginx.com.
+
+Thank you for using nginx.
+```
+
+### Clean up
+
+Remove the instance:
+
+```
+kubectl delete simpledeployments test-app
+```
+
+Remove the resourcegraphdefinition:
+
+```
+kubectl delete rgd simple-deployment.kro.run
+```

--- a/examples/kubernetes/simple-deployment/instance.yaml
+++ b/examples/kubernetes/simple-deployment/instance.yaml
@@ -1,0 +1,8 @@
+apiVersion: kro.run/v1alpha1
+kind: SimpleDeployment
+metadata:
+  name: test-app
+spec:
+  name: test-app
+  port: 80 # nginx default port is 80
+  service: {} # this is needed

--- a/examples/kubernetes/simple-deployment/rg.yaml
+++ b/examples/kubernetes/simple-deployment/rg.yaml
@@ -1,0 +1,78 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: simple-deployment.kro.run
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: SimpleDeployment
+    spec:
+      name: string
+      namespace: string | default=default
+      image: string | default=nginx
+      port: integer | default=8080
+      replicas: integer | default=1
+      service:
+        enabled: boolean | default=true
+      serviceAccount: string | default=default
+    status:
+      deploymentConditions: ${deployment.status.conditions}
+      availableReplicas: ${deployment.status.availableReplicas}
+
+  resources:
+  - id: deployment
+    readyWhen:
+      - ${deployment.spec.replicas == deployment.status.availableReplicas}
+    template:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ${schema.spec.name}
+        namespace: ${schema.spec.namespace}
+        labels:
+          app.kubernetes.io/name: ${schema.spec.name}
+      spec:
+        replicas: ${schema.spec.replicas}
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: ${schema.spec.name}
+            app: ${schema.spec.name}
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: ${schema.spec.name}
+              app: ${schema.spec.name}
+          spec:
+            serviceAccountName: ${schema.spec.serviceAccount}
+            containers:
+            - name: ${schema.spec.name}
+              image: ${schema.spec.image}
+              imagePullPolicy: Always
+              ports:
+              - containerPort: ${schema.spec.port}
+              resources:
+                requests:
+                  memory: "64Mi"
+                  cpu: "250m"
+                limits:
+                  memory: "1Gi"
+                  cpu: "1"
+            restartPolicy: Always
+
+  - id: service
+    includeWhen:
+    - ${schema.spec.service.enabled}  
+    template:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: ${deployment.metadata.name}
+        namespace: ${deployment.metadata.namespace}
+      spec:
+        selector:
+          app: ${schema.spec.name}
+        ports:
+        - name: http
+          protocol: TCP
+          port: 80
+          targetPort: ${schema.spec.port}

--- a/pkg/controller/instance/controller_reconcile.go
+++ b/pkg/controller/instance/controller_reconcile.go
@@ -56,6 +56,9 @@ type instanceGraphReconciler struct {
 	gvr schema.GroupVersionResource
 	// client is a dynamic client for interacting with the Kubernetes API server
 	client dynamic.Interface
+	// resourceClient is a dynamic client for interacting with the Kubernetes API server
+	// for resources.
+	resourceClient dynamic.Interface
 	// runtime is the runtime representation of the ResourceGraphDefinition. It holds the
 	// information about the instance and its sub-resources, the CEL expressions
 	// their dependencies, and the resolved values... etc
@@ -233,9 +236,9 @@ func (igr *instanceGraphReconciler) getResourceClient(resourceID string) dynamic
 	namespace := igr.getResourceNamespace(resourceID)
 
 	if descriptor.IsNamespaced() {
-		return igr.client.Resource(gvr).Namespace(namespace)
+		return igr.resourceClient.Resource(gvr).Namespace(namespace)
 	}
-	return igr.client.Resource(gvr)
+	return igr.resourceClient.Resource(gvr)
 }
 
 // handleResourceCreation manages the creation of a new resource

--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -388,11 +388,11 @@ func (dc *DynamicController) updateFunc(old, new interface{}) {
 		return
 	}
 
-	dc.enqueueObject(new, "update")
+	dc.EnqueueObject(new, "update")
 }
 
 // enqueueObject adds an object to the workqueue
-func (dc *DynamicController) enqueueObject(obj interface{}, eventType string) {
+func (dc *DynamicController) EnqueueObject(obj interface{}, eventType string) {
 	namespacedKey, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		dc.log.Error(err, "Failed to get key for object", "eventType", eventType)
@@ -437,7 +437,7 @@ func (dc *DynamicController) StartServingGVK(ctx context.Context, gvr schema.Gro
 			return fmt.Errorf("failed to list objects for GVR %s: %w", gvr, err)
 		}
 		for _, obj := range objs.Items {
-			dc.enqueueObject(&obj, "update")
+			dc.EnqueueObject(&obj, "update")
 		}
 		return nil
 	}
@@ -455,9 +455,9 @@ func (dc *DynamicController) StartServingGVK(ctx context.Context, gvr schema.Gro
 
 	// Set up event handlers
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { dc.enqueueObject(obj, "add") },
+		AddFunc:    func(obj interface{}) { dc.EnqueueObject(obj, "add") },
 		UpdateFunc: dc.updateFunc,
-		DeleteFunc: func(obj interface{}) { dc.enqueueObject(obj, "delete") },
+		DeleteFunc: func(obj interface{}) { dc.EnqueueObject(obj, "delete") },
 	})
 	if err != nil {
 		dc.log.Error(err, "Failed to add event handler", "gvr", gvr)

--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -153,7 +153,7 @@ func TestEnqueueObject(t *testing.T) {
 	obj.SetNamespace("default")
 	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "test", Version: "v1", Kind: "Test"})
 
-	dc.enqueueObject(obj, "add")
+	dc.EnqueueObject(obj, "add")
 
 	assert.Equal(t, 1, dc.queue.Len())
 }

--- a/watchset/dynamicinterface.go
+++ b/watchset/dynamicinterface.go
@@ -1,0 +1,206 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchset
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+)
+
+var _ dynamic.Interface = &dynamicInterface{}
+var _ dynamic.NamespaceableResourceInterface = &namespaceableRsrcInterface{}
+var _ dynamic.ResourceInterface = &rsrcInterface{}
+
+type WatchSetManager interface {
+	HandleCreate(ctx context.Context, obj *unstructured.Unstructured)
+	HandleUpdate(ctx context.Context, obj *unstructured.Unstructured)
+	HandlePatch(ctx context.Context, obj *unstructured.Unstructured)
+	HandleDelete(ctx context.Context, obj *unstructured.Unstructured)
+	HandleGet(ctx context.Context, obj *unstructured.Unstructured)
+}
+
+type dynamicInterface struct {
+	dynamic.Interface
+	watchsetMgr WatchSetManager
+}
+
+// NewDynamicInterface wraps a kubernetes dynamic interface client and adds watchset support.
+// The `dynInterface` is the kubernetes dynamic interface that will be used wrapped and setup to invoke `watchsetMgr`
+// to watch resources. `watchsetMgr` can be either a label based manager or an object based manager.
+// The `watchsetMgr` is used to register watches for resources being created/updated/deleted by the `dynInterface`.
+// The `watchsetMgr` can be created using the `watchset.NewWatchManagerUsingObject()` or
+// `watchset.NewWatchManagerUsingLabels()` functions.
+func NewDynamicInterface(dynInterface dynamic.Interface, watchsetMgr WatchSetManager) dynamic.Interface {
+	return &dynamicInterface{
+		Interface:   dynInterface,
+		watchsetMgr: watchsetMgr,
+	}
+}
+
+func (di *dynamicInterface) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	ri := di.Interface.Resource(resource)
+	return &namespaceableRsrcInterface{
+		NamespaceableResourceInterface: ri,
+		gvr:                            resource,
+		di:                             di,
+	}
+}
+
+type namespaceableRsrcInterface struct {
+	gvr schema.GroupVersionResource
+	dynamic.NamespaceableResourceInterface
+	di *dynamicInterface
+}
+
+func (nri *namespaceableRsrcInterface) Namespace(ns string) dynamic.ResourceInterface {
+	return &rsrcInterface{
+		nri:               nri,
+		ns:                ns,
+		ResourceInterface: nri.NamespaceableResourceInterface.Namespace(ns),
+	}
+}
+
+type rsrcInterface struct {
+	ns string
+	dynamic.ResourceInterface
+	nri *namespaceableRsrcInterface
+}
+
+func (ri *rsrcInterface) Create(
+	ctx context.Context,
+	obj *unstructured.Unstructured,
+	options metav1.CreateOptions,
+	subresources ...string,
+) (*unstructured.Unstructured, error) {
+	u, err := ri.ResourceInterface.Create(ctx, obj, options, subresources...)
+	if err == nil {
+		ri.nri.di.watchsetMgr.HandleCreate(ctx, u)
+	}
+	return u, err
+}
+
+func (ri *rsrcInterface) Update(
+	ctx context.Context,
+	obj *unstructured.Unstructured,
+	options metav1.UpdateOptions,
+	subresources ...string,
+) (*unstructured.Unstructured, error) {
+	u, err := ri.ResourceInterface.Update(ctx, obj, options, subresources...)
+	if err == nil {
+		ri.nri.di.watchsetMgr.HandleUpdate(ctx, u)
+	}
+	return u, err
+}
+
+func (ri *rsrcInterface) UpdateStatus(
+	ctx context.Context,
+	obj *unstructured.Unstructured,
+	options metav1.UpdateOptions,
+) (*unstructured.Unstructured, error) {
+	panic("method not implemented")
+}
+func (ri *rsrcInterface) Delete(
+	ctx context.Context,
+	name string,
+	options metav1.DeleteOptions,
+	subresources ...string,
+) error {
+	err := ri.ResourceInterface.Delete(ctx, name, options, subresources...)
+	if err != nil {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": ri.nri.gvr.GroupVersion().String(),
+				"kind":       ri.nri.gvr.Resource,
+				"metadata":   map[string]interface{}{"name": name, "namespace": ri.ns},
+			},
+		}
+		ri.nri.di.watchsetMgr.HandleDelete(ctx, obj)
+	}
+	return err
+}
+func (ri *rsrcInterface) DeleteCollection(
+	ctx context.Context,
+	options metav1.DeleteOptions,
+	listOptions metav1.ListOptions,
+) error {
+	panic("method not implemented")
+}
+func (ri *rsrcInterface) Get(
+	ctx context.Context,
+	name string,
+	options metav1.GetOptions,
+	subresources ...string,
+) (*unstructured.Unstructured, error) {
+	u, err := ri.ResourceInterface.Get(ctx, name, options, subresources...)
+	if err == nil {
+		ri.nri.di.watchsetMgr.HandleGet(ctx, u)
+	}
+	return u, err
+}
+
+func (ri *rsrcInterface) List(
+	ctx context.Context,
+	opts metav1.ListOptions,
+) (*unstructured.UnstructuredList, error) {
+	u, err := ri.ResourceInterface.List(ctx, opts)
+	return u, err
+}
+
+func (ri *rsrcInterface) Watch(
+	ctx context.Context,
+	opts metav1.ListOptions,
+) (watch.Interface, error) {
+	panic("method not implemented")
+}
+
+func (ri *rsrcInterface) Patch(
+	ctx context.Context,
+	name string,
+	pt types.PatchType,
+	data []byte,
+	options metav1.PatchOptions,
+	subresources ...string,
+) (*unstructured.Unstructured, error) {
+	u, err := ri.ResourceInterface.Patch(ctx, name, pt, data, options, subresources...)
+	if err == nil {
+		ri.nri.di.watchsetMgr.HandlePatch(ctx, u)
+	}
+	return u, err
+}
+
+func (ri *rsrcInterface) Apply(
+	ctx context.Context,
+	name string,
+	obj *unstructured.Unstructured,
+	options metav1.ApplyOptions,
+	subresources ...string,
+) (*unstructured.Unstructured, error) {
+	panic("method not implemented")
+}
+
+func (ri *rsrcInterface) ApplyStatus(
+	ctx context.Context,
+	name string,
+	obj *unstructured.Unstructured,
+	options metav1.ApplyOptions,
+) (*unstructured.Unstructured, error) {
+	panic("method not implemented")
+}

--- a/watchset/labelwatchmanager.go
+++ b/watchset/labelwatchmanager.go
@@ -1,0 +1,136 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchset
+
+import (
+	"context"
+	"log"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type watchManagerUsingLabels struct {
+	watchset *WatchSet
+	parent   *unstructured.Unstructured
+	idFn     func(labels map[string]string) (string, error)
+	checkFn  func(obj *unstructured.Unstructured) bool
+	trigger  Trigger
+}
+
+// NewWatchManagerUsingLabels creates a new WatchManager that can be used by the `watchset.NewDynamicInterface()`
+// to register watches with `watchset`. Any resources get/create/update are automatically added to the watchset.
+// Any time those resources are updated/deleted, the `parent` is notified. Watches are setup per GVK and a
+// map[id]callbacks are used to demux a child event to the parent. Since we are watching based on labels, the ID
+// has to be constructed from the child labels to uniquely identify the parent. We use a user provided `idFn` to
+// generate the id given the child labels.
+// The `checkFn` is used to do a quick check if the child event should be processed or ignored. In this case the
+// user should match the child labels to the parent metadata and return true if it matches the parent.
+// The `trigger` provides either a channel or a callback function where the parent event is sent.
+func NewWatchManagerUsingLabels(
+	watchset *WatchSet,
+	parent *unstructured.Unstructured,
+	idFn func(labels map[string]string) (string, error),
+	checkFn func(obj *unstructured.Unstructured) bool,
+	trigger Trigger,
+) WatchSetManager {
+	return &watchManagerUsingLabels{
+		watchset: watchset,
+		parent:   parent,
+		idFn:     idFn,
+		checkFn:  checkFn,
+		trigger:  trigger,
+	}
+}
+
+func (w *watchManagerUsingLabels) HandleGet(ctx context.Context, obj *unstructured.Unstructured) {
+	w.HandlePatch(ctx, obj)
+}
+
+func (w *watchManagerUsingLabels) HandleUpdate(ctx context.Context, obj *unstructured.Unstructured) {
+	w.HandlePatch(ctx, obj)
+}
+
+func (w *watchManagerUsingLabels) HandleCreate(ctx context.Context, obj *unstructured.Unstructured) {
+	w.HandlePatch(ctx, obj)
+}
+
+func (w *watchManagerUsingLabels) HandlePatch(ctx context.Context, obj *unstructured.Unstructured) {
+	if obj == nil {
+		return
+	}
+
+	id, err := w.idFn(obj.GetLabels())
+	if err != nil {
+		log.Printf("Failed to get watchset id for %s/%s: %v",
+			obj.GetKind(),
+			obj.GetName(),
+			err)
+		return
+	}
+
+	gk := schema.GroupKind{
+		Group: obj.GetObjectKind().GroupVersionKind().Group,
+		Kind:  obj.GetObjectKind().GroupVersionKind().Kind,
+	}
+
+	triggerFn := w.trigger.TriggerFn
+
+	if triggerFn == nil {
+		triggerFn = func(event watch.Event) {
+			parentEvent := watch.Event{
+				Type:   watch.Modified,
+				Object: w.parent,
+			}
+			w.trigger.Channel <- parentEvent
+		}
+	}
+	// Register a watch for this specific resource
+	if err := w.watchset.RegisterGK(id, gk, w.checkFn, triggerFn); err != nil {
+		log.Printf("Failed to register watch for %s/%s: %v",
+			obj.GetKind(),
+			obj.GetName(),
+			err)
+	}
+}
+
+func (w *watchManagerUsingLabels) HandleDelete(ctx context.Context, obj *unstructured.Unstructured) {
+	if obj == nil {
+		return
+	}
+
+	id, err := w.idFn(obj.GetLabels())
+	if err != nil {
+		log.Printf("Failed to get watchset id for %s/%s: %v",
+			obj.GetKind(),
+			obj.GetName(),
+			err)
+		return
+	}
+
+	gk := schema.GroupKind{
+		Group: obj.GetObjectKind().GroupVersionKind().Group,
+		Kind:  obj.GetObjectKind().GroupVersionKind().Kind,
+	}
+
+	// Unregister the watch using the parent and child objects
+	if err := w.watchset.UnregisterGK(id, gk); err != nil {
+		log.Printf("Failed to unregister watch for %s/%s: %v",
+			obj.GetKind(),
+			obj.GetName(),
+			err)
+	}
+}

--- a/watchset/objectwatchmanager.go
+++ b/watchset/objectwatchmanager.go
@@ -1,0 +1,86 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchset
+
+import (
+	"context"
+	"log"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type watchManagerUsingObject struct {
+	watchset *WatchSet
+	parent   *unstructured.Unstructured
+	trigger  Trigger
+}
+
+// NewWatchManagerUsingObject creates a new WatchManager that can be used by the `watchset.NewDynamicInterface()`
+// to register watches with `watchset`. Any resources get/create/update are automatically added to the watchset.
+// Any time those resources are updated/deleted, the `parent` is notified. Watches are setup per GVK and a
+// map[id]callbacks are used to demux a child event to the parent. This manager uses watchset to automatically
+// construct the ID from the parent and child object.
+// The `trigger` provides either a channel or a callback function where the parent event is sent.
+func NewWatchManagerUsingObject(
+	watchset *WatchSet,
+	parent *unstructured.Unstructured,
+	trigger Trigger,
+) WatchSetManager {
+	return &watchManagerUsingObject{
+		watchset: watchset,
+		parent:   parent,
+		trigger:  trigger,
+	}
+}
+
+func (w *watchManagerUsingObject) HandleGet(ctx context.Context, obj *unstructured.Unstructured) {
+	w.HandlePatch(ctx, obj)
+}
+
+func (w *watchManagerUsingObject) HandleUpdate(ctx context.Context, obj *unstructured.Unstructured) {
+	w.HandlePatch(ctx, obj)
+}
+
+func (w *watchManagerUsingObject) HandleCreate(ctx context.Context, obj *unstructured.Unstructured) {
+	w.HandlePatch(ctx, obj)
+}
+
+func (w *watchManagerUsingObject) HandlePatch(ctx context.Context, obj *unstructured.Unstructured) {
+	if obj == nil {
+		return
+	}
+
+	// Register a watch for this specific resource
+	if err := w.watchset.RegisterGVKNNForParent(w.trigger, w.parent, obj); err != nil {
+		log.Printf("Failed to register watch for %s/%s: %v",
+			obj.GetKind(),
+			obj.GetName(),
+			err)
+	}
+}
+
+func (w *watchManagerUsingObject) HandleDelete(ctx context.Context, obj *unstructured.Unstructured) {
+	if obj == nil {
+		return
+	}
+
+	// Unregister the watch using the parent and child objects
+	if err := w.watchset.UnregisterGVKNNForParent(w.parent, obj); err != nil {
+		log.Printf("Failed to unregister watch for %s/%s: %v",
+			obj.GetKind(),
+			obj.GetName(),
+			err)
+	}
+}

--- a/watchset/watchset.go
+++ b/watchset/watchset.go
@@ -1,0 +1,347 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchset
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+)
+
+// WatchSet manages watches for GroupKinds
+type WatchSet struct {
+	client dynamic.Interface
+	// Map of GroupKind to check and trigger function pairs
+	// map[GR]map[ID]callbackFns
+	callbackMap sync.Map
+
+	// watchMap is a map of GroupResource to bool
+	// map[GR]watchEntry
+	watchMap sync.Map
+
+	// labelSelector is the label selector to use for the watch
+	labelSelector string
+
+	// RESTMapper for mapping GK to GVR
+	restMapper meta.RESTMapper
+
+	// cancelFn is a context.CancelFunc that stops the watchSet
+	cancelFn  context.CancelFunc
+	cancelCtx context.Context
+}
+
+// NewWatchGK creates a new WatchGK instance
+func NewWatchSet(
+	ctx context.Context,
+	client dynamic.Interface,
+	restMapper meta.RESTMapper,
+	labelSelector string,
+) *WatchSet {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancelFn := context.WithCancel(ctx)
+	return &WatchSet{
+		client:        client,
+		restMapper:    restMapper,
+		cancelFn:      cancelFn,
+		cancelCtx:     ctx,
+		labelSelector: labelSelector,
+	}
+}
+
+type watchEntry struct {
+	watcher watch.Interface
+	stopCh  chan struct{}
+}
+
+// CheckFn is a function that checks if an event should trigger a callback
+type CheckFn func(*unstructured.Unstructured) bool
+
+// TriggerFn is a function that handles an event
+type TriggerFn func(watch.Event)
+
+// callbackFns represents a check and trigger function pair
+type callbackFns struct {
+	CheckFn   CheckFn
+	TriggerFn TriggerFn
+}
+
+type Trigger struct {
+	Channel   chan<- watch.Event
+	TriggerFn TriggerFn
+}
+
+// UnregisterGVKNN unregisters a check and trigger function pair for a GroupVersionKind and NamespacedName
+func (w *WatchSet) UnregisterGVKNNForParent(
+	parent,
+	child *unstructured.Unstructured,
+) error {
+	// Convert GroupKind to GroupVersionResource using RESTMapper
+	// Watch should trigger for all versions of the GVK so ignoring version.
+	gk := schema.GroupKind{
+		Group: child.GetObjectKind().GroupVersionKind().Group,
+		Kind:  child.GetKind(),
+	}
+
+	parentGVK := fmt.Sprintf("%s/%s", parent.GetAPIVersion(), parent.GetKind())
+	parentNN := fmt.Sprintf("%s/%s", parent.GetNamespace(), parent.GetName())
+	childGVK := fmt.Sprintf("%s/%s", child.GetAPIVersion(), child.GetKind())
+	childNN := fmt.Sprintf("%s/%s", child.GetNamespace(), child.GetName())
+	id := fmt.Sprintf("%s/%s/%s/%s", parentGVK, parentNN, childGVK, childNN)
+
+	return w.UnregisterGK(id, gk)
+}
+
+// UnregisterGKForParent unregisters a check and trigger function pair for a GroupVersionKind and NamespacedName
+func (w *WatchSet) UnregisterGKForParent(id string, parent *unstructured.Unstructured, gk schema.GroupKind) error {
+	// Convert GroupKind to GroupVersionResource using RESTMapper
+	// Watch should trigger for all versions of the GVK so ignoring version.
+	mapping, err := w.restMapper.RESTMapping(gk)
+	if err != nil {
+		return err
+	}
+	gvr := schema.GroupVersionResource{
+		Group:    mapping.GroupVersionKind.Group,
+		Version:  mapping.GroupVersionKind.Version,
+		Resource: mapping.Resource.Resource,
+	}
+
+	parentGVK := fmt.Sprintf("%s/%s", parent.GetAPIVersion(), parent.GetKind())
+	parentNN := fmt.Sprintf("%s/%s", parent.GetNamespace(), parent.GetName())
+	id = fmt.Sprintf("%s/%s/%s", parentGVK, parentNN, id)
+
+	return w.UnregisterGVR(id, gvr)
+}
+
+func (w *WatchSet) UnregisterGVR(id string, gvr schema.GroupVersionResource) error {
+	gr := schema.GroupResource{
+		Group:    gvr.Group,
+		Resource: gvr.Resource,
+	}
+
+	callbackMap, ok := w.callbackMap.Load(gr)
+	if !ok {
+		return nil
+	}
+
+	callbackMap.(*sync.Map).Delete(id)
+	return nil
+}
+
+// UnregisterGK unregisters a check and trigger function pair for a GroupVersionKind
+func (w *WatchSet) UnregisterGK(id string, gk schema.GroupKind) error {
+	// Convert GroupKind to GroupVersionResource using RESTMapper
+	// Watch should trigger for all versions of the GVK so ignoring version.
+	mapping, err := w.restMapper.RESTMapping(gk)
+	if err != nil {
+		return err
+	}
+	gvr := schema.GroupVersionResource{
+		Group:    mapping.GroupVersionKind.Group,
+		Version:  mapping.GroupVersionKind.Version,
+		Resource: mapping.Resource.Resource,
+	}
+
+	return w.UnregisterGVR(id, gvr)
+}
+
+func (w *WatchSet) RegisterGVR(id string, gvr schema.GroupVersionResource, checkFn CheckFn, triggerFn TriggerFn) error {
+	gr := schema.GroupResource{
+		Group:    gvr.Group,
+		Resource: gvr.Resource,
+	}
+
+	callbackMap, _ := w.callbackMap.LoadOrStore(gr, &sync.Map{})
+	callbackMap.(*sync.Map).Store(id, callbackFns{CheckFn: checkFn, TriggerFn: triggerFn})
+	w.startWatch(gvr)
+	return nil
+}
+
+// RegisterGK registers a check and trigger function pair for a GroupVersionKind
+func (w *WatchSet) RegisterGK(id string, gk schema.GroupKind, checkFn CheckFn, triggerFn TriggerFn) error {
+	// Convert GroupKind to GroupVersionResource using RESTMapper
+	// Watch should trigger for all versions of the GVK so ignoring version.
+	mapping, err := w.restMapper.RESTMapping(gk)
+	if err != nil {
+		return err
+	}
+	gvr := schema.GroupVersionResource{
+		Group:    mapping.GroupVersionKind.Group,
+		Version:  mapping.GroupVersionKind.Version,
+		Resource: mapping.Resource.Resource,
+	}
+
+	return w.RegisterGVR(id, gvr, checkFn, triggerFn)
+}
+
+// RegisterGKForParent registers a check and trigger function pair for a GroupVersionKind for a parent object
+func (w *WatchSet) RegisterGKForParent(
+	id string,
+	trigger Trigger,
+	parent *unstructured.Unstructured,
+	gk schema.GroupKind,
+	checkFn CheckFn,
+) error {
+	mapping, err := w.restMapper.RESTMapping(gk)
+	if err != nil {
+		return err
+	}
+	gvr := schema.GroupVersionResource{
+		Group:    mapping.GroupVersionKind.Group,
+		Version:  mapping.GroupVersionKind.Version,
+		Resource: mapping.Resource.Resource,
+	}
+	triggerFn := trigger.TriggerFn
+	if triggerFn == nil {
+		triggerFn = func(event watch.Event) {
+			// Create a new event with the parent object
+			parentEvent := watch.Event{
+				// Any change in the child is treated as a Modified event for the parent.
+				Type:   watch.Modified,
+				Object: parent,
+			}
+			trigger.Channel <- parentEvent
+		}
+	}
+
+	parentGVK := fmt.Sprintf("%s/%s", parent.GetAPIVersion(), parent.GetKind())
+	parentNN := fmt.Sprintf("%s/%s", parent.GetNamespace(), parent.GetName())
+	id = fmt.Sprintf("%s/%s/%s", parentGVK, parentNN, id)
+
+	return w.RegisterGVR(id, gvr, checkFn, triggerFn)
+}
+
+// RegisterGVKNNForParent registers a watch for a specific GVK and NamespacedName for a parent object
+func (w *WatchSet) RegisterGVKNNForParent(trigger Trigger, parent, child *unstructured.Unstructured) error {
+	if trigger.Channel == nil && trigger.TriggerFn == nil {
+		return fmt.Errorf("one of the trigger channel or trigger function must be provided")
+	}
+
+	gk := schema.GroupKind{
+		Group: child.GetObjectKind().GroupVersionKind().Group,
+		Kind:  child.GetKind(),
+	}
+
+	checkFn := func(obj *unstructured.Unstructured) bool {
+		// Check if this object matches the child's name and namespace
+		// We can depend on labels but labels could be deleted intentionally or accidentally.
+		if obj.GetName() == child.GetName() && obj.GetNamespace() == child.GetNamespace() {
+			return true
+		}
+		return false
+	}
+
+	triggerFn := trigger.TriggerFn
+	if triggerFn == nil {
+		triggerFn = func(event watch.Event) {
+			// Create a new event with the parent object
+			parentEvent := watch.Event{
+				// Any change in the child is treated as a Modified event for the parent.
+				Type:   watch.Modified,
+				Object: parent,
+			}
+			trigger.Channel <- parentEvent
+		}
+	}
+	parentGVK := fmt.Sprintf("%s/%s", parent.GetAPIVersion(), parent.GetKind())
+	parentNN := fmt.Sprintf("%s/%s", parent.GetNamespace(), parent.GetName())
+	childGVK := fmt.Sprintf("%s/%s", child.GetAPIVersion(), child.GetKind())
+	childNN := fmt.Sprintf("%s/%s", child.GetNamespace(), child.GetName())
+	id := fmt.Sprintf("%s/%s/%s/%s", parentGVK, parentNN, childGVK, childNN)
+
+	return w.RegisterGK(id, gk, checkFn, triggerFn)
+}
+
+// startWatch starts a watch for a GroupResource
+func (w *WatchSet) startWatch(gvr schema.GroupVersionResource) {
+	gr := schema.GroupResource{
+		Group:    gvr.Group,
+		Resource: gvr.Resource,
+	}
+
+	// return if already watching
+	_, existing := w.watchMap.LoadOrStore(gr, &watchEntry{watcher: nil, stopCh: make(chan struct{})})
+	if existing {
+		return
+	}
+
+	go func() {
+		//log.Printf("Starting watch for %s", gr)
+		errCount := 0
+		defer w.watchMap.Delete(gr)
+		for {
+			select {
+			case <-w.cancelCtx.Done():
+				log.Printf("WatchSet stopped (context cancelled) for %s", gr)
+				return
+			default:
+			}
+
+			listOptions := metav1.ListOptions{}
+			if w.labelSelector != "" {
+				listOptions.LabelSelector = w.labelSelector
+			}
+			watcher, err := w.client.Resource(gvr).Watch(context.Background(), listOptions)
+			if err != nil {
+				// Log error and retry
+				log.Printf("Error watching %s: %v", gr, err)
+				errCount++
+				if errCount > 100 {
+					log.Printf("Giving up watching %s: %v", gr, err)
+					break
+				}
+				time.Sleep(5 * time.Second)
+				continue
+			}
+
+			w.watchMap.Store(gr, &watchEntry{watcher: watcher, stopCh: make(chan struct{})})
+
+			// Process events
+			for event := range watcher.ResultChan() {
+				select {
+				case <-w.cancelCtx.Done():
+					log.Printf("WatchSet stopped (context cancelled) for %s", gr)
+					return
+				default:
+				}
+				if obj, ok := event.Object.(*unstructured.Unstructured); ok {
+					if callbackMap, ok := w.callbackMap.Load(gr); ok {
+						callbackMap.(*sync.Map).Range(func(key, value any) bool {
+							if value.(callbackFns).CheckFn(obj) {
+								value.(callbackFns).TriggerFn(event)
+							}
+							return true
+						})
+					}
+				}
+			}
+		}
+	}()
+}
+
+// StopWatch stops watching a GroupKind
+func (w *WatchSet) Stop() {
+	w.cancelFn()
+}


### PR DESCRIPTION
Watch child objects and trigger instance reconciliation on change
* watchset package to implement watches
  * Abstracts changes away from kro controllers
  * Reusable package that can be used for other controllers
  * Can be upstreamed to k8s ecosystem at some point.
* watchset implementation
  * watchset sets up watches per GVK and uses a map[id]callbacks to
    demux event object to parent object.
  * When an event is detected (for a GVK), check callback is called to
    see if it matches a specific resource. If it matches, trigger
    callback is invoked to generate a parent (instance) event for the
    reconciler.
  * Uses a dynamic interface that intercepts reconciler calls on behalf
    of a parent and added the resources to a watchset.
  * watchset manager interface is used by dynamic interface to register
    handlers for an object.
  * objectWatchManager - sets up callback per object-parent pair.
  * labelWatchManager - sets up callback per parent based on labels.
* Changes in kro controller
  * Create watchset in RGD reconciler with a label selector
  * Use watchset dynamic client for managing resources in instance
    reconciler
  * During reconcile setup watchManager using object and a trigger
    callback to Enqueue the parent to dynamic controller.
* examples/kubernetes
  * Add a simple-deployment example for testing. The current webapp does
    not successfully reconcile in a kind cluster.
* Makefile changes to help with e2e test locally.

### E2E Tests

```
❯ make test-e2e
go test -v ./test/e2e/suites/basic/...
=== RUN   TestAutoscaledDeploymentRGD
    multi_resource_test.go:38: Using namespace: e2e-autoscaled-deployment-rgd-1748650149, from: testdata/../../../../test/e2e/testdata/autoscaled-deployment-rgd
    testcase.go:193: Running step0: Install the RGD AutoscaledDeployment that creates a ConfigMap, Service, Deployment, and HPA 
    testcase.go:359:    Applying ResourceGraphDefinition/autoscaled-deployment-rgd[rgd.yaml]
    verify.go:57:       Verifying ResourceGraphDefinition/autoscaled-deployment-rgd[0rgd.yaml]
    verify.go:57:       Verifying CustomResourceDefinition/autoscaleddeployments.kro.run[1instancecrd.yaml]
    testcase.go:193: Running step1: Create an instance of AutoscaledDeployment with initial settings (version 1.24, 1 replica, 20% CPU utilization) 
    testcase.go:359:    Applying AutoscaledDeployment/test-app-instance[instance.yaml]
    verify.go:57:       Verifying ConfigMap/test-app-config[configmap.yaml]
    verify.go:57:       Verifying Deployment/test-app-deployment[deployment.yaml]
    verify.go:57:       Verifying HorizontalPodAutoscaler/test-app-hpa[hpa.yaml]
    verify.go:57:       Verifying AutoscaledDeployment/test-app-instance[instance.yaml]
    verify.go:57:       Verifying Service/test-app-service[service.yaml]
    testcase.go:193: Running step2: Update the instance to use a newer version (1.25) which should trigger a rolling update of the Deployment 
    testcase.go:359:    Applying AutoscaledDeployment/test-app-instance[instance.yaml]
    verify.go:57:       Verifying Deployment/test-app-deployment[deployment.yaml]
    testcase.go:193: Running step3: Update the instance to increase replicas to 3 and adjust HPA settings (min: 2, max: 5) 
    testcase.go:359:    Applying AutoscaledDeployment/test-app-instance[instance.yaml]
    verify.go:57:       Verifying Deployment/test-app-deployment[deployment.yaml]
    verify.go:57:       Verifying HorizontalPodAutoscaler/test-app-hpa[hpa.yaml]
    testcase.go:134: Deleting namespace: e2e-autoscaled-deployment-rgd-1748650149
    testcase.go:148: Deleting cluster-scoped object: ResourceGraphDefinition/autoscaled-deployment-rgd
--- PASS: TestAutoscaledDeploymentRGD (25.35s)
=== RUN   TestSimpleDeploymentRGD
    simple_deployment_test.go:27: Using namespace: e2e-simple-deployment-rgd-1748650174, from: testdata/../../../../test/e2e/testdata/simple-deployment-rgd
    testcase.go:193: Running step0: Install RGD and verify that the RGD is created
    testcase.go:359:    Applying ResourceGraphDefinition/simple-deployment-rgd[rgd.yaml]
    verify.go:57:       Verifying ResourceGraphDefinition/simple-deployment-rgd[0rgd.yaml]
    verify.go:57:       Verifying CustomResourceDefinition/simpledeployments.kro.run[1instancecrd.yaml]
    testcase.go:193: Running step1: Create instance SimpleDeployment with replicas=2
    testcase.go:359:    Applying SimpleDeployment/test-instance[instance.yaml]
    verify.go:57:       Verifying Deployment/test-instance[deployment.yaml]
    verify.go:57:       Verifying SimpleDeployment/test-instance[instance.yaml]
    testcase.go:193: Running step2: Update instance SimpleDeployment with replicas=3
    testcase.go:359:    Applying SimpleDeployment/test-instance[instance.yaml]
    verify.go:57:       Verifying Deployment/test-instance[deployment.yaml]
    testcase.go:134: Deleting namespace: e2e-simple-deployment-rgd-1748650174
    testcase.go:148: Deleting cluster-scoped object: ResourceGraphDefinition/simple-deployment-rgd
--- PASS: TestSimpleDeploymentRGD (15.17s)
PASS
ok      github.com/kro-run/kro/test/e2e/suites/basic    40.575s
```