### PR TITLE
fix: typo in website

### DIFF
--- a/website/docs/examples/aws/pod-rds-dbinstance.md
+++ b/website/docs/examples/aws/pod-rds-dbinstance.md
@@ -45,6 +45,6 @@ spec:
             - name: container1
               image: ${schema.spec.image}
               env:
-                - name: POSTGRESS_ENDPOINT
+                - name: POSTGRES_ENDPOINT
                   value: ${dbinstance.status.endpoint.address}
 ```

--- a/website/versioned_docs/version-0.1.0/examples/pod-rds-dbinstance.md
+++ b/website/versioned_docs/version-0.1.0/examples/pod-rds-dbinstance.md
@@ -46,6 +46,6 @@ spec:
             - name: container1
               image: ${schema.spec.image}
               env:
-                - name: POSTGRESS_ENDPOINT
+                - name: POSTGRES_ENDPOINT
                   value: ${dbinstance.status.endpoint.address}
 ```

--- a/website/versioned_docs/version-0.2.0/examples/pod-rds-dbinstance.md
+++ b/website/versioned_docs/version-0.2.0/examples/pod-rds-dbinstance.md
@@ -46,6 +46,6 @@ spec:
             - name: container1
               image: ${schema.spec.image}
               env:
-                - name: POSTGRESS_ENDPOINT
+                - name: POSTGRES_ENDPOINT
                   value: ${dbinstance.status.endpoint.address}
 ```

--- a/website/versioned_docs/version-0.2.1/examples/aws/pod-rds-dbinstance.md
+++ b/website/versioned_docs/version-0.2.1/examples/aws/pod-rds-dbinstance.md
@@ -45,6 +45,6 @@ spec:
             - name: container1
               image: ${schema.spec.image}
               env:
-                - name: POSTGRESS_ENDPOINT
+                - name: POSTGRES_ENDPOINT
                   value: ${dbinstance.status.endpoint.address}
 ```

--- a/website/versioned_docs/version-0.2.2/examples/aws/pod-rds-dbinstance.md
+++ b/website/versioned_docs/version-0.2.2/examples/aws/pod-rds-dbinstance.md
@@ -45,6 +45,6 @@ spec:
             - name: container1
               image: ${schema.spec.image}
               env:
-                - name: POSTGRESS_ENDPOINT
+                - name: POSTGRES_ENDPOINT
                   value: ${dbinstance.status.endpoint.address}
 ```

--- a/website/versioned_docs/version-0.3.0/examples/aws/pod-rds-dbinstance.md
+++ b/website/versioned_docs/version-0.3.0/examples/aws/pod-rds-dbinstance.md
@@ -45,6 +45,6 @@ spec:
             - name: container1
               image: ${schema.spec.image}
               env:
-                - name: POSTGRESS_ENDPOINT
+                - name: POSTGRES_ENDPOINT
                   value: ${dbinstance.status.endpoint.address}
 ```

--- a/website/versioned_docs/version-0.4.0/examples/aws/pod-rds-dbinstance.md
+++ b/website/versioned_docs/version-0.4.0/examples/aws/pod-rds-dbinstance.md
@@ -45,6 +45,6 @@ spec:
             - name: container1
               image: ${schema.spec.image}
               env:
-                - name: POSTGRESS_ENDPOINT
+                - name: POSTGRES_ENDPOINT
                   value: ${dbinstance.status.endpoint.address}
 ```

--- a/website/versioned_docs/version-0.4.1/examples/aws/pod-rds-dbinstance.md
+++ b/website/versioned_docs/version-0.4.1/examples/aws/pod-rds-dbinstance.md
@@ -45,6 +45,6 @@ spec:
             - name: container1
               image: ${schema.spec.image}
               env:
-                - name: POSTGRESS_ENDPOINT
+                - name: POSTGRES_ENDPOINT
                   value: ${dbinstance.status.endpoint.address}
 ```

--- a/website/versioned_docs/version-0.5.0/examples/aws/pod-rds-dbinstance.md
+++ b/website/versioned_docs/version-0.5.0/examples/aws/pod-rds-dbinstance.md
@@ -45,6 +45,6 @@ spec:
             - name: container1
               image: ${schema.spec.image}
               env:
-                - name: POSTGRESS_ENDPOINT
+                - name: POSTGRES_ENDPOINT
                   value: ${dbinstance.status.endpoint.address}
 ```

--- a/website/versioned_docs/version-0.5.1/examples/aws/pod-rds-dbinstance.md
+++ b/website/versioned_docs/version-0.5.1/examples/aws/pod-rds-dbinstance.md
@@ -45,6 +45,6 @@ spec:
             - name: container1
               image: ${schema.spec.image}
               env:
-                - name: POSTGRESS_ENDPOINT
+                - name: POSTGRES_ENDPOINT
                   value: ${dbinstance.status.endpoint.address}
 ```


### PR DESCRIPTION
`POSTGRESS_ENDPOINT` -> `POSTGRES_ENDPOINT`

Correct POSTGRESS_ENDPOINT to POSTGRES_ENDPOINT to follow standard PostgreSQL endpoint naming conventions. POSTGRES is the widely accepted and accurate term for PostgreSQL service endpoints

ref: https://hub.docker.com/_/postgres#what-is-postgresql

> PostgreSQL, often simply "Postgres", is an object-relational database management system (ORDBMS)