### PR TITLE
fix: add dependency readiness check in instance reconciliation

### DIFF
--- a/pkg/controller/instance/controller_reconcile.go
+++ b/pkg/controller/instance/controller_reconcile.go
@@ -238,7 +238,7 @@ func (igr *instanceGraphReconciler) reconcileInstance(ctx context.Context) error
 		if clusterObj != nil {
 			igr.runtime.SetResource(resourceID, clusterObj)
 			igr.updateResourceReadiness(resourceID)
-			// Synchronize runtime state after each resource
+			// Synchronize runtime state after each resource to re-evaluate CEL expressions
 			if _, err := igr.runtime.Synchronize(); err != nil {
 				return fmt.Errorf("failed to synchronize after apply/prune: %w", err)
 			}
@@ -252,6 +252,10 @@ func (igr *instanceGraphReconciler) reconcileInstance(ctx context.Context) error
 			resourceState.State = ResourceStateError
 			resourceState.Err = applied.Error
 		} else {
+			// Update runtime with the applied resource
+			if applied.LastApplied != nil {
+				igr.runtime.SetResource(applied.ID, applied.LastApplied)
+			}
 			igr.updateResourceReadiness(applied.ID)
 		}
 	}


### PR DESCRIPTION
Implement a new method to verify if all dependencies of a resource are ready before proceeding with reconciliation. This enhances the instance reconciliation process by ensuring that resources are only applied when their dependencies are resolved and meet readiness conditions.

fix : #744 