### PR TITLE
fix: update version label from 'latest' to 'main' in docusaurus configuration

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -64,7 +64,7 @@ const config: Config = {
           sidebarPath: "./sidebars.ts",
           versions: {
             current: {
-              label: "latest",
+              label: "main",
             },
           },
           // sidebarCollapsed: false,


### PR DESCRIPTION
latest is now the latest versioned doc, so lets rename latest to main to reflect the development state