### PR TITLE
Update PR and commit style guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,13 +35,17 @@ To send create a Pull Request, please:
 
 1. Fork the repository.
 2. Make commits in your fork.
-   * Please focus on the specific change you are contributing.
-   * If your work must include changes in various functional areas, consider using multiple commits so they can be reviewed and managed atomically.
-   * If your change includes large scale reformats, please separate these changes into their own commits. It is difficult to review reformats and implementation changes together.
+   * Please focus on the specific change you are contributing. While many PRs require multiple commits, if commits start addressing other issues, please migrate these changes to another PR. 
+   * Please use single-intent commits, squashing intermediate updates and fixes. This helps PR review and makes rebases and merges smoother.
+   * If changes include large scale reformats, please separate these changes into their own commits. This makes it easier to review reformats and implementation changes together in the same PR.
+   * Please use clear commit messages, describing your committed changes.
 3. Please ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Create a PR from your fork, answering any default questions in the pull request interface.
-6. Monitor for automated CI failures reported in the pull request, and stay involved in the conversation (followups, rebases, etc are all part of the process).
+   * We can't start meaningful review and discussion if tests are failing.
+   * Feel free to update any tests that require it; often failing tests are simply related to changes in the PR.
+   * If you are adding new functionality, please include tests along with your changes.
+   * This step is especially required when using agentic AI to help with the coding.
+4. Create a PR from your fork, answering any default questions in the pull request interface.
+5. Monitor for automated CI failures reported in the pull request, and stay involved in the conversation (followups, rebases, etc are all part of the process).
 
 GitHub provides nice documentation on [forking a repository](https://help.github.com/articles/fork-a-repo/) and [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 


### PR DESCRIPTION
This PR adds a bit more specificity to contribution guidance, including guiding toward single-scope PRs and single-intent commits.