### PR TITLE
Improve CRD cleanup skip log clarity

### DIFF
--- a/pkg/controller/resourcegraphdefinition/controller_cleanup.go
+++ b/pkg/controller/resourcegraphdefinition/controller_cleanup.go
@@ -62,7 +62,10 @@ func (r *ResourceGraphDefinitionReconciler) shutdownResourceGraphDefinitionMicro
 // If CRD deletion is disabled, it logs the skip and returns nil.
 func (r *ResourceGraphDefinitionReconciler) cleanupResourceGraphDefinitionCRD(ctx context.Context, crdName string) error {
 	if !r.allowCRDDeletion {
-		ctrl.LoggerFrom(ctx).Info("skipping CRD deletion (disabled)", "crd", crdName)
+		ctrl.LoggerFrom(ctx).Info(
+			"skipping CRD deletion because allowCRDDeletion is disabled",
+			"crd", crdName,
+		)
 		return nil
 	}
 


### PR DESCRIPTION
What this PR does
Updates the log message emitted when CRD deletion is skipped during ResourceGraphDefinition cleanup to explicitly state that allowCRDDeletion is disabled.

Why this is needed
The previous log message was ambiguous (“disabled”) and did not clearly indicate which configuration caused the CRD deletion to be skipped. This made troubleshooting and operational debugging harder.

What changed

Improved the skip log message to clearly reference the allowCRDDeletion flag

No behavior or logic changes

Testing

go test ./...

Fixes #921