### PR TITLE
fix: Fixed Quickstart instance.yaml sample on document

### DIFF
--- a/website/versioned_docs/version-0.7.0/docs/getting-started/02-deploy-a-resource-graph-definition.md
+++ b/website/versioned_docs/version-0.7.0/docs/getting-started/02-deploy-a-resource-graph-definition.md
@@ -160,7 +160,7 @@ an `Ingress`. Let's use it!
    with the following content:
 
    ```yaml title="instance.yaml"
-   apiVersion: v1alpha1
+   apiVersion: kro.run/v1alpha1
    kind: Application
    metadata:
      name: my-app-instance
@@ -242,10 +242,13 @@ kro continuously reconciles your resources. Try these experiments:
    ```
 
 2. Apply the change:
+
    ```bash
    kubectl apply -f instance.yaml
    ```
+
 3. Watch the deployment scale up:
+
    ```bash
    kubectl get deployment my-app
    ```
@@ -253,10 +256,13 @@ kro continuously reconciles your resources. Try these experiments:
 **See kro's automatic reconciliation:**
 
 1. Delete the service:
+
    ```bash
    kubectl delete service my-app-svc
    ```
+
 2. Watch kro recreate it automatically:
+
    ```bash
    kubectl get service my-app-svc -w
    ```

--- a/website/versioned_docs/version-0.7.1/docs/getting-started/02-deploy-a-resource-graph-definition.md
+++ b/website/versioned_docs/version-0.7.1/docs/getting-started/02-deploy-a-resource-graph-definition.md
@@ -160,7 +160,7 @@ an `Ingress`. Let's use it!
    with the following content:
 
    ```yaml title="instance.yaml"
-   apiVersion: v1alpha1
+   apiVersion: kro.run/v1alpha1
    kind: Application
    metadata:
      name: my-app-instance
@@ -242,10 +242,13 @@ kro continuously reconciles your resources. Try these experiments:
    ```
 
 2. Apply the change:
+
    ```bash
    kubectl apply -f instance.yaml
    ```
+
 3. Watch the deployment scale up:
+
    ```bash
    kubectl get deployment my-app
    ```
@@ -253,10 +256,13 @@ kro continuously reconciles your resources. Try these experiments:
 **See kro's automatic reconciliation:**
 
 1. Delete the service:
+
    ```bash
    kubectl delete service my-app-svc
    ```
+
 2. Watch kro recreate it automatically:
+
    ```bash
    kubectl get service my-app-svc -w
    ```


### PR DESCRIPTION
Issue: https://github.com/kubernetes-sigs/kro/issues/911

**Location**:
<!-- Specify where the documentation issue is (URL, file path, etc.) -->
https://kro.run/docs/getting-started/deploy-a-resource-graph-definition#create-your-application-instance

**Current State**:
<!-- What does the current documentation say? -->
It says the example "instance.yaml" would be this

```yaml
apiVersion: v1alpha1
kind: Application
metadata:
  name: my-app-instance
spec:
  name: my-app
  replicas: 1
  ingress:
    enabled: true
```

**Suggested Changes**:
<!-- How should it be improved? -->

However, the apiVersion of the sample above seems wrong.

It should be fixed to this

```yaml
apiVersion: kro.run/v1alpha1
kind: Application
metadata:
  name: my-app-instance
spec:
  name: my-app
  replicas: 1
  ingress:
    enabled: true
```

**Additional Context**:
<!-- Any additional information that might be helpful -->
This quickstart page would be the first document for new comers who uses kro like me.
Would be good to fix this document as soon as possible :)
