### PR TITLE
0.7.0 ternary expression type check issue solved

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/sync v0.12.0
 	golang.org/x/time v0.9.0
-	google.golang.org/genproto/googleapis/api v0.0.0-20250303144028-a0af3efb3deb
 	k8s.io/api v0.34.1
 	k8s.io/apiextensions-apiserver v0.31.0
 	k8s.io/apimachinery v0.34.1
@@ -92,6 +91,7 @@ require (
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/tools v0.28.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect


### PR DESCRIPTION
## Description
This PR improves how CEL ternary (condition ? l : r) expressions are handled during validation by detecting ternary expressions early and rewriting only when necessary using dyn(), avoiding hard CEL type checking failure while preserving existing behavior and schema integrity.

The goal is to unblock valid user expressions without changing CEL’s core typing rules or resource schemas.

## Previous Behavior
Today cel expressions are parsed and type checked against OpenAPI schemas using a typed CEL environment.
However CEL enforces a strict rule for ternary expressions that both branches of a ternary expression must resolve to the same static type and this causes valid, real-world expressions to fail validation.

## What this PR does

This PR introduces a non invasive preprocessing step that:
- detects ternary expressions in CEL ASTs (including nested and complex ones)
- identifies ternary branches that would cause type mismatches
- rewrites only the ternary branches using dyn() when needed.

and this allows  treat both branches as dyn, defer validation to runtime nd preserve strict typing everywhere else.

Resolves: #895 