### PR TITLE
chore: automatically push tags when version is incremented

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,23 @@
+name: 'Tag Release'
+
+on:
+  push:
+    branches:
+      - master
+      - 'release-*'
+    paths:
+      - version.go
+
+jobs:
+  tag-release:
+    if: ${{ github.repository == 'kubernetes-sigs/kro' }}
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v5
+      - run: /usr/bin/git config --global user.email actions@github.com
+      - run: /usr/bin/git config --global user.name 'GitHub Actions Release Tagger'
+      - run: dev/tasks/push-tag

--- a/dev/tasks/push-tag
+++ b/dev/tasks/push-tag
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERSION=$(grep 'var Version\s*=' version.go  | awk '{print $4}' | sed -e 's_"__g')
+
+if [[ ! "${VERSION}" =~ ^([0-9]+[.][0-9]+)[.]([0-9]+)(-(alpha|beta)[.]([0-9]+))?$ ]]; then
+  echo "Version ${VERSION} must be 'X.Y.Z', 'X.Y.Z-alpha.N', or 'X.Y.Z-beta.N'"
+  exit 1
+fi
+
+MINOR=${BASH_REMATCH[1]}
+RELEASE_BRANCH="release-${MINOR}"
+
+if [ "$(git tag -l "v${VERSION}")" ]; then
+  echo "Tag v${VERSION} already exists"
+  exit 0
+fi
+
+echo "Tagging v${VERSION}"
+git tag -a -m "Release ${VERSION}" "v${VERSION}"
+git push origin "v${VERSION}"

--- a/version.go
+++ b/version.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kro
+
+// Version can be rewritten by build tooling.
+// Changing this value triggers the pushing of a tag, by dev/tasks/push-tag
+var Version = "0.5.0"


### PR DESCRIPTION
This also has the nice side-effect that we can't have two
tags on the same commit, which simplifies build tooling
that needs "the tag" for a commit.
