### PR TITLE
fix: Add structural type compatibility checking for CEL validation

### DIFF
--- a/pkg/cel/compatibility.go
+++ b/pkg/cel/compatibility.go
@@ -1,0 +1,270 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cel
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+)
+
+const (
+	// TypeNamePrefix is the prefix used for CEL type names when converting OpenAPI schemas.
+	// Used to namespace custom types and avoid conflicts with built-in CEL types.
+	// Example: "__type_schema.spec.ports" for a ports field in the schema resource.
+	TypeNamePrefix = "__type_"
+)
+
+// AreTypesStructurallyCompatible checks if two CEL types are structurally compatible,
+// ignoring type names and using duck-typing semantics.
+//
+// This performs deep structural comparison:
+// - For primitives: checks kind equality
+// - For lists: recursively checks element type compatibility
+// - For maps: recursively checks key and value type compatibility
+// - For structs: uses DeclTypeProvider to introspect fields and check all required fields exist with compatible types
+//
+// The provider is required for introspecting struct field information.
+// Returns true if types are compatible, false otherwise. If false, the error describes why.
+func AreTypesStructurallyCompatible(output, expected *cel.Type, provider *DeclTypeProvider) (bool, error) {
+	if output == nil || expected == nil {
+		return false, fmt.Errorf("nil type(s): output=%v, expected=%v", output, expected)
+	}
+
+	// Dynamic type is compatible with anything
+	if expected.Kind() == cel.DynKind || output.Kind() == cel.DynKind {
+		return true, nil
+	}
+
+	// Kinds must match
+	if output.Kind() != expected.Kind() {
+		return false, fmt.Errorf("type kind mismatch: got %q, expected %q", output.String(), expected.String())
+	}
+
+	switch expected.Kind() {
+	case cel.ListKind:
+		return areListTypesCompatible(output, expected, provider)
+	case cel.MapKind:
+		return areMapTypesCompatible(output, expected, provider)
+	case cel.StructKind:
+		return areStructTypesCompatible(output, expected, provider)
+	default:
+		// For primitives (int, string, bool, etc.), kind equality is enough
+		return true, nil
+	}
+}
+
+// areListTypesCompatible checks if list element types are structurally compatible.
+func areListTypesCompatible(output, expected *cel.Type, provider *DeclTypeProvider) (bool, error) {
+	outputParams := output.Parameters()
+	expectedParams := expected.Parameters()
+
+	// Both must have element type parameters
+	if len(outputParams) == 0 || len(expectedParams) == 0 {
+		if len(outputParams) != len(expectedParams) {
+			return false, fmt.Errorf("list parameter count mismatch: got %d, expected %d", len(outputParams), len(expectedParams))
+		}
+		return true, nil
+	}
+
+	// Recursively check element type compatibility
+	compatible, err := AreTypesStructurallyCompatible(outputParams[0], expectedParams[0], provider)
+	if !compatible {
+		return false, fmt.Errorf("list element type incompatible: %w", err)
+	}
+	return true, nil
+}
+
+// areMapTypesCompatible checks if map key and value types are structurally compatible.
+func areMapTypesCompatible(output, expected *cel.Type, provider *DeclTypeProvider) (bool, error) {
+	outputParams := output.Parameters()
+	expectedParams := expected.Parameters()
+
+	// Both must have key and value type parameters
+	if len(outputParams) < 2 || len(expectedParams) < 2 {
+		if len(outputParams) != len(expectedParams) {
+			return false, fmt.Errorf("map parameter count mismatch: got %d, expected %d", len(outputParams), len(expectedParams))
+		}
+		return true, nil
+	}
+
+	// Check key type compatibility
+	compatible, err := AreTypesStructurallyCompatible(outputParams[0], expectedParams[0], provider)
+	if !compatible {
+		return false, fmt.Errorf("map key type incompatible: %w", err)
+	}
+
+	// Check value type compatibility
+	compatible, err = AreTypesStructurallyCompatible(outputParams[1], expectedParams[1], provider)
+	if !compatible {
+		return false, fmt.Errorf("map value type incompatible: %w", err)
+	}
+	return true, nil
+}
+
+// areStructTypesCompatible checks if struct types are structurally compatible
+// by introspecting their fields using the DeclTypeProvider.
+func areStructTypesCompatible(output, expected *cel.Type, provider *DeclTypeProvider) (bool, error) {
+	if provider == nil {
+		// Without provider, we can't introspect fields - fall back to kind check only
+		return true, nil
+	}
+
+	// Resolve DeclTypes by walking through nested type paths
+	expectedDecl := resolveDeclTypeFromPath(expected.String(), provider)
+	outputDecl := resolveDeclTypeFromPath(output.String(), provider)
+
+	// If we can't resolve both types, we can't do structural comparison
+	// Fall back to accepting it (permissive - could make this stricter)
+	if expectedDecl == nil || outputDecl == nil {
+		return true, nil
+	}
+
+	// Check that output has all required fields of expected
+	return areStructFieldsCompatible(outputDecl, expectedDecl, provider)
+}
+
+// resolveDeclTypeFromPath resolves a DeclType by walking through a nested path.
+// For example, "__type_ingressroute.spec.routes.@idx.middlewares" would:
+// 1. Strip TypeNamePrefix and look up "ingressroute" in the provider
+// 2. Find the "spec" field
+// 3. Find the "routes" field
+// 4. Get the list element type (@idx)
+// 5. Find the "middlewares" field
+func resolveDeclTypeFromPath(typePath string, provider *DeclTypeProvider) *apiservercel.DeclType {
+	if provider == nil || typePath == "" {
+		return nil
+	}
+
+	// Split the path into segments
+	segments := strings.Split(typePath, ".")
+	if len(segments) == 0 {
+		return nil
+	}
+
+	// Get the root name - keep it as-is (with or without prefix)
+	rootName := segments[0]
+
+	// Look up the root type in the provider
+	// Try first with the name as-is, then try without prefix if it has one
+	currentDecl, found := provider.FindDeclType(rootName)
+	if !found && strings.HasPrefix(rootName, TypeNamePrefix) {
+		// Try without prefix for backwards compatibility
+		shortName := strings.TrimPrefix(rootName, TypeNamePrefix)
+		currentDecl, found = provider.FindDeclType(shortName)
+	}
+	if !found {
+		return nil
+	}
+
+	// Walk through remaining path segments
+	for i := 1; i < len(segments); i++ {
+		segment := segments[i]
+
+		// Handle list element type (@idx) and map value type (@elem)
+		// These are KRO conventions used in DeclTypeProvider, not CEL built-ins
+		if segment == "@idx" || segment == "@elem" {
+			if currentDecl.ElemType != nil {
+				currentDecl = currentDecl.ElemType
+			} else {
+				return nil
+			}
+			continue
+		}
+
+		// Handle array index notation like "routes[0]" - strip the index
+		if idx := strings.Index(segment, "["); idx != -1 {
+			segment = segment[:idx]
+		}
+
+		// Look up field in current struct
+		if currentDecl.Fields == nil {
+			return nil
+		}
+
+		field, exists := currentDecl.Fields[segment]
+		if !exists {
+			return nil
+		}
+
+		currentDecl = field.Type
+		if currentDecl == nil {
+			return nil
+		}
+	}
+
+	return currentDecl
+}
+
+// areStructFieldsCompatible checks if output struct is a subset of expected struct.
+// The output type can have fewer fields than expected (subset semantics), but cannot have extra fields.
+// For each field that exists in output:
+// 1. The field must exist in expected
+// 2. The field type must be compatible
+func areStructFieldsCompatible(output, expected *apiservercel.DeclType, provider *DeclTypeProvider) (bool, error) {
+	if expected == nil {
+		return true, nil
+	}
+
+	if output == nil {
+		return false, fmt.Errorf("output type is nil")
+	}
+
+	outputFields := output.Fields
+	if outputFields == nil {
+		// Output has no fields - this is a valid subset of any expected type
+		return true, nil
+	}
+
+	expectedFields := expected.Fields
+	if expectedFields == nil {
+		// Expected has no fields, but output does - incompatible
+		if len(outputFields) > 0 {
+			return false, fmt.Errorf("output has fields but expected type has none")
+		}
+		return true, nil
+	}
+
+	// Check each field in output exists in expected with compatible type
+	for fieldName, outputField := range outputFields {
+		expectedField, exists := expectedFields[fieldName]
+
+		// Output has a field that expected doesn't have - not a subset
+		if !exists {
+			return false, fmt.Errorf("field %q exists in output but not in expected type", fieldName)
+		}
+
+		// Field exists in both - check type compatibility recursively
+		expectedFieldType := expectedField.Type
+		outputFieldType := outputField.Type
+
+		if expectedFieldType == nil || outputFieldType == nil {
+			continue
+		}
+
+		// Recursively compare field types
+		expectedCELType := expectedFieldType.CelType()
+		outputCELType := outputFieldType.CelType()
+
+		compatible, err := AreTypesStructurallyCompatible(outputCELType, expectedCELType, provider)
+		if !compatible {
+			return false, fmt.Errorf("field %q has incompatible type: %w", fieldName, err)
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/cel/compatibility_test.go
+++ b/pkg/cel/compatibility_test.go
@@ -1,0 +1,439 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cel
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+)
+
+func TestPrimitiveTypes(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      *cel.Type
+		expected    *cel.Type
+		compatible  bool
+		errContains string
+	}{
+		{
+			name:       "string to string",
+			output:     cel.StringType,
+			expected:   cel.StringType,
+			compatible: true,
+		},
+		{
+			name:       "int to int",
+			output:     cel.IntType,
+			expected:   cel.IntType,
+			compatible: true,
+		},
+		{
+			name:       "bool to bool",
+			output:     cel.BoolType,
+			expected:   cel.BoolType,
+			compatible: true,
+		},
+		{
+			name:       "double to double",
+			output:     cel.DoubleType,
+			expected:   cel.DoubleType,
+			compatible: true,
+		},
+		{
+			name:        "string to int",
+			output:      cel.StringType,
+			expected:    cel.IntType,
+			compatible:  false,
+			errContains: "kind mismatch",
+		},
+		{
+			name:        "int to string",
+			output:      cel.IntType,
+			expected:    cel.StringType,
+			compatible:  false,
+			errContains: "kind mismatch",
+		},
+		{
+			name:        "bool to string",
+			output:      cel.BoolType,
+			expected:    cel.StringType,
+			compatible:  false,
+			errContains: "kind mismatch",
+		},
+		{
+			name:       "dyn to string",
+			output:     cel.DynType,
+			expected:   cel.StringType,
+			compatible: true,
+		},
+		{
+			name:       "string to dyn",
+			output:     cel.StringType,
+			expected:   cel.DynType,
+			compatible: true,
+		},
+		{
+			name:        "nil output type",
+			output:      nil,
+			expected:    cel.StringType,
+			compatible:  false,
+			errContains: "nil type",
+		},
+		{
+			name:        "nil expected type",
+			output:      cel.StringType,
+			expected:    nil,
+			compatible:  false,
+			errContains: "nil type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compatible, err := AreTypesStructurallyCompatible(tt.output, tt.expected, nil)
+			assert.Equal(t, tt.compatible, compatible)
+			if tt.compatible {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestListTypes(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      *cel.Type
+		expected    *cel.Type
+		compatible  bool
+		errContains string
+	}{
+		{
+			name:       "[]string to []string",
+			output:     cel.ListType(cel.StringType),
+			expected:   cel.ListType(cel.StringType),
+			compatible: true,
+		},
+		{
+			name:       "[]int to []int",
+			output:     cel.ListType(cel.IntType),
+			expected:   cel.ListType(cel.IntType),
+			compatible: true,
+		},
+		{
+			name:        "[]string to []int",
+			output:      cel.ListType(cel.StringType),
+			expected:    cel.ListType(cel.IntType),
+			compatible:  false,
+			errContains: "list element type incompatible",
+		},
+		{
+			name:        "[]string to string",
+			output:      cel.ListType(cel.StringType),
+			expected:    cel.StringType,
+			compatible:  false,
+			errContains: "kind mismatch",
+		},
+		{
+			name:       "[]dyn to []string",
+			output:     cel.ListType(cel.DynType),
+			expected:   cel.ListType(cel.StringType),
+			compatible: true,
+		},
+		{
+			name:       "[][]string to [][]string",
+			output:     cel.ListType(cel.ListType(cel.StringType)),
+			expected:   cel.ListType(cel.ListType(cel.StringType)),
+			compatible: true,
+		},
+		{
+			name:        "[][]string to [][]int",
+			output:      cel.ListType(cel.ListType(cel.StringType)),
+			expected:    cel.ListType(cel.ListType(cel.IntType)),
+			compatible:  false,
+			errContains: "list element type incompatible",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compatible, err := AreTypesStructurallyCompatible(tt.output, tt.expected, nil)
+			assert.Equal(t, tt.compatible, compatible)
+			if tt.compatible {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestMapTypes(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      *cel.Type
+		expected    *cel.Type
+		compatible  bool
+		errContains string
+	}{
+		{
+			name:       "map[string]string to map[string]string",
+			output:     cel.MapType(cel.StringType, cel.StringType),
+			expected:   cel.MapType(cel.StringType, cel.StringType),
+			compatible: true,
+		},
+		{
+			name:       "map[string]int to map[string]int",
+			output:     cel.MapType(cel.StringType, cel.IntType),
+			expected:   cel.MapType(cel.StringType, cel.IntType),
+			compatible: true,
+		},
+		{
+			name:        "map[string]string to map[string]int",
+			output:      cel.MapType(cel.StringType, cel.StringType),
+			expected:    cel.MapType(cel.StringType, cel.IntType),
+			compatible:  false,
+			errContains: "map value type incompatible",
+		},
+		{
+			name:        "map[string]int to map[int]int",
+			output:      cel.MapType(cel.StringType, cel.IntType),
+			expected:    cel.MapType(cel.IntType, cel.IntType),
+			compatible:  false,
+			errContains: "map key type incompatible",
+		},
+		{
+			name:        "map[string]string to string",
+			output:      cel.MapType(cel.StringType, cel.StringType),
+			expected:    cel.StringType,
+			compatible:  false,
+			errContains: "kind mismatch",
+		},
+		{
+			name:       "map[string]dyn to map[string]string",
+			output:     cel.MapType(cel.StringType, cel.DynType),
+			expected:   cel.MapType(cel.StringType, cel.StringType),
+			compatible: true,
+		},
+		{
+			name:       "map[string]map[string]int to map[string]map[string]int",
+			output:     cel.MapType(cel.StringType, cel.MapType(cel.StringType, cel.IntType)),
+			expected:   cel.MapType(cel.StringType, cel.MapType(cel.StringType, cel.IntType)),
+			compatible: true,
+		},
+		{
+			name:        "map[string]map[string]int to map[string]map[string]string",
+			output:      cel.MapType(cel.StringType, cel.MapType(cel.StringType, cel.IntType)),
+			expected:    cel.MapType(cel.StringType, cel.MapType(cel.StringType, cel.StringType)),
+			compatible:  false,
+			errContains: "map value type incompatible",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compatible, err := AreTypesStructurallyCompatible(tt.output, tt.expected, nil)
+			assert.Equal(t, tt.compatible, compatible)
+			if tt.compatible {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestStructTypes(t *testing.T) {
+	personFields := map[string]*apiservercel.DeclField{
+		"name":  apiservercel.NewDeclField("name", apiservercel.StringType, true, nil, nil),
+		"age":   apiservercel.NewDeclField("age", apiservercel.IntType, false, nil, nil),
+		"email": apiservercel.NewDeclField("email", apiservercel.StringType, false, nil, nil),
+	}
+	personType := apiservercel.NewObjectType(TypeNamePrefix+"person", personFields)
+
+	personSubsetFields := map[string]*apiservercel.DeclField{
+		"name": apiservercel.NewDeclField("name", apiservercel.StringType, true, nil, nil),
+		"age":  apiservercel.NewDeclField("age", apiservercel.IntType, false, nil, nil),
+	}
+	personSubsetType := apiservercel.NewObjectType(TypeNamePrefix+"personSubset", personSubsetFields)
+
+	personWithExtraFields := map[string]*apiservercel.DeclField{
+		"name":       apiservercel.NewDeclField("name", apiservercel.StringType, true, nil, nil),
+		"age":        apiservercel.NewDeclField("age", apiservercel.IntType, false, nil, nil),
+		"email":      apiservercel.NewDeclField("email", apiservercel.StringType, false, nil, nil),
+		"extraField": apiservercel.NewDeclField("extraField", apiservercel.StringType, false, nil, nil),
+	}
+	personWithExtraType := apiservercel.NewObjectType(TypeNamePrefix+"personWithExtra", personWithExtraFields)
+
+	personWrongTypeFields := map[string]*apiservercel.DeclField{
+		"name": apiservercel.NewDeclField("name", apiservercel.StringType, true, nil, nil),
+		"age":  apiservercel.NewDeclField("age", apiservercel.StringType, false, nil, nil),
+	}
+	personWrongTypeType := apiservercel.NewObjectType(TypeNamePrefix+"personWrongType", personWrongTypeFields)
+
+	provider := NewDeclTypeProvider(personType, personSubsetType, personWithExtraType, personWrongTypeType)
+
+	tests := []struct {
+		name        string
+		output      *cel.Type
+		expected    *cel.Type
+		compatible  bool
+		errContains string
+	}{
+		{
+			name:       "identical structs",
+			output:     personType.CelType(),
+			expected:   personType.CelType(),
+			compatible: true,
+		},
+		{
+			name:       "subset struct",
+			output:     personSubsetType.CelType(),
+			expected:   personType.CelType(),
+			compatible: true,
+		},
+		{
+			name:        "struct with extra field",
+			output:      personWithExtraType.CelType(),
+			expected:    personType.CelType(),
+			compatible:  false,
+			errContains: "exists in output but not in expected type",
+		},
+		{
+			name:        "struct with wrong field type",
+			output:      personWrongTypeType.CelType(),
+			expected:    personType.CelType(),
+			compatible:  false,
+			errContains: "has incompatible type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compatible, err := AreTypesStructurallyCompatible(tt.output, tt.expected, provider)
+			assert.Equal(t, tt.compatible, compatible)
+			if tt.compatible {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestNestedTypes(t *testing.T) {
+	addressFields := map[string]*apiservercel.DeclField{
+		"street": apiservercel.NewDeclField("street", apiservercel.StringType, true, nil, nil),
+		"city":   apiservercel.NewDeclField("city", apiservercel.StringType, true, nil, nil),
+		"zip":    apiservercel.NewDeclField("zip", apiservercel.StringType, false, nil, nil),
+	}
+	addressType := apiservercel.NewObjectType(TypeNamePrefix+"address", addressFields)
+
+	userFields := map[string]*apiservercel.DeclField{
+		"name":    apiservercel.NewDeclField("name", apiservercel.StringType, true, nil, nil),
+		"address": apiservercel.NewDeclField("address", addressType, false, nil, nil),
+		"tags":    apiservercel.NewDeclField("tags", apiservercel.NewListType(apiservercel.StringType, -1), false, nil, nil),
+	}
+	userType := apiservercel.NewObjectType(TypeNamePrefix+"user", userFields)
+
+	addressSubsetFields := map[string]*apiservercel.DeclField{
+		"street": apiservercel.NewDeclField("street", apiservercel.StringType, true, nil, nil),
+		"city":   apiservercel.NewDeclField("city", apiservercel.StringType, true, nil, nil),
+	}
+	addressSubsetType := apiservercel.NewObjectType(TypeNamePrefix+"addressSubset", addressSubsetFields)
+
+	userSubsetFields := map[string]*apiservercel.DeclField{
+		"name":    apiservercel.NewDeclField("name", apiservercel.StringType, true, nil, nil),
+		"address": apiservercel.NewDeclField("address", addressSubsetType, false, nil, nil),
+	}
+	userSubsetType := apiservercel.NewObjectType(TypeNamePrefix+"userSubset", userSubsetFields)
+
+	addressWrongTypeFields := map[string]*apiservercel.DeclField{
+		"street": apiservercel.NewDeclField("street", apiservercel.IntType, true, nil, nil),
+		"city":   apiservercel.NewDeclField("city", apiservercel.StringType, true, nil, nil),
+	}
+	addressWrongType := apiservercel.NewObjectType(TypeNamePrefix+"addressWrongType", addressWrongTypeFields)
+
+	userWrongTypeFields := map[string]*apiservercel.DeclField{
+		"name":    apiservercel.NewDeclField("name", apiservercel.StringType, true, nil, nil),
+		"address": apiservercel.NewDeclField("address", addressWrongType, false, nil, nil),
+	}
+	userWrongType := apiservercel.NewObjectType(TypeNamePrefix+"userWrongType", userWrongTypeFields)
+
+	provider := NewDeclTypeProvider(
+		addressType, addressSubsetType, addressWrongType,
+		userType, userSubsetType, userWrongType,
+	)
+
+	tests := []struct {
+		name        string
+		output      *cel.Type
+		expected    *cel.Type
+		compatible  bool
+		errContains string
+	}{
+		{
+			name:       "identical nested structs",
+			output:     userType.CelType(),
+			expected:   userType.CelType(),
+			compatible: true,
+		},
+		{
+			name:       "nested struct subset",
+			output:     userSubsetType.CelType(),
+			expected:   userType.CelType(),
+			compatible: true,
+		},
+		{
+			name:        "nested struct wrong type",
+			output:      userWrongType.CelType(),
+			expected:    userType.CelType(),
+			compatible:  false,
+			errContains: "has incompatible type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compatible, err := AreTypesStructurallyCompatible(tt.output, tt.expected, provider)
+			assert.Equal(t, tt.compatible, compatible)
+			if tt.compatible {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -97,7 +97,7 @@ func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
 	if len(opts.typedResources) > 0 {
 		// We need both a TypeProvider (for field resolution) and variable declarations.
 		// To avoid conflicts, we use different names for types vs variables:
-		//  - Types are registered with "__type_<name>" prefix (e.g "__type_schema")
+		//  - Types are registered with TypeNamePrefix + "<name>" (e.g "__type_schema")
 		//  - Variables use the original names (e.g "pod", "schema"...)
 
 		declTypes := make([]*apiservercel.DeclType, 0, len(opts.typedResources))
@@ -105,7 +105,7 @@ func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
 		for name, schema := range opts.typedResources {
 			declType := SchemaDeclTypeWithMetadata(&openapi.Schema{Schema: schema}, false)
 			if declType != nil {
-				typeName := "__type_" + name
+				typeName := TypeNamePrefix + name
 				declType = declType.MaybeAssignTypeName(typeName)
 
 				// add type declaration

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strings"
 
 	"github.com/google/cel-go/cel"
 	"golang.org/x/exp/maps"
@@ -25,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/apiserver/pkg/cel/openapi"
 	"k8s.io/apiserver/pkg/cel/openapi/resolver"
 	"k8s.io/client-go/rest"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -35,6 +37,7 @@ import (
 	"github.com/kubernetes-sigs/kro/pkg/cel/ast"
 	"github.com/kubernetes-sigs/kro/pkg/graph/crd"
 	"github.com/kubernetes-sigs/kro/pkg/graph/dag"
+	"github.com/kubernetes-sigs/kro/pkg/graph/fieldpath"
 	"github.com/kubernetes-sigs/kro/pkg/graph/parser"
 	"github.com/kubernetes-sigs/kro/pkg/graph/schema"
 	schemaresolver "github.com/kubernetes-sigs/kro/pkg/graph/schema/resolver"
@@ -211,6 +214,9 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 	}
 	schemas["schema"] = schemaWithoutStatus
 
+	// Create a DeclTypeProvider for introspecting type structures during validation
+	typeProvider := krocel.CreateDeclTypeProvider(schemas)
+
 	// First, build the dependency graph by inspecting CEL expressions.
 	// This extracts all resource dependencies and validates that:
 	// 1. All referenced resources are defined in the RGD
@@ -249,7 +255,7 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 
 	// Validate all CEL expressions for each resource node
 	for _, resource := range resources {
-		if err := validateNode(resource, templatesEnv, schemaEnv, schemas[resource.id]); err != nil {
+		if err := validateNode(resource, templatesEnv, schemaEnv, schemas[resource.id], typeProvider); err != nil {
 			return nil, fmt.Errorf("failed to validate node %q: %w", resource.id, err)
 		}
 	}
@@ -337,6 +343,12 @@ func (b *Builder) buildRGResource(
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract CEL expressions from schema for resource %s: %w", rgResource.ID, err)
 		}
+
+		// 6. Set ExpectedType on each descriptor by converting schema to CEL type with proper naming
+		for i := range fieldDescriptors {
+			setExpectedTypeOnDescriptor(&fieldDescriptors[i], resourceSchema, rgResource.ID)
+		}
+
 		for _, fieldDescriptor := range fieldDescriptors {
 			templateVariables = append(templateVariables, &variable.ResourceField{
 				// Assume variables are static; we'll validate them later
@@ -623,7 +635,7 @@ func buildStatusSchema(
 				}
 
 				outputType := checkedAST.OutputType()
-				if err := validateExpressionType(outputType, cel.StringType, expression, "status", fieldDescriptor.Path); err != nil {
+				if err := validateExpressionType(outputType, cel.StringType, expression, "status", fieldDescriptor.Path, provider); err != nil {
 					return nil, nil, err
 				}
 			}
@@ -672,13 +684,125 @@ func extractDependencies(env *cel.Env, expression string, resourceNames []string
 	return dependencies, isStatic, nil
 }
 
+// setExpectedTypeOnDescriptor sets the ExpectedType field on a FieldDescriptor.
+// This is the single place where ExpectedType is determined for all field descriptors.
+//
+// For string templates (multiple expressions like "foo-${expr1}-${expr2}"):
+//   - Always sets to cel.StringType since concatenation produces strings
+//
+// For standalone expressions (single expression like "${expr}"):
+//  1. Parses path into segments (e.g., "spec.containers[0].name" -> ["spec", "containers", [0], "name"])
+//  2. Walks through each segment, building type name and navigating schema:
+//     - Named segments: append to type name, look up in schema
+//     - Index segments: dereference array to element schema, append ".@idx" to type name
+//  3. Converts final schema to CEL type with constructed type name
+func resolveSchemaAndTypeName(segments []fieldpath.Segment, rootSchema *spec.Schema, resourceID string) (*spec.Schema, string, error) {
+	typeName := krocel.TypeNamePrefix + resourceID
+	currentSchema := rootSchema
+
+	for _, seg := range segments {
+		if seg.Name != "" {
+			typeName = typeName + "." + seg.Name
+			currentSchema = lookupSchemaAtPath(currentSchema, seg.Name)
+			if currentSchema == nil {
+				return nil, "", fmt.Errorf("field %q not found in schema", seg.Name)
+			}
+		}
+
+		if seg.Index != -1 {
+			if currentSchema.Items != nil && currentSchema.Items.Schema != nil {
+				currentSchema = currentSchema.Items.Schema
+				typeName = typeName + ".@idx"
+			} else {
+				return nil, "", fmt.Errorf("field is not an array")
+			}
+		}
+	}
+
+	return currentSchema, typeName, nil
+}
+
+func setExpectedTypeOnDescriptor(descriptor *variable.FieldDescriptor, rootSchema *spec.Schema, resourceID string) {
+	if !descriptor.StandaloneExpression {
+		descriptor.ExpectedType = cel.StringType
+		return
+	}
+
+	segments, err := fieldpath.Parse(descriptor.Path)
+	if err != nil {
+		descriptor.ExpectedType = cel.DynType
+		return
+	}
+
+	schema, typeName, err := resolveSchemaAndTypeName(segments, rootSchema, resourceID)
+	if err != nil {
+		descriptor.ExpectedType = cel.DynType
+		return
+	}
+
+	descriptor.ExpectedType = getCelTypeFromSchema(schema, typeName)
+}
+
+// getCelTypeFromSchema converts an OpenAPI schema to a CEL type with the given type name
+func getCelTypeFromSchema(schema *spec.Schema, typeName string) *cel.Type {
+	if schema == nil {
+		return cel.DynType
+	}
+
+	declType := krocel.SchemaDeclTypeWithMetadata(&openapi.Schema{Schema: schema}, false)
+	if declType == nil {
+		return cel.DynType
+	}
+
+	declType = declType.MaybeAssignTypeName(typeName)
+	return declType.CelType()
+}
+
+// lookupSchemaAtPath traverses a schema following a field path and returns the schema at that location
+func lookupSchemaAtPath(schema *spec.Schema, path string) *spec.Schema {
+	if path == "" {
+		return schema
+	}
+
+	// Split path by "." to get field names
+	parts := strings.Split(path, ".")
+	current := schema
+
+	for _, part := range parts {
+		if current == nil {
+			return nil
+		}
+
+		// Check if it's an object with properties
+		if prop, ok := current.Properties[part]; ok {
+			current = &prop
+			continue
+		}
+
+		// Check if it's an array and we need to look at items
+		if current.Items != nil && current.Items.Schema != nil {
+			current = current.Items.Schema
+			// Try again with this part on the items schema
+			if prop, ok := current.Properties[part]; ok {
+				current = &prop
+				continue
+			}
+		}
+
+		// Couldn't find the field
+		return nil
+	}
+
+	return current
+}
+
 // validateNode validates all CEL expressions for a single resource node:
 // - Template expressions (resource field values)
 // - includeWhen expressions (conditional resource creation)
 // - readyWhen expressions (resource readiness conditions)
-func validateNode(resource *Resource, templatesEnv, schemaEnv *cel.Env, resourceSchema *spec.Schema) error {
+func validateNode(resource *Resource, templatesEnv, schemaEnv *cel.Env, resourceSchema *spec.Schema, typeProvider *krocel.DeclTypeProvider) error {
 	// Validate template expressions
-	if err := validateTemplateExpressions(templatesEnv, resource); err != nil {
+	if err := validateTemplateExpressions(templatesEnv, resource, typeProvider); err != nil {
 		return err
 	}
 
@@ -708,7 +832,7 @@ func validateNode(resource *Resource, templatesEnv, schemaEnv *cel.Env, resource
 // validateTemplateExpressions validates CEL template expressions for a single resource.
 // It type-checks that expressions reference valid fields and return the expected types
 // based on the OpenAPI schemas.
-func validateTemplateExpressions(env *cel.Env, resource *Resource) error {
+func validateTemplateExpressions(env *cel.Env, resource *Resource, typeProvider *krocel.DeclTypeProvider) error {
 	for _, templateVariable := range resource.variables {
 		if len(templateVariable.Expressions) == 1 {
 			// Single expression - validate against expected types
@@ -719,8 +843,7 @@ func validateTemplateExpressions(env *cel.Env, resource *Resource) error {
 				return fmt.Errorf("failed to type-check template expression %q at path %q: %w", expression, templateVariable.Path, err)
 			}
 			outputType := checkedAST.OutputType()
-
-			if err := validateExpressionType(outputType, templateVariable.ExpectedType, expression, resource.id, templateVariable.Path); err != nil {
+			if err := validateExpressionType(outputType, templateVariable.ExpectedType, expression, resource.id, templateVariable.Path, typeProvider); err != nil {
 				return err
 			}
 		} else if len(templateVariable.Expressions) > 1 {
@@ -732,7 +855,7 @@ func validateTemplateExpressions(env *cel.Env, resource *Resource) error {
 				}
 
 				outputType := checkedAST.OutputType()
-				if err := validateExpressionType(outputType, templateVariable.ExpectedType, expression, resource.id, templateVariable.Path); err != nil {
+				if err := validateExpressionType(outputType, templateVariable.ExpectedType, expression, resource.id, templateVariable.Path, typeProvider); err != nil {
 					return err
 				}
 			}
@@ -743,7 +866,8 @@ func validateTemplateExpressions(env *cel.Env, resource *Resource) error {
 
 // validateExpressionType verifies that the CEL expression output type matches
 // the expected type. Returns an error if there is a type mismatch.
-func validateExpressionType(outputType, expectedType *cel.Type, expression, resourceID, path string) error {
+func validateExpressionType(outputType, expectedType *cel.Type, expression, resourceID, path string, typeProvider *krocel.DeclTypeProvider) error {
+	// Try CEL's built-in nominal type checking first
 	if expectedType.IsAssignableType(outputType) {
 		return nil
 	}
@@ -751,6 +875,19 @@ func validateExpressionType(outputType, expectedType *cel.Type, expression, reso
 	// Check output is dynamic - always valid
 	if outputType.String() == cel.DynType.String() {
 		return nil
+	}
+
+	// Try structural compatibility checking (duck typing)
+	compatible, compatErr := krocel.AreTypesStructurallyCompatible(outputType, expectedType, typeProvider)
+	if compatible {
+		return nil
+	}
+	// If we have a detailed compatibility error, use it
+	if compatErr != nil {
+		return fmt.Errorf(
+			"type mismatch in resource %q at path %q: expression %q returns type %q but expected %q: %w",
+			resourceID, path, expression, outputType.String(), expectedType.String(), compatErr,
+		)
 	}
 
 	// Check if unwrapping would fix the type mismatch - provide helpful error message

--- a/pkg/graph/fieldpath/builder.go
+++ b/pkg/graph/fieldpath/builder.go
@@ -28,18 +28,19 @@ func Build(segments []Segment) string {
 	var b strings.Builder
 
 	for i, segment := range segments {
-		if i > 0 && !strings.HasSuffix(b.String(), "]") {
-			b.WriteByte('.')
-		}
-
 		if segment.Index != -1 {
 			b.WriteString(fmt.Sprintf("[%d]", segment.Index))
 			continue
 		}
 
-		if strings.Contains(segment.Name, ".") {
+		// Use bracket notation for field names with dots or empty names
+		if strings.Contains(segment.Name, ".") || segment.Name == "" {
 			b.WriteString(fmt.Sprintf(`[%q]`, segment.Name))
 		} else {
+			// Add a dot before regular field names if this isn't the first segment
+			if i > 0 {
+				b.WriteByte('.')
+			}
 			b.WriteString(segment.Name)
 		}
 	}

--- a/pkg/graph/fieldpath/builder_test.go
+++ b/pkg/graph/fieldpath/builder_test.go
@@ -100,7 +100,7 @@ func TestBuild(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests[0:1] {
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Build(tt.segments)
 			if got != tt.want {

--- a/pkg/graph/parser/schemaless.go
+++ b/pkg/graph/parser/schemaless.go
@@ -72,10 +72,13 @@ func parseSchemalessResource(resource interface{}, path string) ([]variable.Fiel
 				return nil, err
 			}
 			if len(expressions) > 0 {
+				// String template in schemaless parsing
+				// StandaloneExpression=false tells builder to set ExpectedType to cel.StringType
 				expressionsFields = append(expressionsFields, variable.FieldDescriptor{
-					Expressions:  expressions,
-					ExpectedType: cel.StringType, // String templates always produce strings
-					Path:         path,
+					Expressions:          expressions,
+					ExpectedType:         nil, // Builder will set this to cel.StringType
+					Path:                 path,
+					StandaloneExpression: false, // String template - always string
 				})
 			}
 		}

--- a/pkg/graph/variable/variable.go
+++ b/pkg/graph/variable/variable.go
@@ -32,13 +32,20 @@ type FieldDescriptor struct {
 	Path string
 	// Expressions is a list of CEL expressions in the field.
 	Expressions []string
-	// ExpectedType is the expected CEL type of the field, derived from the OpenAPI schema.
-	// For single expressions, this is the schema's CEL type.
-	// For multiple expressions (string templates), this is always cel.StringType.
+
+	// ExpectedType is the expected CEL type of the field.
+	// Set by: builder.setExpectedTypeOnDescriptor() - the single place where types are determined.
+	// Parser leaves this nil, builder sets it based on StandaloneExpression:
+	//   - For string templates (StandaloneExpression=false): always cel.StringType
+	//   - For standalone expressions (StandaloneExpression=true): derived from OpenAPI schema
 	ExpectedType *cel.Type
-	// StandaloneExpression is true if the field contains a single CEL expression
-	// that is not part of a larger string. example: "${foo}" is a standalone expression
-	// but not "hello-${foo}" or "${foo}${bar}"
+
+	// StandaloneExpression indicates if this is a single CEL expression vs a string template.
+	// Set by: parser (both parser.go and schemaless.go)
+	// Used by: builder.setExpectedTypeOnDescriptor() to determine how to set ExpectedType
+	// Examples:
+	//   true:  "${foo}" - single expression, type derived from schema
+	//   false: "hello-${foo}" or "${foo}-${bar}" - string template, always produces string
 	StandaloneExpression bool
 }
 

--- a/pkg/testutil/k8s/discovery.go
+++ b/pkg/testutil/k8s/discovery.go
@@ -349,6 +349,23 @@ func NewFakeResolver() (*FakeResolver, *fake.FakeDiscovery) {
 													Properties: map[string]spec.Schema{
 														"name":  {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
 														"image": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+														"ports": {
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"array"},
+																Items: &spec.SchemaOrArray{
+																	Schema: &spec.Schema{
+																		SchemaProps: spec.SchemaProps{
+																			Type: []string{"object"},
+																			Properties: map[string]spec.Schema{
+																				"name":          {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+																				"containerPort": {SchemaProps: spec.SchemaProps{Type: []string{"integer"}}},
+																				"protocol":      {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+																			},
+																		},
+																	},
+																},
+															},
+														},
 														"env": {
 															SchemaProps: spec.SchemaProps{
 																Type: []string{"array"},

--- a/test/integration/suites/core/type_compatibility_test.go
+++ b/test/integration/suites/core/type_compatibility_test.go
@@ -1,0 +1,191 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/controller/resourcegraphdefinition"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+var _ = Describe("Structural Type Compatibility", func() {
+	var (
+		namespace string
+	)
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})).To(Succeed())
+	})
+
+	Context("Comprehensive Type Compatibility", func() {
+		It("should validate all type compatibility scenarios", func(ctx SpecContext) {
+			rgd := generator.NewResourceGraphDefinition("test-comprehensive-types",
+				generator.WithSchema(
+					"AppDeployment", "v1alpha1",
+					map[string]interface{}{
+						"appName":    "string",
+						"containers": "[]containerConfig",
+						"ports":      "[]portConfig",
+						"labels":     "map[string]string",
+					},
+					nil,
+					generator.WithTypes(map[string]interface{}{
+						"containerConfig": map[string]interface{}{
+							"name":  "string",
+							"image": "string",
+						},
+						"portConfig": map[string]interface{}{
+							"name":          "string",
+							"containerPort": "integer",
+							"protocol":      "string",
+						},
+					}),
+				),
+				generator.WithResource("basePod", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name":      "${schema.spec.appName}-base",
+						"namespace": namespace,
+						"labels":    "${schema.spec.labels}",
+					},
+					"spec": map[string]interface{}{
+						"containers": "${schema.spec.containers}",
+					},
+				}, nil, nil),
+				generator.WithResource("replicaPod", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name":        "${schema.spec.appName}-replica",
+						"namespace":   namespace,
+						"labels":      "${basePod.metadata.labels}",
+						"annotations": "${basePod.metadata.annotations}",
+					},
+					"spec": map[string]interface{}{
+						"containers": "${basePod.spec.containers}",
+					},
+				}, nil, nil),
+				generator.WithResource("podWithPorts", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name":      "${schema.spec.appName}-ports",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "${schema.spec.containers[0].name}",
+								"image": "${schema.spec.containers[0].image}",
+								"ports": []interface{}{
+									map[string]interface{}{
+										"name":          "${schema.spec.ports[0].name}",
+										"containerPort": "${schema.spec.ports[0].containerPort}",
+										"protocol":      "${schema.spec.ports[0].protocol}",
+									},
+								},
+							},
+						},
+					},
+				}, nil, nil),
+			)
+
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name: rgd.Name,
+				}, rgd)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+
+		It("should reject incompatible types comprehensively", func(ctx SpecContext) {
+			rgd := generator.NewResourceGraphDefinition("test-incompatible-types",
+				generator.WithSchema(
+					"BadAppDeployment", "v1alpha1",
+					map[string]interface{}{
+						"podName":    "string",
+						"containers": "[]badContainerConfig",
+					},
+					nil,
+					generator.WithTypes(map[string]interface{}{
+						"badContainerConfig": map[string]interface{}{
+							"name":       "integer",
+							"image":      "string",
+							"extraField": "string",
+						},
+					}),
+				),
+				generator.WithResource("pod", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name":      "${schema.spec.podName}",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"containers": "${schema.spec.containers}",
+					},
+				}, nil, nil),
+			)
+
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name: rgd.Name,
+				}, rgd)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
+
+				var condition *krov1alpha1.Condition
+				for _, cond := range rgd.Status.Conditions {
+					if cond.Type == resourcegraphdefinition.Ready {
+						condition = &cond
+						break
+					}
+				}
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(*condition.Message).To(Or(
+					ContainSubstring("kind mismatch"),
+					ContainSubstring("exists in output but not in expected type"),
+				))
+			}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+	})
+})

--- a/test/integration/suites/core/unknown_fields_test.go
+++ b/test/integration/suites/core/unknown_fields_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package core_test
 
 import (


### PR DESCRIPTION
This patch implements structural type compatibility checking to resolve
false positive type errors in CEL expression validation. The core issue
is that CEL's `IsAssignable` performs nominal type checking, which
rejects structurally compatible types that have different names. This
becomes problematic in kro where we generate unique type names for each
resource's schema (e.g `__type_pod.spec.containers` vs
`__type_deployment.spec.template.speccontainers`), causing validation to
fail even when the underlying structure is identical.

In a nutshell, we introduces `AreTypesStructurallyCompatible`, a function
that performs deep structural comparison of CEL types using proper type
checking semantics. Wehn nominal type checking fails, we fall back to
structural checking to determine if types are truly incompatible. This
approach checks that the output type is a valid subset of the expected
type, meaning it can have fewer fields but cannot have extra fields or
mismatched types

cases handled:

- Primitive types: simple kind equality checking (string, int, bool,
  double...)
- List types: recursive element type compatibility checking with
  proper handling of nested arrays
- Map types: both key and value type compatibility with recursive
  validation
- Struct types: field by field compatibility using `DeclTypeProvider`
  for introspection, supporting subset semantics where output can omit
  fields but cannot add unexpected ones
- Nested structures: deep traversal through complex type hierarchies
  including arrays of structs and maps of structs
- Cross resource references: enables copying entire structs between
  resources (e.g `${pod.spec.containers}` into another pod's spec)

The parser now leaves `ExpectedType` nil for field descriptors, deferring
type resolution to the builder. The builder implements
`setExpectedTypeOnDescriptor` which walks through schema paths,
constructing proper type names that include the full path (e.g
`__type_schema.spec.ports.[at]idx`). This ensures that when we perform
structural checking, the `DeclTypeProvider` can correctly resolve and
introspect the type definitions.

Future work:

The current implementation works at the CEL type level, which requires
converting OpenAPI schemas to CEL types and then performing structural
comparison on the CEL representation. A more efficient approach would be
to implement schema-level structural comparison directly on the OpenAPI
`spec.Schema` types. This would avoid the conversion overhead and provide
more direct access to schema metadata like required fields, default
values, and validation constraintz. However, the current CEL based
approach is sufficient for our needs and integrates cleanly with the
existing validation infrastructure.