### PR TITLE
bump gcb-docker-gcloud to v20251110-7ccd542560

### DIFF
--- a/dev/ci/builds/push-images/cloudbuild.yaml
+++ b/dev/ci/builds/push-images/cloudbuild.yaml
@@ -3,7 +3,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: E2_HIGHCPU_32
 steps:
-- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251110-7ccd542560
   entrypoint: dev/tasks/push-images
   env:
   - IMAGE_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/kro/


### PR DESCRIPTION
Since #800 upgraded the project to Go 1.25.0 and addressed a Go toolchain bug, we need to ensure that our build environment, for pushing images, also provides Go 1.25.x or newer.

gcb-docker-gcloud:v20251110-7ccd542560 ships with go 1.25.4

```
$ docker run --rm -it gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251110-7ccd542560
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
3a7645fbed80:/workspace# which go
/usr/local/go/bin/go
3a7645fbed80:/workspace# go version
go version go1.25.4 linux/amd64
```