### PR TITLE
chore(docs): remove namespace for cluster scope resource

### DIFF
--- a/website/docs/docs/concepts/00-resource-group-definitions.md
+++ b/website/docs/docs/concepts/00-resource-group-definitions.md
@@ -28,7 +28,7 @@ consistent, controlled way.
 
 A ResourceGraphDefinition, like any Kubernetes resource, consists of three main parts:
 
-1. **Metadata**: name, namespace, labels, etc.
+1. **Metadata**: name, labels, etc.
 2. **Spec**: Defines the structure and properties of the ResourceGraphDefinition
 3. **Status**: Reflects the current state of the ResourceGraphDefinition
 


### PR DESCRIPTION
Just getting to know the project and reading through the docs. Loving it so far!

ResourceGraphDefinition appears to be a cluster-scoped resource, so I was a bit confused to see namespace mentioned in the metadata list.