### PR TITLE
Cluster management example: ensure access to workload cluster is granted before Argo CD secret creation

### DIFF
--- a/examples/aws/eks-cluster-mgmt/charts/kro/resource-groups/eks/rg-eks-basic.yaml
+++ b/examples/aws/eks-cluster-mgmt/charts/kro/resource-groups/eks/rg-eks-basic.yaml
@@ -249,6 +249,8 @@ spec:
           server: "${ekscluster.status.ackResourceMetadata.arn}"
           project: "default"
     - id: accessEntry
+      readyWhen:
+      - ${accessEntry.status.conditions.exists(x, x.type == 'ACK.ResourceSynced' && x.status == "True")} #check on ACK condition
       template:
         apiVersion: eks.services.k8s.aws/v1alpha1
         kind: AccessEntry


### PR DESCRIPTION
We need to ensure that access to workload cluster is granted to ArgoCD in the management cluster before adding the secret registering the workload cluster to ArgoCD.

We used `readyWhen` to ensure that the corresponding `AccessEntry` resource created and reconciled before ArgoCD secret creation.

Earlier, there was just a dummy reference to the `AccessEntry` resource in the ArgoCD secret to enforce the ordering, but we needed to add `readyWhen` so the secret creation is not attempted till `AccessEntry` is reconciled, not just created.