### PR TITLE
chore: add managedby label to kro owned resources

### DIFF
--- a/pkg/metadata/labels_test.go
+++ b/pkg/metadata/labels_test.go
@@ -162,12 +162,16 @@ func TestSetKROOwned(t *testing.T) {
 		{
 			name:          "set owned on empty label",
 			initialLabels: map[string]string{},
-			expected:      map[string]string{OwnedLabel: "true"},
+			expected: map[string]string{
+				OwnedLabel: "true", ManagedByLabelKey: ManagedByKROValue,
+			},
 		},
 		{
-			name:          "override existing owned label",
-			initialLabels: map[string]string{OwnedLabel: "false"},
-			expected:      map[string]string{OwnedLabel: "true"},
+			name:          "override existing owned and mangedby labels",
+			initialLabels: map[string]string{OwnedLabel: "false", ManagedByLabelKey: "other"},
+			expected: map[string]string{
+				OwnedLabel: "true", ManagedByLabelKey: ManagedByKROValue,
+			},
 		},
 	}
 
@@ -189,12 +193,19 @@ func TestSetKROUnowned(t *testing.T) {
 		{
 			name:          "set unowned on empty label",
 			initialLabels: map[string]string{},
+			expected: map[string]string{
+				OwnedLabel: "false",
+			},
+		},
+		{
+			name:          "override existing owned label and remove managedBy label",
+			initialLabels: map[string]string{OwnedLabel: "true", ManagedByLabelKey: ManagedByKROValue},
 			expected:      map[string]string{OwnedLabel: "false"},
 		},
 		{
-			name:          "override existing owned label",
-			initialLabels: map[string]string{OwnedLabel: "true"},
-			expected:      map[string]string{OwnedLabel: "false"},
+			name:          "don't remove if mangedBy label if value is not kro",
+			initialLabels: map[string]string{OwnedLabel: "true", ManagedByLabelKey: "other"},
+			expected:      map[string]string{OwnedLabel: "false", ManagedByLabelKey: "other"},
 		},
 	}
 

--- a/test/integration/suites/core/kubernetes_time_test.go
+++ b/test/integration/suites/core/kubernetes_time_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package core_test
 
 import (


### PR DESCRIPTION
This change adds the kubernetes recommended managedby label to resources
kro owns. https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

This change overrides the managed by label if it already exists.