### PR TITLE
fix(runtime): return nil for empty intersection

### DIFF
--- a/pkg/runtime/collection.go
+++ b/pkg/runtime/collection.go
@@ -58,7 +58,7 @@ func orderedIntersection(
 	observed, desired []*unstructured.Unstructured,
 ) []*unstructured.Unstructured {
 	if len(observed) == 0 || len(desired) == 0 {
-		return observed
+		return nil
 	}
 
 	observedByKey := make(map[string]*unstructured.Unstructured, len(observed))

--- a/pkg/runtime/collection_test.go
+++ b/pkg/runtime/collection_test.go
@@ -113,7 +113,7 @@ func TestOrderedIntersection(t *testing.T) {
 			name:     "empty desired",
 			observed: []*unstructured.Unstructured{newUnstructured("v1", "Pod", "ns", "a")},
 			desired:  nil,
-			want:     []string{"a"},
+			want:     nil, // intersection with empty = empty
 		},
 		{
 			name: "reorders to match desired",


### PR DESCRIPTION
While working on increasing runtime.Node test coverage I discovered
that orderedIntersection incorrectly returned the observed slice
when either input was empty. An intersection with an empty set should
always return empty.