### PR TITLE
docs: correct apiVersion for Application example

### DIFF
--- a/website/docs/docs/getting-started/02-deploy-a-resource-graph-definition.md
+++ b/website/docs/docs/getting-started/02-deploy-a-resource-graph-definition.md
@@ -160,7 +160,7 @@ an `Ingress`. Let's use it!
    with the following content:
 
    ```yaml title="instance.yaml"
-   apiVersion: v1alpha1
+   apiVersion: kro.run/v1alpha1
    kind: Application
    metadata:
      name: my-app-instance


### PR DESCRIPTION
Correct the apiVersion in the Application example, at the Quick start -> Create your Application Instance.

resolves: #898