### PR TITLE
fix: applying resources with null fields

### DIFF
--- a/pkg/runtime/resolver/resolver.go
+++ b/pkg/runtime/resolver/resolver.go
@@ -204,7 +204,12 @@ func (r *Resolver) setValueAtPath(path string, value interface{}) error {
 			if i == len(segments)-1 {
 				array := current.([]interface{})
 				if value == nil {
+					// Nil array elements are removed rather than set to null. SSA's structured-merge-diff
+					// library sets omitted fields to null, but most CRDs don't define nullable:true.
+					// Removing the element avoids SSA conflicts and aligns with K8s API conventions.
+					// See: kubernetes-sigs/structured-merge-diff#171, kubernetes/kubernetes#103011
 					array = append(array[:segment.Index], array[segment.Index+1:]...)
+					updateParent(parent, parentKey, parentIndex, array)
 				} else {
 					array[segment.Index] = value
 				}
@@ -221,8 +226,13 @@ func (r *Resolver) setValueAtPath(path string, value interface{}) error {
 			}
 
 			if i == len(segments)-1 {
-				// if the expression value evaluates to nil
-				// remove field (specifically in cases where we have optionals)
+				// Nil values trigger field deletion instead of setting null. This works around an
+				// SSA limitation where structured-merge-diff sets omitted fields to null during Apply.
+				// Most CRD providers (ACK, ASO, KCC) don't mark optional fields as nullable:true,
+				// causing SSA conflicts when null is applied. Deleting the field releases ownership
+				// and follows K8s API conventions (field omission > null). kro will not re-manage
+				// this field until the expression evaluates to non-nil.
+				// See: kubernetes-sigs/structured-merge-diff#171, kubernetes/kubernetes#103011
 				if value == nil {
 					delete(currentMap, segment.Name)
 				} else {

--- a/pkg/runtime/resolver/resolver_test.go
+++ b/pkg/runtime/resolver/resolver_test.go
@@ -187,6 +187,15 @@ func TestSetValueAtPath(t *testing.T) {
 			},
 		},
 		{
+			name: "set top level field to nil",
+			resource: map[string]interface{}{
+				"name": "${someexpression}",
+			},
+			path:  "name",
+			value: nil,
+			want:  map[string]interface{}{},
+		},
+		{
 			name: "set nested field",
 			resource: map[string]interface{}{
 				"spec": map[string]interface{}{},
@@ -200,6 +209,19 @@ func TestSetValueAtPath(t *testing.T) {
 			},
 		},
 		{
+			name: "set nested field to nil",
+			resource: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"replicas": "${someexpression}",
+				},
+			},
+			path:  `spec.replicas`,
+			value: nil,
+			want: map[string]interface{}{
+				"spec": map[string]interface{}{},
+			},
+		},
+		{
 			name:     "create intermediate structures",
 			resource: map[string]interface{}{},
 			path:     `spec.template.metadata.name`,
@@ -210,6 +232,19 @@ func TestSetValueAtPath(t *testing.T) {
 						"metadata": map[string]interface{}{
 							"name": "my-pod",
 						},
+					},
+				},
+			},
+		},
+		{
+			name:     "create intermediate structures with nil value",
+			resource: map[string]interface{}{},
+			path:     `spec.template.metadata.name`,
+			value:    nil,
+			want: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{},
 					},
 				},
 			},
@@ -248,6 +283,22 @@ func TestSetValueAtPath(t *testing.T) {
 			},
 		},
 		{
+			name: "set array element to nil",
+			resource: map[string]interface{}{
+				"containers": []interface{}{
+					map[string]interface{}{"name": "container1"},
+					"${someexpression}",
+				},
+			},
+			path:  "containers[1]",
+			value: nil,
+			want: map[string]interface{}{
+				"containers": []interface{}{
+					map[string]interface{}{"name": "container1"},
+				},
+			},
+		},
+		{
 			name:     "create array and set element",
 			resource: map[string]interface{}{},
 			path:     `spec.containers[0].ports[0].containerPort`,
@@ -267,6 +318,23 @@ func TestSetValueAtPath(t *testing.T) {
 			},
 		},
 		{
+			name:     "create array and set element to nil",
+			resource: map[string]interface{}{},
+			path:     `spec.containers[0].ports[0].containerPort`,
+			value:    nil,
+			want: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"ports": []interface{}{
+								map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "extend existing array",
 			resource: map[string]interface{}{
 				"args": []interface{}{"arg1"},
@@ -278,6 +346,20 @@ func TestSetValueAtPath(t *testing.T) {
 					"arg1",
 					nil,
 					"arg3",
+				},
+			},
+		},
+		{
+			name: "extend existing array and set to nil",
+			resource: map[string]interface{}{
+				"args": []interface{}{"arg1"},
+			},
+			path:  "args[2]",
+			value: nil,
+			want: map[string]interface{}{
+				"args": []interface{}{
+					"arg1",
+					nil,
 				},
 			},
 		},


### PR DESCRIPTION
When applying fields that evaluate to `null`, we get an error denying the request.
This issue was not allowing us to create resources with fields that might evaluate to null.

With these changes, if a field evaluates to null, we remove it from the manifest before attempting to apply it.

example:
```yaml
apiVersion: kro.run/v1alpha1
kind: ResourceGraphDefinition
metadata:
  name: bucket.kro.run
spec:
  schema:
    apiVersion: v1alpha1
    kind: S3Bucket
    spec:
      name: string | required=true
      policy: string
  resources:
  - id: policyBucket
    template:
      apiVersion: s3.services.k8s.aws/v1alpha1
      kind: Bucket
      metadata:
        name: ${schema.spec.name}
      spec:
        name: ${schema.spec.name}
        policy: '${schema.spec.?policy}'
```