### PR TITLE
feat: Add opt-in pprof profiling support via build tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ LDFLAGS="-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=$(GIT_VERSION
         -X sigs.k8s.io/release-utils/version.buildDate=$(BUILD_DATE)"
 
 WITH_GOFLAGS = GOFLAGS="$(GOFLAGS)"
+PPROF_GOFLAGS ?= -tags=pprof
+PPROF_IMAGE_TAG_SUFFIX ?= -debug
 
 HELM_STATIC_MANIFESTS_FLAGS ?= --set metadata.includeHelmChart=false --set metadata.includeManagedBy=false --include-crds --namespace kro-system
 HELM_STATIC_MANIFEST_IMAGE_FLAGS ?= --set image.tag=${RELEASE_VERSION}
@@ -241,19 +243,27 @@ envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) $(GOPREFIX) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
-.PHONY: image
-build-image: ko ## Build the kro controller images using ko build
-	echo "Building kro image $(RELEASE_VERSION).."
+.PHONY: build-image
+build-image: ko ## Build kro controller image.
+	@echo "Building kro image ${RELEASE_VERSION}..."
 	$(WITH_GOFLAGS) KOCACHE=$(KOCACHE) KO_DOCKER_REPO=$(KO_DOCKER_REPO) \
 		$(KO) build --bare github.com/kubernetes-sigs/kro/cmd/controller \
 		$(if $(filter true,$(KO_LOCAL)),--local,--oci-layout-path rendered/oci/layout) \
 		--push=false --tags ${RELEASE_VERSION} --sbom=none
 
-.PHONY: publish
-publish-image: ko ## Publish the kro controller images
+.PHONY: build-debug-image
+build-debug-image: ## Build kro controller debug image with pprof enabled.
+	$(MAKE) build-image GOFLAGS="$(PPROF_GOFLAGS)" RELEASE_VERSION=${RELEASE_VERSION}${PPROF_IMAGE_TAG_SUFFIX}
+
+.PHONY: publish-image
+publish-image: ko ## Publish kro controller image.
 	$(WITH_GOFLAGS) KOCACHE=$(KOCACHE) KO_DOCKER_REPO=$(KO_DOCKER_REPO) \
 		$(KO) publish --bare github.com/kubernetes-sigs/kro/cmd/controller \
 		--tags ${RELEASE_VERSION} --sbom=none
+
+.PHONY: publish-debug-image
+publish-debug-image: ## Publish kro controller debug image with pprof enabled.
+	$(MAKE) publish-image GOFLAGS="$(PPROF_GOFLAGS)" RELEASE_VERSION=${RELEASE_VERSION}${PPROF_IMAGE_TAG_SUFFIX}
 
 .PHONY: inject-helm-version
 inject-helm-version:
@@ -282,8 +292,13 @@ render-static-manifests: inject-helm-version
 		rm -f $$tmpfile; \
 	done
 
-.PHONY:
-release: build-image publish-image package-helm publish-helm
+.PHONY: release
+release: ko package-helm ## Full release pipeline (images + pprof images + helm)
+	@echo "Building and publishing standard image..."
+	$(MAKE) build-image publish-image
+	@echo "Building and publishing pprof image..."
+	$(MAKE) build-debug-image publish-debug-image
+	$(MAKE) publish-helm
 
 ##@ Deployment
 
@@ -311,7 +326,7 @@ deploy-kind-helm: ko start-kind
 	make install
 	# This generates deployment with ko://... used in image.
 	# ko then intercepts it builds image, pushes to kind node, replaces the image in deployment and applies it
-	${HELM} template kro ./helm --namespace kro-system --set image.pullPolicy=Never --set image.ko=true --set config.allowCRDDeletion=true | $(KO) apply -f -
+	${HELM} template kro ./helm --namespace kro-system --set image.pullPolicy=Never --set image.ko=true --set config.allowCRDDeletion=true | $(WITH_GOFLAGS) $(KO) apply -f -
 	kubectl wait --for=condition=ready --timeout=1m pod -n kro-system -l app.kubernetes.io/component=controller
 	$(KUBECTL) --context kind-${KIND_CLUSTER_NAME} get pods -A
 
