### PR TITLE
fix(release): capture `GIT_VERSION` once to prevent -dirty suffix in LDFAGS

### DIFF
--- a/dev/tasks/push-images
+++ b/dev/tasks/push-images
@@ -5,6 +5,8 @@ set -euo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
+export GIT_VERSION=$(git describe --tags --always --dirty)
+
 if [[ -z ${IMAGE_PREFIX:-} ]]; then
   echo "IMAGE_PREFIX is not set"
   exit 1


### PR DESCRIPTION
GIT_VERSION was re-evaluated on each make invocation. When package-helm
modified helm/Chart.yaml between build-image and publish-image, the second
evaluation of `git describe --dirty` detected uncommitted changes.

Export `GIT_VERSION` once at script start so all make commands use the same
frozen value.