### PR TITLE
fix: remove GIT_VERSION suffix

### DIFF
--- a/dev/tasks/push-images
+++ b/dev/tasks/push-images
@@ -31,10 +31,10 @@ echo "Using HELM_IMAGE=${HELM_IMAGE}"
 # build first, technically this is not needed as publish does a build too
 RELEASE_VERSION=${IMAGE_TAG} OCI_REPO=${IMAGE_PREFIX%/} make build-image
 
-# we are also pushing the helm chart, build it first
-RELEASE_VERSION=${IMAGE_TAG} HELM_IMAGE=${HELM_IMAGE} make package-helm
-
-
 # Do the actual publish
 RELEASE_VERSION=${IMAGE_TAG} OCI_REPO=${IMAGE_PREFIX%/} make publish-image
+
+# we are also pushing the helm chart, build it first
+RELEASE_VERSION=${IMAGE_TAG} HELM_IMAGE=${HELM_IMAGE} make package-helm
+# then publish it
 RELEASE_VERSION=${IMAGE_TAG} HELM_IMAGE=${HELM_IMAGE} make publish-helm


### PR DESCRIPTION
During releases, we have been running `inject-helm-version` before we publish the kro image, which causes the controller to be built with a `dirty` suffix in its tag. With this change, we ensure the image is published before we package and publish the helm chart