### PR TITLE
feat: add controller warmup support for improved leader failover

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -95,6 +95,9 @@ spec:
             - --leader-election-namespace
             - {{ .Values.config.leaderElectionNamespace | quote }}
             {{- end }}
+            {{- if .Values.config.enableControllerWarmup }}
+            - --enable-controller-warmup
+            {{- end }}
             {{- end }}
           livenessProbe:
             httpGet:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -110,6 +110,10 @@ config:
   # will attempt to use the namespace of the service account mounted to the Controller
   # pod.
   leaderElectionNamespace: ""
+  # Enable controller warmup to start controller sources (watches/informers) before
+  # leader election is won. This pre-populates caches and improves leader failover time.
+  # Requires enableLeaderElection to be true.
+  enableControllerWarmup: false
   # The address the metric endpoint binds to
   metricsBindAddress: :8078
   # The address the probe endpoint binds to


### PR DESCRIPTION
Add `--enable-controller-warmup` flag to start watches/informers before
leader election is won. This pre-populates caches and reduces leader
failover time. Requires `--leader-elect` to be set.