### PR TITLE
Docs: manifests download URL changed to match actual URL

### DIFF
--- a/website/docs/docs/getting-started/01-Installation.md
+++ b/website/docs/docs/getting-started/01-Installation.md
@@ -87,7 +87,7 @@ echo $KRO_VERSION
 
 ```bash
 kubectl create namespace kro-system
-kubectl apply -f https://github.com/kubernetes-sigs/kro/releases/download/$KRO_VERSION/$KRO_VARIANT.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/kro/releases/download/v$KRO_VERSION/$KRO_VARIANT.yaml
 ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Hi,
Thanks for the awesome project!

The docs currently generate a URL that misses the "v" in the download URL. This PR is a quick fix.

I'm not sure where you'd like to add the "v", or whether you want to change the directory structure of the releases to not have a "v", but I thought I'd submit a simple pull request and let maintainers choose if it should be fixed elsewhere.

Thanks again!
Colin