### PR TITLE
feat: add DurationType and TimestampType conversion to go native types

### DIFF
--- a/pkg/cel/conversions.go
+++ b/pkg/cel/conversions.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
@@ -45,6 +46,10 @@ func GoNativeType(v ref.Val) (interface{}, error) {
 		return v.Value().(string), nil
 	case types.BytesType:
 		return v.Value().([]byte), nil
+	case types.DurationType:
+		return v.Value().(time.Duration), nil
+	case types.TimestampType:
+		return v.Value().(time.Time), nil
 	case types.ListType:
 		return convertList(v)
 	case types.MapType:


### PR DESCRIPTION
This PR adds conversion for DurationType and TimestampType values back to Go native types for use in Kubernetes resources. 

* https://pkg.go.dev/github.com/google/cel-go@v0.26.0/common/types#DurationType 
* https://pkg.go.dev/github.com/google/cel-go@v0.26.0/common/types#TimestampType