### PR TITLE
feat: support recursive references in custom types (Supersedes #714)

### DIFF
--- a/website/docs/docs/concepts/rgd/01-schema.md
+++ b/website/docs/docs/concepts/rgd/01-schema.md
@@ -310,6 +310,25 @@ schema:
 
 Custom types are expanded inline when kro generates the CRD.
 
+### Recursive Custom Types
+
+Custom types can reference other custom types. kro resolves dependencies automatically and detects cyclic references:
+
+```yaml
+schema:
+  types:
+    Address:
+      street: string
+      city: string
+    Person:
+      name: string
+      address: Address
+  spec:
+    owner: Person
+```
+
+For more details about SimpleSchema syntax and custom types, see the [SimpleSchema Specification](../../../api/specifications/simple-schema.md).
+
 ## Additional Printer Columns
 
 Control what `kubectl get` displays:


### PR DESCRIPTION
**Description**
This PR adds support for recursive references in custom type definitions (Issue #906).
It allows types to reference other custom types (e.g., `BaseCluster` referencing `KubeconfigRef`).

This supersedes #714. I picked up the original work by @AlessioDiama, resolved the conflicts, and applied a fix for dependency parsing.

**Changes:**
1. Rebased on main.
2. **Fix:** Added logic to `pkg/simpleschema/transform.go` to strip markers (split by `|`) before resolving dependencies. Previously, the parser failed on `Type | required=true` with "node does not exist".

**Verification:**
- Verified locally with the reproduction case from #906.
- RGD state successfully transitions to `Active`.