### PR TITLE
ci: upgrade Node.js from 18 to 20 in docs deployment workflow

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install dependencies
         run: npm install --frozen-lockfile


### PR DESCRIPTION
Update the documentation deployment workflow to use Node.js 20.