### PR TITLE
refactor: use domain-based naming for leader election ID

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -154,7 +154,7 @@ func main() {
 		},
 		HealthProbeBindAddress:        probeAddr,
 		LeaderElection:                enableLeaderElection,
-		LeaderElectionID:              "kro-controller",
+		LeaderElectionID:              "controller.kro.run",
 		LeaderElectionNamespace:       leaderElectionNamespace,
 		LeaderElectionReleaseOnCancel: false,
 		Logger:                        rootLogger,


### PR DESCRIPTION
Change `LeaderElectionID` from `kro-controller` to `controller.kro.run` to follow k8s convention of using domain notation