### PR TITLE
feat: Add support for passing unstructured data to CRDs managed by KRO

### DIFF
--- a/pkg/simpleschema/transform.go
+++ b/pkg/simpleschema/transform.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -28,6 +29,7 @@ const (
 	keyTypeInteger = string(AtomicTypeInteger)
 	keyTypeBoolean = string(AtomicTypeBool)
 	keyTypeNumber  = "number"
+	keyTypeObject  = "object"
 )
 
 // A predefinedType is a type that is predefined in the schema.
@@ -128,6 +130,9 @@ func (tf *transformer) parseFieldSchema(key, fieldValue string, parentSchema *ex
 
 	if isAtomicType(fieldType) {
 		fieldJSONSchemaProps.Type = fieldType
+	} else if fieldType == keyTypeObject {
+		fieldJSONSchemaProps.Type = fieldType
+		fieldJSONSchemaProps.XPreserveUnknownFields = ptr.To(true)
 	} else if isCollectionType(fieldType) {
 		if isMapType(fieldType) {
 			fieldJSONSchemaProps, err = tf.handleMapType(key, fieldType)

--- a/test/e2e/chainsaw/check-arbitary-objects/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/check-arbitary-objects/chainsaw-test.yaml
@@ -1,0 +1,43 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: check-arbitrary-objects
+spec:
+  description: |
+    Tests if an instance with a key of type 'object' allows passing unstructured data
+  steps:
+  - name: install-rgd
+    try:
+    #description: Install the RGD that creates an Instance CRD
+    - apply:
+        file: rgd.yaml
+      description: Apply RGD
+    - assert:
+        file: rgd-assert.yaml
+      description: Verify RGD state
+    - assert:
+        file: instancecrd-assert.yaml
+      description: Verify Instance CRD state
+    catch:
+    - description: kro controller pod logs collector
+      podLogs:
+        selector: app.kubernetes.io/instance=kro
+        namespace: kro-system
+    finally:
+    - description: sleep operation
+      sleep:
+        duration: 5s
+  - name: create-instance
+    try:
+    #description: Create instance
+    - apply:
+        file: instance.yaml
+      description: Create ArbitraryObjectNoOp Instance
+    - assert:
+        file: instance-create-assert.yaml
+      description: Verify Instance state
+    catch:
+    - description: kro controller pod logs collector
+      podLogs:
+        selector: app.kubernetes.io/instance=kro
+        namespace: kro-system

--- a/test/e2e/chainsaw/check-arbitary-objects/instance-create-assert.yaml
+++ b/test/e2e/chainsaw/check-arbitary-objects/instance-create-assert.yaml
@@ -1,0 +1,30 @@
+apiVersion: kro.run/v1alpha1
+kind: CheckArbitraryObjectsNoOp
+metadata:
+  finalizers:
+  - kro.run/finalizer
+  generation: 1
+  labels:
+    kro.run/owned: "true"
+  name: test-instance
+spec:
+  values:
+    bool-value: true
+    numeric-value: 42
+    structural-type:
+      with-additional:
+        nested: fields
+    string-value: my-string
+    mapping-value:
+      - item1
+      - item2
+      - item3
+status:
+  conditions:
+  - message: Instance reconciled successfully
+    observedGeneration: 1
+    reason: ReconciliationSucceeded
+    status: "True"
+    type: InstanceSynced
+  state: ACTIVE
+

--- a/test/e2e/chainsaw/check-arbitary-objects/instance.yaml
+++ b/test/e2e/chainsaw/check-arbitary-objects/instance.yaml
@@ -1,0 +1,17 @@
+apiVersion: kro.run/v1alpha1
+kind: CheckArbitraryObjectsNoOp
+metadata:
+  name: test-instance
+spec:
+  values:
+    bool-value: true
+    numeric-value: 42
+    structural-type:
+      with-additional:
+        nested: fields
+    string-value: my-string
+    mapping-value:
+      - item1
+      - item2
+      - item3
+

--- a/test/e2e/chainsaw/check-arbitary-objects/instancecrd-assert.yaml
+++ b/test/e2e/chainsaw/check-arbitary-objects/instancecrd-assert.yaml
@@ -1,0 +1,93 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  generation: 1
+  name: checkarbitraryobjectsnoops.kro.run
+spec:
+  conversion:
+    strategy: None
+  group: kro.run
+  names:
+    kind: CheckArbitraryObjectsNoOp
+    listKind: CheckArbitraryObjectsNoOpList
+    plural: checkarbitraryobjectsnoops
+    singular: checkarbitraryobjectsnoop
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The state of a ResourceGraphDefinition instance
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: Whether a ResourceGraphDefinition instance have all it's subresources
+        ready
+      jsonPath: .status.conditions[?(@.type=="InstanceSynced")].status
+      name: Synced
+      type: string
+    - description: Age of the resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              values:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+            required:
+              - values
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      type: string
+                    message:
+                      type: string
+                    observedGeneration:
+                      type: integer
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              state:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: CheckArbitraryObjectsNoOp
+    listKind: CheckArbitraryObjectsNoOpList
+    plural: checkarbitraryobjectsnoops
+    singular: checkarbitraryobjectsnoop
+  conditions:
+  - message: no conflicts found
+    reason: NoConflicts
+    status: "True"
+    type: NamesAccepted
+  - message: the initial names have been accepted
+    reason: InitialNamesAccepted
+    status: "True"
+    type: Established
+  storedVersions:
+  - v1alpha1
+

--- a/test/e2e/chainsaw/check-arbitary-objects/rgd-assert.yaml
+++ b/test/e2e/chainsaw/check-arbitary-objects/rgd-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: check-arbitrary-objects
+  finalizers:
+    - kro.run/finalizer
+  generation: 1
+status:
+  # filter conditions array to keep elements where `type == 'Ready'`
+  # and assert there's a single element matching the filter
+  # and that this element status is `True`
+  (conditions[?type == 'Ready']):
+    - status: 'True'
+      observedGeneration: 1
+  state: Active
+

--- a/test/e2e/chainsaw/check-arbitary-objects/rgd.yaml
+++ b/test/e2e/chainsaw/check-arbitary-objects/rgd.yaml
@@ -1,0 +1,12 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: check-arbitrary-objects
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: CheckArbitraryObjectsNoOp
+    spec:
+      values: object | required=true
+  resources: []
+

--- a/website/docs/docs/concepts/10-simple-schema.md
+++ b/website/docs/docs/concepts/10-simple-schema.md
@@ -23,6 +23,9 @@ spec:
       replicas: integer | default=1 minimum=1 maximum=100
       image: string | required=true
 
+      # Unstructured objects
+      values: object | required=true
+
       # Structured type
       ingress:
         enabled: boolean | default=false
@@ -86,6 +89,46 @@ user:
     street: string
     city: string
   contacts: "[]string" # Array of strings
+```
+
+### Unstructured Objects
+
+Unstructured objects are declared using `object` as a type.
+
+:::warning
+
+This disables the field-validation normally offered by kro, and forwards the values to your RGD as-is. This is generally discouraged and should therefore be used with caution. In most cases, using a structured object is a better approach.
+
+:::
+
+```yaml
+kind: ResourceGraphDefintion
+metadata: {}
+spec:
+  schema:
+    spec:
+      additionalHelmChartValues: object
+```
+
+This allows you to pass data to your CRDs directly in cases where the schema is not known in advance. This type supports any valid object, and can mix and match different primitives as well as structured types.
+
+```yaml
+apiVersion: kro.run/v1alpha1
+kind: CRDWithUnstructuredObjects
+metadata:
+  name: test-instance
+spec:
+  additionalHelmChartValues:
+    boolean-value: true
+    numeric-value: 42
+    structural-type:
+      with-additional:
+        nested: fields
+    string-value: my-string
+    mapping-value:
+      - item1
+      - item2
+      - item3
 ```
 
 ### Array Types
@@ -228,7 +271,7 @@ schema:
   spec:
     image: string | default="nginx"
   status:
-      availableReplicas: ${deployment.status.availableReplicas}
+    availableReplicas: ${deployment.status.availableReplicas}
   additionalPrinterColumns:
     - jsonPath: .status.availableReplicas
       name: Available replicas


### PR DESCRIPTION
~~This PR allows users to specify 'object' as a type when defining their spec, spec alongside a new marker type 'MarkerTypePreserve'. This annotates the key with  `x-kubernetes-preserve-unknown-fields: true` and allows us to pass unstructured data, such as values for Helm charts, to CRDs managed by KRO~~

This PR allows users to specify 'object' as a type when defining their spec. This annotates the key with  `x-kubernetes-preserve-unknown-fields: true` and allows us to pass unstructured data, such as values for Helm charts, to CRDs managed by KRO.