### PR TITLE
Check spelling on branches

### DIFF
--- a/.github/workflows/postsubmit.yaml
+++ b/.github/workflows/postsubmit.yaml
@@ -14,3 +14,4 @@ jobs:
           cd hydrate-goproxy
           go mod init hydrate-goproxy
           go get github.com/kubernetes-sigs/kro@${GITHUB_SHA}
+

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -1,0 +1,12 @@
+name: presubmit
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  presubmit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - name: Check spelling
+        uses: crate-ci/typos@master

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,18 @@
+[default]
+extend-ignore-re = [
+    # This enables # spellchecker:disable-line
+    "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",
+    # This enables # spellchecker:off/on
+    "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on",
+]
+
+[default.extend-words]
+Applyable = "Applyable"
+ASO = "ASO"
+AKS = "AKS"
+
+[files]
+extend-exclude = [
+    "go.mod",
+    "go.sum",
+]

--- a/examples/aws/dogsvscats-appstack/instance.yaml
+++ b/examples/aws/dogsvscats-appstack/instance.yaml
@@ -8,7 +8,7 @@ spec:
   namespace: default
   # Infrastructure values for ap-southeast-2 region
   vpcID: "vpc-0087753f93a7a32e6"
-  subnetIDs: ["subnet-028d4ae9e26605ab2", "subnet-094c0ebceba967f5f", "subnet-07afde0cb81ba4c2e"]
+  subnetIDs: ["subnet-028d4ae9e26605ab2", "subnet-094c0ebceba967f5f", "subnet-07afde0cb81b4c2e"]
   postgresEngineVersion: "16.10"
   # Application configuration
   voteImage: "dogsvscats/vote:latest"

