### PR TITLE
docs: fix some docs about saas-multi-tenant examples

### DIFF
--- a/examples/kubernetes/saas-multi-tenant/README.md
+++ b/examples/kubernetes/saas-multi-tenant/README.md
@@ -1,4 +1,4 @@
-# SaaS Multi-Tenant example
+# SaaS Multi-Tenant
 
 This example demonstrates how to create a multi-tenant SaaS application using Kro ResourceGraphDefinitions. It creates isolated tenant environments with dedicated applications, following a hierarchical structure of ResourceGraphDefinitions.
 

--- a/website/docs/examples/examples.md
+++ b/website/docs/examples/examples.md
@@ -27,3 +27,8 @@ corresponding YAML definitions.
 - [Deploying CoreDNS](./kubernetes/deploying-coredns.md) Learn how to deploy CoreDNS in a
   Kubernetes cluster using kro ResourceGraphDefinitions, including the necessary
   Deployment, Service, and ConfigMap.
+
+- [SaaS Multi-Tenant](./kubernetes/saas-multi-tenant.md) This example demonstrates
+  how to create a multi-tenant SaaS application using Kro ResourceGraphDefinitions.
+  It creates isolated tenant environments with dedicated applications,
+  following a hierarchical structure of ResourceGraphDefinitions.

--- a/website/docs/examples/kubernetes/saas-multi-tenant.md
+++ b/website/docs/examples/kubernetes/saas-multi-tenant.md
@@ -2,7 +2,7 @@
 sidebar_position: 707
 ---
 
-# SaaS Multi-Tenant example
+# SaaS Multi-Tenant
 
 This example demonstrates how to create a multi-tenant SaaS application using Kro ResourceGraphDefinitions. It creates isolated tenant environments with dedicated applications, following a hierarchical structure of ResourceGraphDefinitions.
 

--- a/website/versioned_docs/version-0.7.0/examples/examples.md
+++ b/website/versioned_docs/version-0.7.0/examples/examples.md
@@ -27,3 +27,8 @@ corresponding YAML definitions.
 - [Deploying CoreDNS](./kubernetes/deploying-coredns.md) Learn how to deploy CoreDNS in a
   Kubernetes cluster using kro ResourceGraphDefinitions, including the necessary
   Deployment, Service, and ConfigMap.
+
+- [SaaS Multi-Tenant](./kubernetes/saas-multi-tenant.md) This example demonstrates
+  how to create a multi-tenant SaaS application using Kro ResourceGraphDefinitions.
+  It creates isolated tenant environments with dedicated applications,
+  following a hierarchical structure of ResourceGraphDefinitions.

--- a/website/versioned_docs/version-0.7.0/examples/kubernetes/saas-multi-tenant.md
+++ b/website/versioned_docs/version-0.7.0/examples/kubernetes/saas-multi-tenant.md
@@ -2,7 +2,7 @@
 sidebar_position: 707
 ---
 
-# SaaS Multi-Tenant example
+# SaaS Multi-Tenant
 
 This example demonstrates how to create a multi-tenant SaaS application using Kro ResourceGraphDefinitions. It creates isolated tenant environments with dedicated applications, following a hierarchical structure of ResourceGraphDefinitions.
 


### PR DESCRIPTION
Modify several documents about saas-multi-tenant examples to make it easier for users to reference the examples.