### PR TITLE
stale: remove stale workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![unit tests](https://github.com/kubernetes-sigs/kro/actions/workflows/unit-tests.yaml/badge.svg)](https://github.com/kubernetes-sigs/kro/actions/workflows/unit-tests.yaml)
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/kubernetes-sigs/kro)
 ![GitHub License](https://img.shields.io/github/license/kubernetes-sigs/kro)
-[![Build and Publish](https://github.com/kubernetes-sigs/kro/actions/workflows/build-push-image.yaml/badge.svg?branch=main)](https://github.com/kubernetes-sigs/kro/actions/workflows/build-push-image.yaml)
 ![GitHub Repo stars](https://img.shields.io/github/stars/kubernetes-sigs/kro)
 
 Kube Resource Orchestrator (kro) is a subproject of [Kubernetes SIG Cloud Provider](https://github.com/kubernetes/community/blob/master/sig-cloud-provider/README.md). This project aims to simplify the creation and management of complex custom resources for Kubernetes.


### PR DESCRIPTION
In v0.5.1, we removed the `build-push-image` GitHub Actions workflow, this badge has been stale since then and doesn't render any more.

<img width="681" height="115" alt="Screenshot 2025-11-11 at 20 13 36" src="https://github.com/user-attachments/assets/b4533815-7da7-4fea-9a79-bcb642db3008" />