@@ -320,13 +335,17 @@ deploy-kind-%: export KO_DOCKER_REPO=kind.local
 deploy-kind-%: export HELM_STATIC_MANIFEST_IMAGE_FLAGS=--set image.pullPolicy=Never --set image.ko=true
 deploy-kind-%: export RELEASE_VERSION=v0.0.0-dev
 deploy-kind-%: ko start-kind render-static-manifests ## Apply the static manifests for the given variant
-	$(KO) apply -f manifests/rendered/kro-$*.yaml
+	@ko_goflags='$(GOFLAGS)'; \
+	if [[ "$*" == *pprof* ]]; then \
+		ko_goflags="$${ko_goflags:+$${ko_goflags} }$(PPROF_GOFLAGS)"; \
+	fi; \
+	GOFLAGS="$$ko_goflags" $(KO) apply -f manifests/rendered/kro-$*.yaml
 	kubectl wait --for=condition=ready --timeout=1m pod -n kro-system -l app.kubernetes.io/component=controller
 	$(KUBECTL) --context kind-${KIND_CLUSTER_NAME} get pods -A
 
 .PHONY: ko-apply
 ko-apply: ko
-	${HELM} template kro ./helm --namespace kro-system --set image.pullPolicy=Never --set image.ko=true | $(KO) apply -f -
+	${HELM} template kro ./helm --namespace kro-system --set image.pullPolicy=Never --set image.ko=true | $(WITH_GOFLAGS) $(KO) apply -f -
 
 ## CLI
 .PHONY: cli

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -63,6 +63,7 @@ func main() {
 		enableControllerWarmup                      bool
 		leaderElectionNamespace                     string
 		probeAddr                                   string
+		pprofAddr                                   string
 		allowCRDDeletion                            bool
 		resourceGraphDefinitionConcurrentReconciles int
 		dynamicControllerConcurrentReconciles       int
@@ -85,6 +86,12 @@ func main() {
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8078", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8079", "The address the probe endpoint binds to.")
+	flag.StringVar(
+		&pprofAddr,
+		"pprof-bind-address",
+		":6060",
+		"The address the pprof endpoint binds to (only used in debug builds).",
+	)
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -154,6 +161,10 @@ func main() {
 	ctrl.SetLogger(rootLogger)
 
 	setupLog.Info("feature gates", "knownFeatures", features.FeatureGate.KnownFeatures())
+	if pprofEnabled {
+		setupLog.Info("Starting pprof server", "address", pprofAddr)
+		startPprof(pprofAddr)
+	}
 
 	set, err := kroclient.NewSet(kroclient.Config{
 		QPS:   float32(qps),

--- a/cmd/controller/pprof.go
+++ b/cmd/controller/pprof.go
@@ -1,0 +1,39 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build pprof
+
+package main
+
+import (
+	"net/http"
+	"net/http/pprof"
+)
+
+const pprofEnabled = true
+
+func startPprof(addr string) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	go func() {
+		if err := http.ListenAndServe(addr, mux); err != nil && err != http.ErrServerClosed {
+			panic(err)
+		}
+	}()
+}

--- a/cmd/controller/pprof_disabled.go
+++ b/cmd/controller/pprof_disabled.go
@@ -1,0 +1,21 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !pprof
+
+package main
+
+const pprofEnabled = false
+
+func startPprof(_ string) {}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $pprofEnabled := .Values.debug.pprof.enabled }}
+{{- $pprofPort := .Values.debug.pprof.port }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,12 +38,20 @@ spec:
           {{- if .Values.image.ko }}
           image: "ko://github.com/kubernetes-sigs/kro/cmd/controller"
           {{- else }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+          {{- if $pprofEnabled }}
+          {{- $tag = printf "%s-debug" $tag }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ $tag }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: metricsport
               containerPort: {{ .Values.deployment.containerPort }}
+            {{- if $pprofEnabled }}
+            - name: pprof
+              containerPort: {{ $pprofPort }}
+            {{- end }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           env:
@@ -106,6 +116,10 @@ spec:
             {{- if .Values.config.enableControllerWarmup }}
             - --enable-controller-warmup
             {{- end }}
+            {{- end }}
+            {{- if $pprofEnabled }}
+            - --pprof-bind-address
+            - ":{{ $pprofPort }}"
             {{- end }}
           livenessProbe:
             httpGet:

--- a/helm/templates/pprof-service.yaml
+++ b/helm/templates/pprof-service.yaml
@@ -1,0 +1,21 @@
+{{- $pprofEnabled := .Values.debug.pprof.enabled }}
+{{- $pprofPort := .Values.debug.pprof.port }}
+{{- if and $pprofEnabled .Values.debug.pprof.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kro.fullname" . }}-pprof
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pprof
+spec:
+  type: {{ .Values.debug.pprof.service.type }}
+  ports:
+    - port: {{ $pprofPort }}
+      targetPort: pprof
+      protocol: TCP
+      name: pprof
+  selector:
+    {{- include "kro.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -97,6 +97,21 @@ deployment:
   # Additional volume mount settings for Pods
   extraVolumeMounts: []
 
+# Debugging configuration settings
+# WARNING: pprof profiling endpoints expose sensitive performance data.
+# Do not use in production environments.
+debug:
+  pprof:
+    # Enable pprof profiling (uses the -debug tagged image)
+    # When using image.ko=true, build with GOFLAGS="-tags=pprof".
+    enabled: false
+    # Port for the pprof HTTP server
+    port: 6060
+    # Create a Service for pprof (useful for port-forwarding)
+    service:
+      enabled: false
+      type: ClusterIP
+
 # Application configuration settings
 config:
   # Allow kro to delete CRDs

--- a/manifests/variants.yaml
+++ b/manifests/variants.yaml
@@ -12,3 +12,12 @@ variants:
         create: true
       serviceMonitor:
         enabled: true
+- name: kro-core-install-manifests-with-pprof
+  values:
+    rbac:
+      mode: aggregation
+    debug:
+      pprof:
+        enabled: true
+        service:
+          enabled: true

--- a/website/docs/docs/advanced/03-controller-tuning.md
+++ b/website/docs/docs/advanced/03-controller-tuning.md
@@ -121,3 +121,67 @@ config:
   clientQps: 200
   clientBurst: 300
 ```
+
+## pprof Profiling
+
+For performance testing and troubleshooting, kro provides a debug image variant with [pprof](https://pkg.go.dev/net/http/pprof) profiling enabled.
+
+:::warning
+The debug image exposes sensitive performance data through pprof endpoints. **Do not use in production environments.**
+:::
+
+### Enable pprof in Helm
+
+Enable pprof in your Helm values:
+
+```yaml
+debug:
+  pprof:
+    enabled: true    # Uses the -debug tagged image
+    port: 6060       # Port for the pprof HTTP server
+    service:
+      enabled: true  # Create a Service for port-forwarding
+```
+
+This switches the chart to the `-debug` image tag and configures the controller to serve pprof on the configured port.
+
+### Build the pprof Image
+
+Use the dedicated Make targets when building or publishing the pprof-enabled image:
+
+```bash
+make build-debug-image RELEASE_VERSION=v0.8.6
+make publish-debug-image RELEASE_VERSION=v0.8.6
+```
+
+If you deploy with `image.ko=true` or use `ko apply` directly, build with `GOFLAGS="-tags=pprof"` so the pprof handlers are compiled into the controller binary.
+
+### Collect a Profile
+
+If you enabled the pprof Service, port-forward it locally:
+
+```bash
+kubectl -n kro-system port-forward service/<helm-release>-pprof 6060:6060
+```
+
+If you left the Service disabled, port-forward the controller Pod instead.
+
+Capture a CPU profile while reproducing the issue:
+
+```bash
+go tool pprof http://127.0.0.1:6060/debug/pprof/profile?seconds=30
+```
+
+Inspect heap growth when chasing memory pressure:
+
+```bash
+go tool pprof http://127.0.0.1:6060/debug/pprof/heap
+```
+
+Inside the `pprof` shell, start with `top`, `top -cum`, and `list <function>` to find the hottest code paths.
+
+### What to Look For
+
+- High CPU time in reconciliation hot paths such as graph construction, CEL evaluation, or repeated object conversion.
+- Large retained heap in informer caches, unstructured object copies, or repeated allocations inside reconcile loops.
+- Excess time spent in Kubernetes client calls, which can indicate that `config.clientQps` and `config.clientBurst` are too low for the cluster size.


### PR DESCRIPTION
Add pprof profiling as an opt-in feature controlled by Go build tags. When
built with `-tags pprof`, the controller starts a pprof HTTP server on port
6060 (configurable via --pprof-bind-address). The default build excludes
pprof for smaller binaries and no exposed debug endpoints. Helm chart auto
appends `-debug` suffix to image tag when `debug.enabled=true` and optionally
creates a Service for port-forwarding.