### PR TITLE
fix: add `app.kubernetes.io/managed-by` label to child resources

### DIFF
--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -88,18 +88,6 @@ func CompareRGDOwnership(existing, desired metav1.ObjectMeta) (kroOwned, nameMat
 	return kroOwned, nameMatch, idMatch
 }
 
-// SetKROOwned sets the OwnedLabel to true on the resource.
-func SetKROOwned(meta metav1.ObjectMeta) {
-	setLabel(&meta, OwnedLabel, stringFromBoolean(true))
-	setLabel(&meta, ManagedByLabelKey, ManagedByKROValue)
-}
-
-// SetKROUnowned sets the OwnedLabel to false on the resource.
-func SetKROUnowned(meta metav1.ObjectMeta) {
-	setLabel(&meta, OwnedLabel, stringFromBoolean(false))
-	unsetLabel(&meta, ManagedByLabelKey, ManagedByKROValue)
-}
-
 var (
 	ErrDuplicatedLabels = errors.New("duplicate labels")
 )
@@ -173,11 +161,12 @@ func NewInstanceLabeler(instanceMeta metav1.Object) GenericLabeler {
 }
 
 // NewKROMetaLabeler returns a new labeler that sets the OwnedLabel,
-// KROVersion, and ControllerPodID labels on a resource.
+// KROVersion, and ManagedBy labels on a resource.
 func NewKROMetaLabeler() GenericLabeler {
 	return map[string]string{
-		OwnedLabel:      "true",
-		KROVersionLabel: safeVersion(version.GetVersionInfo().GitVersion),
+		OwnedLabel:        "true",
+		KROVersionLabel:   safeVersion(version.GetVersionInfo().GitVersion),
+		ManagedByLabelKey: ManagedByKROValue,
 	}
 }
 
@@ -197,13 +186,6 @@ func booleanFromString(s string) bool {
 	return s == "true"
 }
 
-func stringFromBoolean(b bool) string {
-	if b {
-		return "true"
-	}
-	return "false"
-}
-
 // Helper function to set a label
 func setLabel(meta metav1.Object, key, value string) {
 	labels := meta.GetLabels()
@@ -212,17 +194,4 @@ func setLabel(meta metav1.Object, key, value string) {
 	}
 	labels[key] = value
 	meta.SetLabels(labels)
-}
-
-// Helper function to unset a label
-func unsetLabel(meta metav1.Object, key, value string) {
-	labels := meta.GetLabels()
-	if labels == nil {
-		return
-	}
-	v := labels[key]
-	if v == value {
-		delete(labels, key)
-		meta.SetLabels(labels)
-	}
 }

--- a/pkg/metadata/labels_test.go
+++ b/pkg/metadata/labels_test.go
@@ -153,71 +153,6 @@ func TestCompareRGDOwnership(t *testing.T) {
 	}
 }
 
-func TestSetKROOwned(t *testing.T) {
-	cases := []struct {
-		name          string
-		initialLabels map[string]string
-		expected      map[string]string
-	}{
-		{
-			name:          "set owned on empty label",
-			initialLabels: map[string]string{},
-			expected: map[string]string{
-				OwnedLabel: "true", ManagedByLabelKey: ManagedByKROValue,
-			},
-		},
-		{
-			name:          "override existing owned and mangedby labels",
-			initialLabels: map[string]string{OwnedLabel: "false", ManagedByLabelKey: "other"},
-			expected: map[string]string{
-				OwnedLabel: "true", ManagedByLabelKey: ManagedByKROValue,
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			meta := metav1.ObjectMeta{Labels: tc.initialLabels}
-			SetKROOwned(meta)
-			assert.Equal(t, tc.expected, meta.Labels)
-		})
-	}
-}
-
-func TestSetKROUnowned(t *testing.T) {
-	cases := []struct {
-		name          string
-		initialLabels map[string]string
-		expected      map[string]string
-	}{
-		{
-			name:          "set unowned on empty label",
-			initialLabels: map[string]string{},
-			expected: map[string]string{
-				OwnedLabel: "false",
-			},
-		},
-		{
-			name:          "override existing owned label and remove managedBy label",
-			initialLabels: map[string]string{OwnedLabel: "true", ManagedByLabelKey: ManagedByKROValue},
-			expected:      map[string]string{OwnedLabel: "false"},
-		},
-		{
-			name:          "don't remove if mangedBy label if value is not kro",
-			initialLabels: map[string]string{OwnedLabel: "true", ManagedByLabelKey: "other"},
-			expected:      map[string]string{OwnedLabel: "false", ManagedByLabelKey: "other"},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			meta := metav1.ObjectMeta{Labels: tc.initialLabels}
-			SetKROUnowned(meta)
-			assert.Equal(t, tc.expected, meta.Labels)
-		})
-	}
-}
-
 func TestGenericLabeler(t *testing.T) {
 	t.Run("ApplyLabels", func(t *testing.T) {
 		cases := []struct {
@@ -318,6 +253,10 @@ func TestNewInstanceLabeler(t *testing.T) {
 func TestNewKROMetaLabeler(t *testing.T) {
 	t.Run("NewKROMetaLabeler", func(t *testing.T) {
 		labeler := NewKROMetaLabeler()
-		assert.Equal(t, GenericLabeler{OwnedLabel: "true", KROVersionLabel: version.GetVersionInfo().GitVersion}, labeler)
+		assert.Equal(t, GenericLabeler{
+			OwnedLabel:        "true",
+			KROVersionLabel:   version.GetVersionInfo().GitVersion,
+			ManagedByLabelKey: ManagedByKROValue,
+		}, labeler)
 	})
 }

--- a/test/integration/suites/deploymentservice/suite_test.go
+++ b/test/integration/suites/deploymentservice/suite_test.go
@@ -163,6 +163,8 @@ var _ = Describe("DeploymentService", func() {
 			g.Expect(service.ObjectMeta.Labels).To(HaveKeyWithValue(metadata.OwnedLabel, "true"))
 			g.Expect(service.ObjectMeta.Labels).
 				To(HaveKeyWithValue(metadata.KROVersionLabel, version.GetVersionInfo().GitVersion))
+			g.Expect(service.ObjectMeta.Labels).
+				To(HaveKeyWithValue(metadata.ManagedByLabelKey, metadata.ManagedByKROValue))
 		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
 		// Verify instance status is updated


### PR DESCRIPTION
`NewKROMetaLabeler()` was missing the managed-by label, causing child
resources to not have `app.kubernetes.io/managed-by=kro` set.

Also removes unused functions: `SetKROOwned`, `SetKROUnowned`,
`stringFromBoolean`, and `unsetLabel`.

follow up to https://github.com/kubernetes-sigs/kro/pull/851