### PR TITLE
Fix url in kubectl commands for upgrade and delete using kubectl manifests

### DIFF
--- a/website/docs/docs/getting-started/01-Installation.md
+++ b/website/docs/docs/getting-started/01-Installation.md
@@ -175,7 +175,7 @@ export KRO_VARIANT=kro-core-install-manifests
 ```
 
 ```
-kubectl apply -f https://github.com/kubernetes-sigs/kro/releases/download/$KRO_VERSION/$KRO_VARIANT.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/kro/releases/download/v$KRO_VERSION/$KRO_VARIANT.yaml
 ```
 
 :::info[**Removal of dangling objects**]
@@ -198,7 +198,7 @@ helm uninstall kro -n kro-system
   </TabItem>
   <TabItem value="kubectl" label="Raw manifest installation">
 ```bash
-kubectl delete -f https://github.com/kubernetes-sigs/kro/releases/download/$KRO_VERSION/$KRO_VARIANT.yaml
+kubectl delete -f https://github.com/kubernetes-sigs/kro/releases/download/v$KRO_VERSION/$KRO_VARIANT.yaml
 ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Upgrade and delete kubectl documentation misses a 'v' prefix in the version which will make the command fail.

```
curl -v https://github.com/kubernetes-sigs/kro/releases/download/$KRO_VERSION/$KRO_VARIANT.yaml

< HTTP/2 404
< date: Wed, 07 Jan 2026 08:34:46 GMT
< content-type: text/plain; charset=utf-8
< content-length: 9
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, X-Requested-With,Accept-Encoding, Accept, X-Requested-With
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; connect-src 'self'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'unsafe-inline'
< server: github.com
< x-github-request-id: 520F:2F13CD:491ED98:3E24BA5:695E1ADB
<
* Connection #0 to host github.com left intact
Not Found%
```

while ```curl -v https://github.com/kubernetes-sigs/kro/releases/download/v$KRO_VERSION/$KRO_VARIANT.yaml``` works