--- a/pkg/applyset/applyset_test.go
+++ b/pkg/applyset/applyset_test.go
@@ -311,14 +311,14 @@ func TestApplySet_Prune(t *testing.T) {
 	// This CM will be pruned
 	pruneCM := configMap("prune-cm", "default")
 	pruneCM.SetLabels(map[string]string{
-		ApplysetPartOfLabel: "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1",
+		ApplysetPartOfLabel: "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1", // spellchecker:disable-line
 	})
 	aset, dynamicClient := newTestApplySet(t, parent, pruneCM)
 	// Set the ApplysetPartOfLabel on the pruneCM to match the ID of the applyset
 	// This is needed because the applyset ID is dynamically generated based on the parent object.
 	// We need to ensure that the pruneCM has the correct label so it is discovered for pruning.
 	as := aset.(*applySet)
-	assert.Equal(t, "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1", as.ID())
+	assert.Equal(t, "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1", as.ID()) // spellchecker:disable-line
 
 	_, err := aset.Add(context.Background(), configMap("test-cm", "default"))
 	assert.NoError(t, err)
@@ -438,18 +438,18 @@ func TestApplySet_PruneMultiNamespace(t *testing.T) {
 	// These CMs will be pruned
 	pruneCM1 := configMap("prune-cm", "ns1")
 	pruneCM1.SetLabels(map[string]string{
-		ApplysetPartOfLabel: "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1",
+		ApplysetPartOfLabel: "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1", // spellchecker:disable-line
 	})
 	pruneCM2 := configMap("prune-cm", "ns2")
 	pruneCM2.SetLabels(map[string]string{
-		ApplysetPartOfLabel: "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1",
+		ApplysetPartOfLabel: "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1", // spellchecker:disable-line
 	})
 	aset, dynamicClient := newTestApplySet(t, parent, pruneCM1, pruneCM2)
 	// Set the ApplysetPartOfLabel on the pruneCM to match the ID of the applyset
 	// This is needed because the applyset ID is dynamically generated based on the parent object.
 	// We need to ensure that the pruneCM has the correct label so it is discovered for pruning.
 	as := aset.(*applySet)
-	assert.Equal(t, "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1", as.ID())
+	assert.Equal(t, "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1", as.ID()) // spellchecker:disable-line
 
 	_, err := aset.Add(context.Background(), configMap("test-cm", "ns1"))
 	assert.NoError(t, err)
@@ -526,18 +526,18 @@ func TestApplySet_PruneOldNamespace(t *testing.T) {
 	// CM in old namespace should be pruned
 	pruneCM1 := configMap("prune-cm", "oldns1")
 	pruneCM1.SetLabels(map[string]string{
-		ApplysetPartOfLabel: "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1",
+		ApplysetPartOfLabel: "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1", // spellchecker:disable-line
 	})
 	pruneCM2 := configMap("prune-cm", "ns2")
 	pruneCM2.SetLabels(map[string]string{
-		ApplysetPartOfLabel: "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1",
+		ApplysetPartOfLabel: "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1", // spellchecker:disable-line
 	})
 	aset, dynamicClient := newTestApplySet(t, parent, pruneCM1, pruneCM2)
 	// Set the ApplysetPartOfLabel on the pruneCM to match the ID of the applyset
 	// This is needed because the applyset ID is dynamically generated based on the parent object.
 	// We need to ensure that the pruneCM has the correct label so it is discovered for pruning.
 	as := aset.(*applySet)
-	assert.Equal(t, "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1", as.ID())
+	assert.Equal(t, "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1", as.ID()) // spellchecker:disable-line
 
 	_, err := aset.Add(context.Background(), configMap("test-cm", "ns1"))
 	assert.NoError(t, err)
@@ -614,14 +614,14 @@ func TestApplySet_PruneOldGVKs(t *testing.T) {
 	// Foo type should be pruned
 	pruneFoo := foo("prune-foo", "ns1")
 	pruneFoo.SetLabels(map[string]string{
-		ApplysetPartOfLabel: "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1",
+		ApplysetPartOfLabel: "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1", // spellchecker:disable-line
 	})
 	aset, dynamicClient := newTestApplySet(t, parent, pruneFoo)
 	// Set the ApplysetPartOfLabel on the pruneCM to match the ID of the applyset
 	// This is needed because the applyset ID is dynamically generated based on the parent object.
 	// We need to ensure that the pruneCM has the correct label so it is discovered for pruning.
 	as := aset.(*applySet)
-	assert.Equal(t, "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1", as.ID())
+	assert.Equal(t, "applyset-wHf5Gity0G0nPN34KuNBIBBEOu2H9ED2KqsblMPFygM-v1", as.ID()) // spellchecker:disable-line
 
 	_, err := aset.Add(context.Background(), configMap("test-cm", "ns1"))
 	assert.NoError(t, err)

--- a/pkg/applyset/tracker.go
+++ b/pkg/applyset/tracker.go
@@ -46,7 +46,7 @@ type ApplyableObject struct {
 
 	// Optional
 	// User provided unique identifier for the object.
-	// If present a uniqeness check is done when adding
+	// If present a uniqueness check is done when adding
 	// It is opaque and is passed in the callbacks as is
 	ID string
 

--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -577,7 +577,7 @@ func (dc *DynamicController) handlerForChildGVR(parent, child schema.GroupVersio
 	parentGVRKey, childGVRKey := keyFromGVR(parent), keyFromGVR(child)
 	parentGVK, err := dc.mapper.KindFor(parent)
 	if err != nil {
-		return nil, fmt.Errorf("failed ot get parent gvk from %s for child handler: %w", parentGVRKey, err)
+		return nil, fmt.Errorf("failed to get parent gvk from %s for child handler: %w", parentGVRKey, err)
 	}
 	handle := func(obj interface{}, eventType string) {
 		objMeta, err := meta.Accessor(obj)

--- a/pkg/graph/dag/dag.go
+++ b/pkg/graph/dag/dag.go
@@ -103,7 +103,7 @@ func AsCycleError[T cmp.Ordered](err error) *CycleError[T] {
 }
 
 // AddDependencies adds a set of dependencies to the "from" vertex.
-// This indicates that all the vertexes in "dependencies" must occur before "from".
+// This indicates that all the vertices in "dependencies" must occur before "from".
 func (d *DirectedAcyclicGraph[T]) AddDependencies(from T, dependencies []T) error {
 	fromNode, fromExists := d.Vertices[from]
 	if !fromExists {
@@ -136,7 +136,7 @@ func (d *DirectedAcyclicGraph[T]) AddDependencies(from T, dependencies []T) erro
 	return nil
 }
 
-// TopologicalSort returns the vertexes of the graph, respecting topological ordering first,
+// TopologicalSort returns the vertices of the graph, respecting topological ordering first,
 // and preserving order of nodes within each "depth" of the topological ordering.
 func (d *DirectedAcyclicGraph[T]) TopologicalSort() ([]T, error) {
 	visited := make(map[T]bool)

--- a/pkg/graph/parser/conditions_test.go
+++ b/pkg/graph/parser/conditions_test.go
@@ -46,7 +46,7 @@ func TestParseReadyWhen(t *testing.T) {
 		},
 		{
 			name:          "Complex standalone expression that works",
-			expression:    []string{"${hello + world - someone = whoever[else]isNone dum dum {pop}out-here}"},
+			expression:    []string{"${hello + world - someone = whoever[else]isNone dump dump {pop}out-here}"},
 			expectedError: "",
 		},
 	}

--- a/pkg/metadata/finalizers_test.go
+++ b/pkg/metadata/finalizers_test.go
@@ -115,7 +115,7 @@ func TestInstanceFinalizerUnstructured(t *testing.T) {
 			expected:  false,
 		},
 		{
-			name: "Try to remve instance finalizer when its not there)",
+			name: "Try to remove instance finalizer when its not there)",
 			initialObject: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{

--- a/test/e2e/chainsaw/check-arbitary-objects/cluster-role.yaml
+++ b/test/e2e/chainsaw/check-arbitary-objects/cluster-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kro:controller:check-arbitary-objects
+  name: kro:controller:check-arbitrary-objects
   labels:
     rbac.kro.run/aggregate-to-controller: "true"
 rules:

--- a/website/docs/api/specifications/simple-schema.md
+++ b/website/docs/api/specifications/simple-schema.md
@@ -103,7 +103,7 @@ This disables the field-validation normally offered by kro, and forwards the val
 :::
 
 ```kro
-kind: ResourceGraphDefintion
+kind: ResourceGraphDefinition
 metadata: {}
 spec:
   schema:

--- a/website/versioned_docs/version-0.7.1/api/specifications/simple-schema.md
+++ b/website/versioned_docs/version-0.7.1/api/specifications/simple-schema.md
@@ -103,7 +103,7 @@ This disables the field-validation normally offered by kro, and forwards the val
 :::
 
 ```kro
-kind: ResourceGraphDefintion
+kind: ResourceGraphDefinition
 metadata: {}
 spec:
   schema:


### PR DESCRIPTION
To ensure no new typos are introduced, add a gh action which checks for typos on branches.

Existing typos are fixed and exceptions are configured in `_typos.toml`.