### PR TITLE
fix: ensure LazyInformer shutdown handles nil cancel safely and add safety tests

### DIFF
--- a/pkg/dynamiccontroller/internal/gvr_watch.go
+++ b/pkg/dynamiccontroller/internal/gvr_watch.go
@@ -166,7 +166,17 @@ func (w *LazyInformer) Informer() cache.SharedIndexInformer {
 func (w *LazyInformer) Shutdown() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	w.cancel()
+
+	if w.cancel != nil {
+		w.cancel()
+		// ensure goroutine terminates before clearing
+		if w.done != nil {
+			<-w.done
+		}
+		w.cancel = nil
+		w.done = nil
+	}
+
 	w.informer = nil
 	w.handlers = make(map[string]cache.ResourceEventHandlerRegistration)
 }


### PR DESCRIPTION
addresses https://github.com/kubernetes-sigs/kro/pull/611#discussion_r2495815783

- Updated `LazyInformer.Shutdown` to handle cases where `cancel` and `done` are nil to prevent potential panics.
- Added a comprehensive test case (`TestLazyInformer_ShutdownSafetyAndRestart`) to validate safe shutdown and reinitialization behavior.