### PR TITLE
fix: prevent panic due to missing runtime

### DIFF
--- a/pkg/apis/condition_set.go
+++ b/pkg/apis/condition_set.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
@@ -60,6 +61,17 @@ func (c ConditionSet) List() []v1alpha1.Condition {
 		return nil
 	}
 	return c.object.GetConditions()
+}
+
+func (c ConditionSet) AsUnstructured() []any {
+	origin := c.List()
+	data := make([]any, 0, len(origin))
+	for _, condition := range origin {
+		if raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&condition); err == nil {
+			data = append(data, raw)
+		}
+	}
+	return data
 }
 
 // Get finds and returns the Condition that matches the ConditionType


### PR DESCRIPTION
Includes a new integration test to validate that an invalid resource surfaces a failure condition with the expected "Inactive" state. Refactors status updates to no longer rely on the runtime instance copy which can be nil if the runtime never got created in the first place. instead it now uses the reconciler copy which is always set because its based on the kubernetes object

fix https://github.com/kubernetes-sigs/kro/issues/858