### PR TITLE
Remove old note about ghcr.io auth issues from `installation.md`

### DIFF
--- a/website/docs/docs/getting-started/01-Installation.md
+++ b/website/docs/docs/getting-started/01-Installation.md
@@ -46,13 +46,6 @@ helm install kro oci://registry.k8s.io/kro/charts/kro \
   --version=${KRO_VERSION}
 ```
 
-:::info[**Troubleshooting Helm Install**]
-Note that authentication is not required for pulling charts from public GHCR (GitHub Container Registry) repositories.
-
-Helm install download failures occur due to expired local credentials. To resolve this issue, clear your local credentials cache by running `helm registry logout ghcr.io` in your terminal, then retry the installation.
-
-:::
-
 ## Verifying the Installation
 
 After running the installation command, verify that Kro has been installed


### PR DESCRIPTION
Now that we moved to kubernetes-sigs this is no longer needed.