### PR TITLE
feat: add group mapping for special cases

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -65,6 +65,10 @@ spec:
               value: {{ .Values.config.clientQps | quote }}
             - name: KRO_CLIENT_BURST
               value: {{ .Values.config.clientBurst | quote }}
+            {{- if .Values.config.groupResourceMap }}
+            - name: KRO_GROUP_RESOURCE_MAP
+              value: {{ .Values.config.groupResourceMap | quote }}
+            {{- end }}
           args:
             {{- if .Values.config.allowCRDDeletion }}
             - --allow-crd-deletion

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -96,6 +96,8 @@ deployment:
 config:
   # Allow kro to delete CRDs
   allowCRDDeletion: false
+  # The group=resource map for special cases (e.g., 'groupalias=groupaliases,person=people')
+  groupResourceMap: ""
   # The maximum number of queries per second to allow
   clientQps: 100
   # The number of requests that can be stored for processing before the server starts enforcing the QPS limit


### PR DESCRIPTION
This is a very basic implementation, tested and working.
it allows to map special cases where the crd plural format is not correct using [github.com/gobuffalo/flect](github.com/gobuffalo/flect)

this implementation make it possible to set mapping using the environment variable `KRO_GROUP_RESOURCE_MAP`
to specify these custom conditions
for example
`KRO_GROUP_RESOURCE_MAP=groupalias=groupaliases,person=people`

this can be implemented in a better way, this is just a proof of concept, it's your choice of merging or not.