### PR TITLE
fix: Support []object and map[string]object types in RGD schema

### DIFF
--- a/pkg/simpleschema/transform.go
+++ b/pkg/simpleschema/transform.go
@@ -190,6 +190,9 @@ func (tf *transformer) handleMapType(key, fieldType string) (*extv1.JSONSchemaPr
 		fieldJSONSchemaProps.AdditionalProperties.Schema = &preDefinedType.Schema
 	} else if isAtomicType(valueType) {
 		fieldJSONSchemaProps.AdditionalProperties.Schema.Type = valueType
+	} else if valueType == keyTypeObject {
+		fieldJSONSchemaProps.AdditionalProperties.Schema.Type = valueType
+		fieldJSONSchemaProps.AdditionalProperties.Schema.XPreserveUnknownFields = ptr.To(true)
 	} else {
 		return nil, fmt.Errorf("unknown type: %s", valueType)
 	}
@@ -218,6 +221,9 @@ func (tf *transformer) handleSliceType(key, fieldType string) (*extv1.JSONSchema
 		fieldJSONSchemaProps.Items.Schema = elementSchema
 	} else if isAtomicType(elementType) {
 		fieldJSONSchemaProps.Items.Schema.Type = elementType
+	} else if elementType == keyTypeObject {
+		fieldJSONSchemaProps.Items.Schema.Type = elementType
+		fieldJSONSchemaProps.Items.Schema.XPreserveUnknownFields = ptr.To(true)
 	} else if preDefinedType, ok := tf.preDefinedTypes[elementType]; ok {
 		fieldJSONSchemaProps.Items.Schema = &preDefinedType.Schema
 	} else {

--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -175,6 +175,53 @@ func TestBuildOpenAPISchema(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Schema with array of objects",
+			obj: map[string]interface{}{
+				"items": "[]object",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"items": {
+						Type: "array",
+						Items: &extv1.JSONSchemaPropsOrArray{
+							Schema: &extv1.JSONSchemaProps{
+								Type:                   "object",
+								XPreserveUnknownFields: ptr.To(true),
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Schema with nested array of objects",
+			obj: map[string]interface{}{
+				"matrix": "[][]object",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"matrix": {
+						Type: "array",
+						Items: &extv1.JSONSchemaPropsOrArray{
+							Schema: &extv1.JSONSchemaProps{
+								Type: "array",
+								Items: &extv1.JSONSchemaPropsOrArray{
+									Schema: &extv1.JSONSchemaProps{
+										Type:                   "object",
+										XPreserveUnknownFields: ptr.To(true),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "Schema with invalid type",
 			obj: map[string]interface{}{
 				"invalid": "unknownType",
@@ -282,6 +329,53 @@ func TestBuildOpenAPISchema(t *testing.T) {
 												},
 											},
 										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Schema with map of objects",
+			obj: map[string]interface{}{
+				"config": "map[string]object",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"config": {
+						Type: "object",
+						AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+							Schema: &extv1.JSONSchemaProps{
+								Type:                   "object",
+								XPreserveUnknownFields: ptr.To(true),
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Schema with nested map of objects",
+			obj: map[string]interface{}{
+				"config": "map[string]map[string]object",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"config": {
+						Type: "object",
+						AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+							Schema: &extv1.JSONSchemaProps{
+								Type: "object",
+								AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+									Schema: &extv1.JSONSchemaProps{
+										Type:                   "object",
+										XPreserveUnknownFields: ptr.To(true),
 									},
 								},
 							},


### PR DESCRIPTION
This PR adds support for `[]object` and `map[string]object` types in RGD spec.schema and includes unit tests for the same.

Closes #927 