### PR TITLE
Make `schema.group` field immutable

### DIFF
--- a/api/v1alpha1/resourcegraphdefinition_types.go
+++ b/api/v1alpha1/resourcegraphdefinition_types.go
@@ -62,11 +62,12 @@ type Schema struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Group is the API group for the generated CRD. Together with APIVersion and Kind,
 	// it forms the complete GVK (Group-Version-Kind) identifier.
-	// If omitted, defaults to "kro.run".
+	// If omitted, defaults to "kro.run". This field is immutable after creation.
 	// Example: "mycompany.io", "databases.example.com"
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="kro.run"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="group is immutable"
 	Group string `json:"group,omitempty"`
 	// Spec defines the schema for the instance's spec section using SimpleSchema syntax.
 	// This becomes the OpenAPI schema for instances of the generated CRD.

--- a/helm/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/helm/crds/kro.run_resourcegraphdefinitions.yaml
@@ -223,9 +223,12 @@ spec:
                     description: |-
                       Group is the API group for the generated CRD. Together with APIVersion and Kind,
                       it forms the complete GVK (Group-Version-Kind) identifier.
-                      If omitted, defaults to "kro.run".
+                      If omitted, defaults to "kro.run". This field is immutable after creation.
                       Example: "mycompany.io", "databases.example.com"
                     type: string
+                    x-kubernetes-validations:
+                    - message: group is immutable
+                      rule: self == oldSelf
                   kind:
                     description: |-
                       Kind is the name of the custom resource type that will be created.

--- a/pkg/controller/resourcegraphdefinition/controller_cleanup.go
+++ b/pkg/controller/resourcegraphdefinition/controller_cleanup.go
@@ -40,12 +40,8 @@ func (r *ResourceGraphDefinitionReconciler) cleanupResourceGraphDefinition(ctx c
 		return fmt.Errorf("failed to shutdown microcontroller: %w", err)
 	}
 
-	group := rgd.Spec.Schema.Group
-	if group == "" {
-		group = v1alpha1.KRODomainName
-	}
 	// cleanup CRD
-	crdName := extractCRDName(group, rgd.Spec.Schema.Kind)
+	crdName := extractCRDName(rgd.Spec.Schema.Group, rgd.Spec.Schema.Kind)
 	if err := r.cleanupResourceGraphDefinitionCRD(ctx, crdName); err != nil {
 		return fmt.Errorf("failed to cleanup CRD %s: %w", crdName, err)
 	}

--- a/pkg/graph/crd/crd.go
+++ b/pkg/graph/crd/crd.go
@@ -21,18 +21,12 @@ import (
 	"github.com/gobuffalo/flect"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 )
 
 // SynthesizeCRD generates a CustomResourceDefinition for a given API version and kind
 // with the provided spec and status schemas~
 func SynthesizeCRD(group, apiVersion, kind string, spec, status extv1.JSONSchemaProps, statusFieldsOverride bool, additionalPrinterColumns []extv1.CustomResourceColumnDefinition) *extv1.CustomResourceDefinition {
-	crdGroup := group
-	if crdGroup == "" {
-		crdGroup = v1alpha1.KRODomainName
-	}
-	return newCRD(crdGroup, apiVersion, kind, newCRDSchema(spec, status, statusFieldsOverride), additionalPrinterColumns)
+	return newCRD(group, apiVersion, kind, newCRDSchema(spec, status, statusFieldsOverride), additionalPrinterColumns)
 }
 
 func newCRD(group, apiVersion, kind string, schema *extv1.JSONSchemaProps, additionalPrinterColumns []extv1.CustomResourceColumnDefinition) *extv1.CustomResourceDefinition {

--- a/pkg/graph/crd/crd_test.go
+++ b/pkg/graph/crd/crd_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
-	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 )
 
 func TestSynthesizeCRD(t *testing.T) {
@@ -46,17 +44,6 @@ func TestSynthesizeCRD(t *testing.T) {
 			statusFieldsOverride: true,
 			expectedName:         "widgets.kro.com",
 			expectedGroup:        "kro.com",
-		},
-		{
-			name:                 "empty group uses default domain",
-			group:                "",
-			apiVersion:           "v1alphav2",
-			kind:                 "Service",
-			spec:                 extv1.JSONSchemaProps{Type: "object"},
-			status:               extv1.JSONSchemaProps{Type: "object"},
-			statusFieldsOverride: false,
-			expectedName:         "services." + v1alpha1.KRODomainName,
-			expectedGroup:        v1alpha1.KRODomainName,
 		},
 		{
 			name:                 "mixes case kind",

--- a/test/integration/suites/core/format_test.go
+++ b/test/integration/suites/core/format_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package core_test
 
 import (

--- a/website/static/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/website/static/crds/kro.run_resourcegraphdefinitions.yaml
@@ -223,9 +223,12 @@ spec:
                     description: |-
                       Group is the API group for the generated CRD. Together with APIVersion and Kind,
                       it forms the complete GVK (Group-Version-Kind) identifier.
-                      If omitted, defaults to "kro.run".
+                      If omitted, defaults to "kro.run". This field is immutable after creation.
                       Example: "mycompany.io", "databases.example.com"
                     type: string
+                    x-kubernetes-validations:
+                    - message: group is immutable
+                      rule: self == oldSelf
                   kind:
                     description: |-
                       Kind is the name of the custom resource type that will be created.


### PR DESCRIPTION
Add CEL validation to prevent changes to `schema.group` after RGD
creation. Remove redundant runtime defaults since the CRD-level
default handles this.