### PR TITLE
fix(schema): use `date-time` format for timestamps

### DIFF
--- a/pkg/graph/schema/conversion_cel_type.go
+++ b/pkg/graph/schema/conversion_cel_type.go
@@ -156,7 +156,7 @@ func inferSchemaFromCELType(celType *cel.Type, provider *krocel.DeclTypeProvider
 		return &extv1.JSONSchemaProps{
 			Description: "Timestamp representing a creation time",
 			Type:        "string",
-			Format:      "datetime",
+			Format:      "date-time",
 		}, nil
 	default:
 		// Unknown type - be permissive

--- a/pkg/graph/schema/conversion_cel_type_test.go
+++ b/pkg/graph/schema/conversion_cel_type_test.go
@@ -144,7 +144,7 @@ func TestGenerateSchemaFromCELTypes_Timestamp(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Equal(t, "string", prop.Type)
-	assert.Equal(t, "datetime", prop.Format)
+	assert.Equal(t, "date-time", prop.Format)
 	assert.Equal(t, "Timestamp representing a creation time", prop.Description)
 }
 


### PR DESCRIPTION
OpenAPI uses the standard `date-time` format for RFC3339 timestamps

https://datatracker.ietf.org/doc/html/rfc3339#section-5.6