### PR TITLE
chore: bump to Go 1.25.0

### DIFF
--- a/cmd/kro/go.mod
+++ b/cmd/kro/go.mod
@@ -1,6 +1,6 @@
 module github.com/kro-run/kro/cmd/kro
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-echarts/go-echarts/v2 v2.6.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/kro
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/tools/lsp/server/go.mod
+++ b/tools/lsp/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/kro-run/kro/tools/lsp/server
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
Closes #801
Depends on #800

This PR is a draft because it depends on #800. Do not merge until that dependency is merged. Currently, on the main branch, `make` commands fail because the pinned controller-gen (v0.16.2) is incompatible with Go 1.25.0.