### PR TITLE
Support Kubernetes CEL library extensions (URLs and Regex)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/onsi/gomega v1.35.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/stretchr/testify v1.10.0
-	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/sync v0.12.0
 	golang.org/x/time v0.9.0
@@ -80,7 +79,10 @@ require (
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	go.opentelemetry.io/otel v1.35.0 // indirect
+	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.38.0 // indirect
@@ -96,6 +98,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/component-base v0.34.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/ext"
 	apiservercel "k8s.io/apiserver/pkg/cel"
+	k8scellib "k8s.io/apiserver/pkg/cel/library"
 	"k8s.io/apiserver/pkg/cel/openapi"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
@@ -84,6 +85,11 @@ func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
 		ext.Strings(),
 		cel.OptionalTypes(),
 		ext.Encoders(),
+		// Kubernetes CEL libraries: enable url(), getHost(), regex helpers, etc.
+		// See https://kubernetes.io/docs/reference/using-api/cel/ and
+		// https://github.com/kubernetes-sigs/kro/issues/880.
+		k8scellib.URLs(),
+		k8scellib.Regex(),
 		library.Random(),
 	}
 

--- a/pkg/cel/environment_test.go
+++ b/pkg/cel/environment_test.go
@@ -140,6 +140,23 @@ func TestDefaultEnvironment(t *testing.T) {
 		})
 	}
 }
+
+// TestDefaultEnvironment_KubernetesLibraries verifies that the default
+// environment includes the Kubernetes CEL libraries we rely on, such as
+// the URL library used by expressions like:
+//   ${url(test.testList[0].uriTemplate).getHost()}
+
+func TestDefaultEnvironment_KubernetesLibraries(t *testing.T) {
+	env, err := DefaultEnvironment()
+	require.NoError(t, err, "failed to create CEL env")
+
+	// The expression should compile without an "undeclared reference to 'url'"
+	// error once the Kubernetes URL library is wired in.
+	expr := `url("https://example.com/foo").getHost()`
+	_, issues := env.Compile(expr)
+	require.NoError(t, issues.Err(), "expected URL expression to compile without errors")
+}
+
 func Test_CELEnvHasFunction(t *testing.T) {
 	env, err := DefaultEnvironment()
 	require.NoError(t, err, "failed to create CEL env")


### PR DESCRIPTION
This commit adds support for Kubernetes CEL library extensions to kro's CEL environment, enabling the use of url() and getHost() functions in ResourceGraphDefinition CEL expressions.

here is the screenshot 
 The following unit test verifies that expressions using `url().getHost()` now compile successfully, matching the RGD usage:

   external: ${url(test.testList[0].uriTemplate).getHost()}   The test `TestDefaultEnvironment_KubernetesLibraries` compiles:

   url("https://example.com/foo").getHost()   without any "undeclared reference to 'url'" errors.
<img width="737" height="109" alt="image" src="https://github.com/user-attachments/assets/38d79841-da62-4bce-ab19-b578787d8957" />


Changes:
- Import k8s.io/apiserver/pkg/cel/library package
- Add k8scellib.URLs() and k8scellib.Regex() to DefaultEnvironment
- Add test case to verify URL library functions work correctly

Fixes: https://github.com/kubernetes-sigs/kro/issues/880