### PR TITLE
feat: add kro-render for offline RGD dry-run rendering (fixes #993)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,6 +335,10 @@ cli:
 	sudo mv bin/kro /usr/local/bin
 	@echo "CLI built successfully"
 
+.PHONY: kro-render
+kro-render:
+	go build -ldflags=${LDFLAGS} -o bin/kro-render ./cmd/kro-render
+
 ##@ E2E Tests
 
 .PHONY: test-e2e

--- a/cmd/kro-render/README.md
+++ b/cmd/kro-render/README.md
@@ -1,0 +1,97 @@
+# kro-render
+
+Offline dry-run renderer for RGD templates with instance data. Implements [issue #993](https://github.com/kubernetes-sigs/kro/issues/993).
+
+Renders the fully hydrated RGD template with a provided instance to stdout, without applying to a cluster.
+
+## Build
+
+```bash
+make kro-render
+# or
+go build -o bin/kro-render ./cmd/kro-render
+```
+
+## Usage
+
+```bash
+# Render RGD with instance file
+kro-render -f empty.rgd.yaml -i empty.yaml
+
+# Render using dummy instance from kro generate instance (pipe for dry-run)
+kro generate instance -f empty.rgd.yaml | kro-render -f empty.rgd.yaml -i -
+
+# JSON output
+kro-render -f empty.rgd.yaml -i empty.yaml -o json
+```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--file` | Path to ResourceGraphDefinition file (required) |
+| `-i`, `--instance` | Path to instance file, or `-` for stdin (required) |
+| `-o`, `--output` | Output format: `yaml` (default) or `json` |
+
+## Requirements
+
+- **Kubeconfig**: Graph building requires OpenAPI schema resolution. Ensure `KUBECONFIG` or `~/.kube/config` points to a reachable cluster (even if you don't apply resources).
+- **Limitation**: RGDs with `readyWhen` that depend on other resources' status cannot be fully rendered offline (no cluster state). Use RGDs where resources only depend on `schema.*` for offline dry-run.
+
+## Example
+
+**empty.yaml** (instance):
+
+```yaml
+apiVersion: kro.run/v1alpha1
+kind: Empty
+metadata:
+  name: myempty
+spec:
+  key: foobar
+  value: test
+```
+
+**empty.rgd.yaml** (RGD):
+
+```yaml
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: empty
+  labels:
+    "kro.run/managed-by": "kro"
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Empty
+    spec:
+      key: string | default="key"
+      value: string | default="value"
+  resources:
+    - id: configmap
+      template:
+        apiVersion: "v1"
+        kind: "ConfigMap"
+        metadata:
+          name: "empty-configmap"
+          labels:
+            "kro.run/managed-by": "empty"
+            "test": '1'
+        data:
+          ${schema.spec.key}: "${schema.spec.value}"
+```
+
+**Output**:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: empty-configmap
+  labels:
+    "kro.run/managed-by": "empty"
+    "test": "1"
+data:
+  foobar: test
+```

--- a/cmd/kro-render/main.go
+++ b/cmd/kro-render/main.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+	kroclient "github.com/kubernetes-sigs/kro/pkg/client"
+	"github.com/kubernetes-sigs/kro/pkg/graph"
+	"github.com/kubernetes-sigs/kro/pkg/runtime"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+func main() {
+	rgdFile := ""
+	instanceFile := ""
+	outputFormat := "yaml"
+
+	for i := 1; i < len(os.Args); i++ {
+		switch os.Args[i] {
+		case "-f", "--file":
+			i++
+			if i < len(os.Args) {
+				rgdFile = os.Args[i]
+			}
+		case "-i", "--instance":
+			i++
+			if i < len(os.Args) {
+				instanceFile = os.Args[i]
+			}
+		case "-o", "--output":
+			i++
+			if i < len(os.Args) {
+				outputFormat = os.Args[i]
+			}
+		case "-h", "--help":
+			printUsage()
+			os.Exit(0)
+		}
+	}
+
+	if rgdFile == "" || instanceFile == "" {
+		fmt.Fprintf(os.Stderr, "Error: -f (RGD file) and -i (instance file) are required\n")
+		printUsage()
+		os.Exit(1)
+	}
+
+	if err := run(rgdFile, instanceFile, outputFormat); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, `kro-render - Offline dry-run render of RGD template with instance data
+
+Usage:
+  kro-render -f <rgd.yaml> -i <instance.yaml> [-o yaml|json]
+
+Options:
+  -f, --file      Path to ResourceGraphDefinition file (required)
+  -i, --instance  Path to instance file, or '-' for stdin (required)
+  -o, --output    Output format: yaml (default) or json
+
+Examples:
+  kro-render -f empty.rgd.yaml -i empty.yaml
+  kro generate instance -f empty.rgd.yaml | kro-render -f empty.rgd.yaml -i -
+
+`)
+}
+
+func run(rgdPath, instancePath, outputFormat string) error {
+	rgdData, err := os.ReadFile(rgdPath)
+	if err != nil {
+		return fmt.Errorf("read RGD file: %w", err)
+	}
+
+	var rgd v1alpha1.ResourceGraphDefinition
+	if err := yaml.Unmarshal(rgdData, &rgd); err != nil {
+		return fmt.Errorf("unmarshal RGD: %w", err)
+	}
+
+	var instanceData []byte
+	if instancePath == "-" {
+		scanner := bufio.NewScanner(os.Stdin)
+		var b strings.Builder
+		for scanner.Scan() {
+			b.WriteString(scanner.Text())
+			b.WriteByte('\n')
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("read stdin: %w", err)
+		}
+		instanceData = []byte(b.String())
+	} else {
+		instanceData, err = os.ReadFile(instancePath)
+		if err != nil {
+			return fmt.Errorf("read instance file: %w", err)
+		}
+	}
+
+	instance, err := decodeInstance(instanceData)
+	if err != nil {
+		return fmt.Errorf("decode instance: %w", err)
+	}
+
+	g, err := createGraph(&rgd)
+	if err != nil {
+		return fmt.Errorf("create graph: %w", err)
+	}
+
+	rt, err := runtime.FromGraph(g, instance)
+	if err != nil {
+		return fmt.Errorf("create runtime: %w", err)
+	}
+
+	var allResources []*unstructured.Unstructured
+	for _, node := range rt.Nodes() {
+		ignored, err := node.IsIgnored()
+		if err != nil {
+			return fmt.Errorf("node %q includeWhen: %w", node.Spec.Meta.ID, err)
+		}
+		if ignored {
+			continue
+		}
+
+		desired, err := node.GetDesired()
+		if err != nil {
+			if runtime.IsDataPending(err) {
+				return fmt.Errorf("node %q: dry-run cannot satisfy readyWhen/dependencies (data pending). Use RGDs without cross-resource readyWhen for offline render", node.Spec.Meta.ID)
+			}
+			return fmt.Errorf("node %q: %w", node.Spec.Meta.ID, err)
+		}
+
+		allResources = append(allResources, desired...)
+	}
+
+	return writeResources(allResources, outputFormat)
+}
+
+func decodeInstance(data []byte) (*unstructured.Unstructured, error) {
+	parts := strings.SplitN(string(data), "\n---\n", 2)
+	doc := strings.TrimSpace(parts[0])
+	if doc == "" {
+		return nil, fmt.Errorf("empty instance input")
+	}
+
+	var obj unstructured.Unstructured
+	if err := yaml.Unmarshal([]byte(doc), &obj); err != nil {
+		return nil, err
+	}
+	if len(obj.Object) == 0 {
+		return nil, fmt.Errorf("empty or invalid instance document")
+	}
+	return &obj, nil
+}
+
+func createGraph(rgd *v1alpha1.ResourceGraphDefinition) (*graph.Graph, error) {
+	set, err := kroclient.NewSet(kroclient.Config{})
+	if err != nil {
+		return nil, fmt.Errorf("create client set: %w", err)
+	}
+
+	builder, err := graph.NewBuilder(set.RESTConfig(), set.HTTPClient())
+	if err != nil {
+		return nil, fmt.Errorf("create graph builder: %w", err)
+	}
+
+	g, err := builder.NewResourceGraphDefinition(rgd)
+	if err != nil {
+		return nil, fmt.Errorf("build resource graph: %w", err)
+	}
+
+	return g, nil
+}
+
+func writeResources(resources []*unstructured.Unstructured, format string) error {
+	for i, obj := range resources {
+		var b []byte
+		var err error
+		switch format {
+		case "json":
+			b, err = json.MarshalIndent(obj.Object, "", "  ")
+		case "yaml":
+			b, err = yaml.Marshal(obj.Object)
+		default:
+			return fmt.Errorf("unsupported format: %s (use yaml or json)", format)
+		}
+		if err != nil {
+			return err
+		}
+		if i > 0 && format == "yaml" {
+			fmt.Println("---")
+		}
+		fmt.Println(string(b))
+	}
+	return nil
+}

--- a/scripts/kro-render.sh
+++ b/scripts/kro-render.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KRO_RENDER="${KRO_RENDER:-$REPO_ROOT/bin/kro-render}"
+
+if [[ ! -x "$KRO_RENDER" ]]; then
+  echo "kro-render not found. Build it with: make kro-render" >&2
+  exit 1
+fi
+
+exec "$KRO_RENDER" "$@"


### PR DESCRIPTION
# feat: add kro-render for offline RGD dry-run rendering

Closes #993

## Summary

Adds a standalone `kro-render` tool that performs offline dry-run rendering of RGD templates with instance data. Resources are rendered to stdout without requiring a Kubernetes cluster apply.

## Motivation

- **Problem**: No way to render RGD templates with instance input offline.
- **Solution**: A CLI that reuses kro's graph builder and runtime to render fully hydrated resources to stdout.

## Changes

### New Files

- `cmd/kro-render/main.go` – CLI that loads RGD + instance, builds graph, runs runtime, and prints rendered resources
- `cmd/kro-render/README.md` – Usage, options, and examples

### Modified Files

- `Makefile` – Added `kro-render` build target
- `scripts/kro-render.sh` – Wrapper script for `kro-render`

## Usage

```bash
# Build
make kro-render

# Render RGD with instance file
kro-render -f empty.rgd.yaml -i empty.yaml

# Dry-run using dummy instance from kro generate instance
kro generate instance -f empty.rgd.yaml | kro-render -f empty.rgd.yaml -i -
```

## Options

| Flag | Description |
|------|-------------|
| `-f`, `--file` | Path to ResourceGraphDefinition file (required) |
| `-i`, `--instance` | Path to instance file, or `-` for stdin (required) |
| `-o`, `--output` | Output format: `yaml` (default) or `json` |

## Example

**Input (empty.yaml)**:
```yaml
apiVersion: kro.run/v1alpha1
kind: Empty
metadata:
  name: myempty
spec:
  key: foobar
  value: test
```

**Output**:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: empty-configmap
  labels:
    "kro.run/managed-by": "empty"
    "test": "1"
data:
  foobar: test
```

## Notes

- **Kubeconfig**: Graph building uses kro's schema resolver, which requires a reachable cluster (or kubeconfig). No resources are applied.
- **Limitation**: RGDs with `readyWhen` that depend on other resources' status may hit `ErrDataPending` offline. Best used with RGDs where resources depend only on `schema.*`.
