### PR TITLE
Delete unused metadata functions

### DIFF
--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -465,7 +465,7 @@ func (b *Builder) buildInstanceResource(
 	// CRD declarations.
 
 	// The instance resource is a Kubernetes resource, so it has a GroupVersionKind.
-	gvk := metadata.GetResourceGraphDefinitionInstanceGVK(group, apiVersion, kind)
+	gvr := metadata.GetResourceGraphDefinitionInstanceGVR(group, apiVersion, kind)
 
 	// The instance resource has a schema defined using the "SimpleSchema" format.
 	instanceSpecSchema, err := buildInstanceSpecSchema(rgDefinition)
@@ -497,7 +497,7 @@ func (b *Builder) buildInstanceResource(
 	// The instance resource has a set of variables that need to be resolved.
 	instance := &Resource{
 		id:     "instance",
-		gvr:    metadata.GVKtoGVR(gvk),
+		gvr:    gvr,
 		schema: instanceSchema,
 		crd:    instanceCRD,
 	}

--- a/pkg/metadata/groupversion.go
+++ b/pkg/metadata/groupversion.go
@@ -59,39 +59,11 @@ func ExtractGVKFromUnstructured(unstructured map[string]interface{}) (schema.Gro
 	}, nil
 }
 
-func GetResourceGraphDefinitionInstanceGVK(group, apiVersion, kind string) schema.GroupVersionKind {
-	//pluralKind := flect.Pluralize(strings.ToLower(kind))
-
-	return schema.GroupVersionKind{
-		Group:   group,
-		Version: apiVersion,
-		Kind:    kind,
-	}
-}
-
 func GetResourceGraphDefinitionInstanceGVR(group, apiVersion, kind string) schema.GroupVersionResource {
 	pluralKind := flect.Pluralize(strings.ToLower(kind))
 	return schema.GroupVersionResource{
 		Group:    group,
 		Version:  apiVersion,
 		Resource: pluralKind,
-	}
-}
-
-func GVRtoGVK(gvr schema.GroupVersionResource) schema.GroupVersionKind {
-	singular := flect.Singularize(gvr.Resource)
-	return schema.GroupVersionKind{
-		Group:   gvr.Group,
-		Version: gvr.Version,
-		Kind:    singular,
-	}
-}
-
-func GVKtoGVR(gvk schema.GroupVersionKind) schema.GroupVersionResource {
-	resource := flect.Pluralize(strings.ToLower(gvk.Kind))
-	return schema.GroupVersionResource{
-		Group:    gvk.Group,
-		Version:  gvk.Version,
-		Resource: resource,
 	}
 }


### PR DESCRIPTION
There are several functions in `pkg/metadata/groupversion.go` that were left unused over time.

With this commit, we aim at giving better clarity about what is actually used.

In addition, there is a simplification opportunity with `GVKtoGVR` and `metadata.GetResourceGraphDefinitionInstanceGVk`

The only place where we used it was in the builder to then provide it to `GVKtoGVR`

In other terms, we were doing `gvr := metadata.GVKtoGVR(metadata.GetResourceGraphDefinitionInstanceGVK(group, apiVersion, kind))` which is strictly equivalent to `gvr := metadata.GetResourceGraphDefinitionInstanceGVR(group, apiVersion, kind)`

TO further clean unused `pkg/metadata` methods, use directly `gvr := metadata.GetResourceGraphDefinitionInstanceGVR(group, apiVersion, kind)` This helps identify that the `Plurilize` function is only used for RGD resources where users only exposes a `kind` that KRO declines into `singular` and `plural` to match Kubernetes' CRD

```
  names:
    plural: crontabs
    singular: crontab
    kind: CronTab
```

This helps solving issues like #683