### PR TITLE
feat: add CEL metrics tracking for expression evaluations (work in progress)

### DIFF
--- a/pkg/controller/instance/controller_status.go
+++ b/pkg/controller/instance/controller_status.go
@@ -162,6 +162,15 @@ func (igr *instanceGraphReconciler) prepareStatus() map[string]interface{} {
 		}
 	}
 
+	// Add CEL metrics to the status
+	celMetrics := igr.runtime.GetCELMetrics()
+	if celMetrics.TotalCost > 0 {
+		status["celMetrics"] = map[string]interface{}{
+			"totalCost":       celMetrics.TotalCost,
+			"costPerResource": celMetrics.CostPerResource,
+		}
+	}
+
 	return status
 }
 

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -69,6 +69,22 @@ type Interface interface {
 	// IgnoreResource ignores resource that has a condition expressison that evaluated
 	// to false
 	IgnoreResource(resourceID string)
+
+	// GetCELMetrics returns the CEL expression evaluation metrics for this runtime.
+	// This includes the total cost and cost breakdown per resource.
+	GetCELMetrics() CELMetrics
+
+	// ResetCELMetrics resets the CEL expression evaluation metrics.
+	// This is typically called at the start of a reconciliation cycle.
+	ResetCELMetrics()
+}
+
+// CELMetrics tracks CEL expression evaluation costs.
+type CELMetrics struct {
+	// TotalCost is the cumulative cost of all CEL expression evaluations.
+	TotalCost uint64
+	// CostPerResource maps resource IDs to their respective CEL evaluation costs.
+	CostPerResource map[string]uint64
 }
 
 // ResourceDescriptor provides metadata about a resource.


### PR DESCRIPTION
- Introduced CELMetrics struct to track total cost and cost per resource.
- Implemented methods to record, reset, and retrieve CEL metrics in ResourceGraphDefinitionRuntime.
- Updated expression evaluation methods to track costs during evaluations.
- Enhanced instance status preparation to include CEL metrics in the status map.
- Added comprehensive tests for CEL metrics functionality and cost tracking in various scenarios

#190 