### PR TITLE
chore: bump gcb-docker-gcloud to latest version

### DIFF
--- a/dev/ci/builds/push-images/cloudbuild.yaml
+++ b/dev/ci/builds/push-images/cloudbuild.yaml
@@ -3,7 +3,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: E2_HIGHCPU_32
 steps:
-- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079
   entrypoint: dev/tasks/push-images
   env:
   - IMAGE_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/kro/


### PR DESCRIPTION
I used an older image that uses go 1.23, which does not
support the tool syntax.
