### PR TITLE
fix(dag): preserve vertex order when dependencies are satisfied

### DIFF
--- a/pkg/graph/dag/dag.go
+++ b/pkg/graph/dag/dag.go
@@ -173,6 +173,7 @@ func (d *DirectedAcyclicGraph[T]) TopologicalSort() ([]T, error) {
 			order = append(order, vertex.ID)
 			visited[vertex.ID] = true
 			progress = true
+			break // restart inner loop to re-check lower order vertices
 		}
 
 		if !progress {

--- a/pkg/graph/dag/dag_test.go
+++ b/pkg/graph/dag/dag_test.go
@@ -111,9 +111,11 @@ func TestDAGTopologicalSort(t *testing.T) {
 		{Nodes: "A,B", Edges: "B->A", Want: "B,A"},
 		{Nodes: "A,B,C,D,E,F", Want: "A,B,C,D,E,F"},
 		{Nodes: "A,B,C,D,E,F", Edges: "C->D", Want: "A,B,C,D,E,F"},
-		{Nodes: "A,B,C,D,E,F", Edges: "D->C", Want: "A,B,D,E,F,C"},
+		{Nodes: "A,B,C,D,E,F", Edges: "D->C", Want: "A,B,D,C,E,F"},
 		{Nodes: "A,B,C,D,E,F", Edges: "F->A,F->B,B->A", Want: "C,D,E,F,B,A"},
-		{Nodes: "A,B,C,D,E,F", Edges: "B->A,C->A,D->B,D->C,F->E,A->E", Want: "D,F,B,C,A,E"},
+		{Nodes: "A,B,C,D,E,F", Edges: "B->A,C->A,D->B,D->C,F->E,A->E", Want: "D,B,C,A,F,E"},
+		// B depends on A and C; D depends on C. B should come before D since B has lower order.
+		{Nodes: "A,B,C,D", Edges: "A->B,C->B,C->D", Want: "A,C,B,D"},
 	}
 
 	for i, g := range grid {

--- a/test/integration/suites/core/include_when_test.go
+++ b/test/integration/suites/core/include_when_test.go
@@ -225,8 +225,8 @@ var _ = Describe("Conditions", func() {
 			g.Expect(createdRGD.Status.TopologicalOrder).To(Equal([]string{
 				"deploymentA",
 				"serviceAccountA",
-				"serviceA",
 				"deploymentB",
+				"serviceA",
 				"serviceAccountB",
 				"serviceB",
 			}))


### PR DESCRIPTION
When a vertex was marked visited, lower order vertices whose dependencies
became satisfied are skipped because the inner loop had already passed
them. This caused higher order vertices to be used before lower oder ones.

This patch adds a break to restart the inner loop, ensuring lower order
vertices are always checked first.

I believe there might better/more elegant/faster ways to do this. But that
might require a reimplementation - i'll send a PR seperately from the bug
fix.