### PR TITLE
List the SIG and K8s on the website footer.

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -178,7 +178,7 @@ const config: Config = {
           ],
         },
       ],
-      copyright: "kro.run",
+      copyright: "kro is a subproject of Kubernetes SIG Cloud Provider. Kubernetes is a CNCF graduated project."
     },
     /* announcementBar: {
       id: `beta announcement`,


### PR DESCRIPTION
Right now the website footer just says "kro.run" - I am hoping to add a statement about kro being part of K8s now.

<img width="2260" height="474" alt="image" src="https://github.com/user-attachments/assets/4b068d1a-aed3-44b3-9ae9-8cd851b5dc29" />
