### PR TITLE
fix website type example typo

### DIFF
--- a/website/docs/docs/concepts/10-simple-schema.md
+++ b/website/docs/docs/concepts/10-simple-schema.md
@@ -36,7 +36,7 @@ spec:
       ports: "[]integer"
 
       # Map type
-      env: "map[string]mytype"
+      env: "map[string]myType"
 
     # Custom Types
     types:


### PR DESCRIPTION
Fixes `mytype` typo in the website example for simple schema.