### PR TITLE
chore: create scripts to build and push images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,34 +135,6 @@ build: manifests generate fmt vet ## Build controller binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/controller/main.go
 
-# If you wish to build the manager image targeting other platforms you can use the --platform flag.
-# (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
-# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-.PHONY: image-build
-image-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} .
-
-.PHONY: image-push
-image-push: ## Push docker image with the manager.
-	$(CONTAINER_TOOL) push ${IMG}
-
-# PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
-# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
-# - be able to use docker buildx. More info: https://docs.docker.com/build/buildx/
-# - have enabled BuildKit. More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-# - be able to push the image to your registry (i.e. if you do not set a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
-# To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
-PLATFORMS ?= linux/arm64,linux/amd64
-.PHONY: docker-buildx
-image-buildx: ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
-	- $(CONTAINER_TOOL) buildx create --name project-v3-builder
-	$(CONTAINER_TOOL) buildx use project-v3-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
-	- $(CONTAINER_TOOL) buildx rm project-v3-builder
-	rm Dockerfile.cross
-
 ##@ Build Dependencies
 
 ## Location to install dependencies to

--- a/dev/ci/builds/push-images/cloudbuild.yaml
+++ b/dev/ci/builds/push-images/cloudbuild.yaml
@@ -1,0 +1,9 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+options:
+  substitution_option: ALLOW_LOOSE
+  machineType: E2_HIGHCPU_32
+steps:
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d
+  entrypoint: dev/tasks/push-images
+  env:
+  - IMAGE_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/kro/

--- a/dev/tasks/push-images
+++ b/dev/tasks/push-images
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+if [[ -z ${IMAGE_PREFIX:-} ]]; then
+  echo "IMAGE_PREFIX is not set"
+  exit 1
+fi
+
+if [[ -z ${IMAGE_TAG:-} ]]; then
+  # Use a tag if the current commit is a tag, otherwise use a date+git-hash tag
+  if git describe --exact-match --tags HEAD >/dev/null 2>&1; then
+    IMAGE_TAG=$(git describe --exact-match --tags HEAD)
+  else
+    IMAGE_TAG="$(date +v%Y%m%d)-$(git rev-parse --short HEAD)"
+  fi
+fi
+echo "Using IMAGE_TAG=${IMAGE_TAG}"
+
+# build first, technically this is not needed as publish does a build too
+RELEASE_VERSION=${IMAGE_TAG} OCI_REPO=${IMAGE_PREFIX%/} make build-image
+
+# Do the actual publish
+RELEASE_VERSION=${IMAGE_TAG} OCI_REPO=${IMAGE_PREFIX%/} make publish-image


### PR DESCRIPTION
On every commit, we will run the cloudbuild job to build and push the
images to our staging image registry.

We use a script to avoid locking behaviour in cloudbuild.

Also remove some obsolete Makefile targets.
