### PR TITLE
feat: add bytes conversion to go native types

### DIFF
--- a/pkg/cel/conversions.go
+++ b/pkg/cel/conversions.go
@@ -43,6 +43,8 @@ func GoNativeType(v ref.Val) (interface{}, error) {
 		return v.Value().(float64), nil
 	case types.StringType:
 		return v.Value().(string), nil
+	case types.BytesType:
+		return v.Value().([]byte), nil
 	case types.ListType:
 		return convertList(v)
 	case types.MapType:

--- a/pkg/cel/conversions_test.go
+++ b/pkg/cel/conversions_test.go
@@ -83,3 +83,30 @@ func TestGoNativeType_ComplexNested(t *testing.T) {
 	_, err = json.Marshal(native)
 	assert.NoError(t, err, "Should be JSON marshallable")
 }
+
+func TestGoNativeType_Bytes(t *testing.T) {
+	env, err := cel.NewEnv()
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`b"hello world"`)
+	require.NoError(t, issues.Err())
+
+	prog, err := env.Program(ast)
+	require.NoError(t, err)
+
+	val, _, err := prog.Eval(map[string]interface{}{})
+	require.NoError(t, err)
+
+	native, err := GoNativeType(val)
+	require.NoError(t, err)
+
+	// Check type
+	bytes, ok := native.([]byte)
+	require.True(t, ok, "Expected []byte, got %T", native)
+	assert.Equal(t, []byte("hello world"), bytes)
+
+	// Check JSON marshalling
+	marshalled, err := json.Marshal(native)
+	assert.NoError(t, err, "Should be JSON marshallable")
+	assert.NotEmpty(t, marshalled)
+}


### PR DESCRIPTION
This PR adds conversion for bytes values back to Go native types for use in Kubernetes resources. Without this when using bytes in Kro resources and creating instances results in errors like 

```
ERROR	dynamic-controller	Error syncing item, requeuing with rate limit	{"item": {"name":"test-rgd-1","namespace":"kro"}, "error": "failed to create runtime resource graph definition: failed to evaluate static variables: unsupported type: bytes"}
```