### PR TITLE
chore: bump pinned version

### DIFF
--- a/website/docs/docs/getting-started/01-Installation.md
+++ b/website/docs/docs/getting-started/01-Installation.md
@@ -36,7 +36,7 @@ Install a specific version for reproducible deployments:
 
 ```bash
 # Set the version you want to install
-export KRO_VERSION=0.6.2
+export KRO_VERSION=0.7.1
 
 # Install kro
 helm install kro oci://registry.k8s.io/kro/charts/kro \
@@ -154,7 +154,7 @@ helm upgrade kro oci://registry.k8s.io/kro/charts/kro \
   <TabItem value="specific" label="Specific Version">
 
 ```bash
-export KRO_VERSION=0.6.2
+export KRO_VERSION=0.7.1
 
 helm upgrade kro oci://registry.k8s.io/kro/charts/kro \
   --namespace kro-system \


### PR DESCRIPTION
Bumping the version to guide readers to install the latest specific release (0.7.1) helps prevent them from encountering bugs we’ve already fixed..