### PR TITLE
Compile CEL programs at build time and reuse at runtime 

### DIFF
--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -90,9 +90,11 @@ func WithListVariables(names []string) EnvOption {
 	}
 }
 
-// DefaultEnvironment returns the default CEL environment.
-func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
-	declarations := []cel.EnvOption{
+// BaseDeclarations returns the base CEL environment options shared by all kro
+// CEL environments. Includes list/string extensions, optional types, encoders,
+// and Kubernetes CEL libraries (URLs, Regex, Random).
+func BaseDeclarations() []cel.EnvOption {
+	return []cel.EnvOption{
 		ext.Lists(),
 		ext.Strings(),
 		cel.OptionalTypes(),
@@ -104,6 +106,11 @@ func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
 		k8scellib.Regex(),
 		library.Random(),
 	}
+}
+
+// DefaultEnvironment returns the default CEL environment.
+func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
+	declarations := BaseDeclarations()
 
 	opts := &envOptions{}
 	for _, opt := range options {

--- a/pkg/cel/expression.go
+++ b/pkg/cel/expression.go
@@ -1,0 +1,81 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cel
+
+import (
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+)
+
+// Expression wraps a CEL expression with its compiled program and metadata.
+// Programs are compiled once at graph build time and reused across reconciliations.
+// The struct is immutable and thread-safe after construction. It is save to use
+// by multiple runtimes and reconciliations in parallel - thanks to Program being
+// thread-safe.
+//
+// Lifecycle:
+//   - Parser: creates with Original set (References and Program nil)
+//   - Builder: populates References during dependency extraction (via ast.Inspector)
+//   - Builder: populates Program during compilation (after type validation)
+//   - Runtime: calls Eval() with context containing values for References
+type Expression struct {
+	// Original is the raw CEL expression string, preserved for error messages
+	// and debugging. Set by parser.
+	Original string
+
+	// References lists all identifiers this expression accesses (e.g., "schema", "vpc").
+	// These are the keys that must be present in the context passed to Eval.
+	// Set by builder during dependency extraction.
+	//
+	// Note: References includes "schema" if used, but schema is NOT a DAG dependency.
+	// DAG dependencies are tracked separately at Node.Meta.Dependencies.
+	References []string
+
+	// Program is the compiled CEL program. Set by builder after type validation.
+	// It is stateless and thread-safe, allowing concurrent evaluation.
+	Program cel.Program
+}
+
+// NewUncompiled creates an uncompiled Expression with only Original set.
+// Use this in parser/tests where References and Program are set later by builder.
+func NewUncompiled(expr string) *Expression {
+	return &Expression{Original: expr}
+}
+
+// NewUncompiledSlice creates a slice of uncompiled Expressions from strings.
+// Use this in parser/tests for multi-expression fields like string templates.
+func NewUncompiledSlice(exprs ...string) []*Expression {
+	result := make([]*Expression, len(exprs))
+	for i, expr := range exprs {
+		result[i] = &Expression{Original: expr}
+	}
+	return result
+}
+
+// Eval evaluates the compiled expression and returns the result.
+func (e *Expression) Eval(ctx map[string]any) (any, error) {
+	out, _, err := e.Program.Eval(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("eval %q: %w", e.Original, err)
+	}
+
+	native, err := GoNativeType(out)
+	if err != nil {
+		return nil, fmt.Errorf("convert %q: %w", e.Original, err)
+	}
+
+	return native, nil
+}

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -182,39 +182,37 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 	// 3. Validate them against the resources defined in the resource graph definition.
 	// 4. Infer the status schema based on the CEL expressions.
 
-	instance, instanceCRD, err := b.buildInstanceNode(
+	// Build instance spec schema from SimpleSchema.
+	// This is independent of resources - just YAML parsing.
+	instanceSpecSchema, err := buildInstanceSpecSchema(rgd.Spec.Schema)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build resourcegraphdefinition %q: %w", rgd.Name, err)
+	}
+
+	// Synthesize CRD early with empty status.
+	// We'll update the status later after inferring it from CEL expressions.
+	instanceCRD := crd.SynthesizeCRD(
 		rgd.Spec.Schema.Group,
 		rgd.Spec.Schema.APIVersion,
 		rgd.Spec.Schema.Kind,
+		*instanceSpecSchema,
+		extv1.JSONSchemaProps{}, // empty status placeholder
+		false,                   // don't add default fields yet
 		rgd.Spec.Schema,
-		// We need to pass the nodes and schemas to the instance, so we can validate
-		// the CEL expressions in the context of the resources.
-		nodes,
-		schemas,
 	)
+
+	// Create a single expression inspector for all AST inspection operations.
+	// This uses a lightweight env that only declares identifier names (no full schemas) -
+	// sufficient for parsing and finding references, but NOT for type-checking or compilation.
+	nodeNames := maps.Keys(nodes)
+	allIdentifiers := append(nodeNames, SchemaVarName, EachVarName)
+	inspectorEnv, err := krocel.DefaultEnvironment(krocel.WithResourceIDs(allIdentifiers))
 	if err != nil {
-		return nil, fmt.Errorf("failed to build resourcegraphdefinition '%v': %w", rgd.Name, err)
+		return nil, fmt.Errorf("failed to create inspector environment: %w", err)
 	}
+	inspector := ast.NewInspectorWithEnv(inspectorEnv, allIdentifiers)
 
-	// Prepare schemas for CEL type checking.
-	// Collections need to be wrapped as list types.
-	celSchemas := collectNodeSchemas(nodes, schemas)
-
-	// include the instance spec schema in the context as "schema". This will let us
-	// validate expressions such as ${schema.spec.someField}.
-	//
-	// not that we only include the spec and metadata fields, instance status references
-	// are not allowed in RGDs (yet)
-	schemaWithoutStatus, err := getSchemaWithoutStatus(instanceCRD)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get schema without status: %w", err)
-	}
-	celSchemas[SchemaVarName] = schemaWithoutStatus
-
-	// Create a DeclTypeProvider for introspecting type structures during validation
-	typeProvider := krocel.CreateDeclTypeProvider(celSchemas)
-
-	// First, build the dependency graph by inspecting CEL expressions.
+	// Build the dependency graph by inspecting CEL expressions.
 	// This extracts all resource dependencies and validates that:
 	// 1. All referenced resources are defined in the RGD
 	// 2. There are no unknown functions
@@ -222,7 +220,7 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 	//
 	// We do this BEFORE type checking so that undeclared resource errors
 	// are caught here with clear messages, rather than as CEL type errors.
-	dag, err := b.buildDependencyGraph(nodes)
+	dag, err := b.buildDependencyGraph(nodes, inspector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build dependency graph: %w", err)
 	}
@@ -232,29 +230,63 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 		return nil, fmt.Errorf("failed to get topological order: %w", err)
 	}
 
-	// Now that we know all resources are properly declared and dependencies are valid,
-	// we can perform type checking on the CEL expressions.
+	// Collect all schemas for CEL validation:
+	// - Resource schemas (wrapped as lists for collections)
+	// - Instance spec schema as "schema" variable (extracted from CRD, without status)
+	//
+	// This allows expressions like ${schema.spec.replicas} and ${deployment.status.replicas}.
+	// Note: only spec and metadata are included - status references are not allowed in RGDs.
+	celSchemas := collectNodeSchemas(nodes, schemas)
+	schemaWithoutStatus, err := getSchemaWithoutStatus(instanceCRD)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get schema without status: %w", err)
+	}
+	celSchemas[SchemaVarName] = schemaWithoutStatus
 
-	// Create a typed CEL environment with all resource schemas for template expressions
-	templatesEnv, err := krocel.TypedEnvironment(celSchemas)
+	// Create a single typed CEL environment with all schemas for compilation.
+	// Following Kubernetes best practice: create one env, extend once at init,
+	// compile all expressions against it. AST inspection handles scope validation.
+	typedEnv, err := krocel.TypedEnvironment(celSchemas)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create typed CEL environment: %w", err)
 	}
+	typeProvider := krocel.CreateDeclTypeProvider(celSchemas)
 
-	// Create a CEL environment with only "schema" for includeWhen expressions
-	var schemaEnv *cel.Env
-	if celSchemas[SchemaVarName] != nil {
-		schemaEnv, err = krocel.TypedEnvironment(map[string]*spec.Schema{SchemaVarName: celSchemas[SchemaVarName]})
-		if err != nil {
-			return nil, fmt.Errorf("failed to create CEL environment for includeWhen validation: %w", err)
+	// Validate and compile all resource CEL expressions.
+	for id, node := range nodes {
+		if err := validateAndCompileNode(node, inspector, typedEnv, schemas[id], typeProvider); err != nil {
+			return nil, fmt.Errorf("failed to validate resource %q: %w", id, err)
 		}
 	}
 
-	// Validate all CEL expressions for each node
-	for id, node := range nodes {
-		if err := validateNode(node, templatesEnv, schemaEnv, schemas[id], typeProvider); err != nil {
-			return nil, fmt.Errorf("failed to validate resource %q: %w", id, err)
-		}
+	// Build instance status schema.
+	// Status expressions reference resources (validated to not reference schema).
+	// We infer the status field types from the CEL expression output types.
+	statusSchema, statusVariables, statusTemplate, err := buildStatusSchema(
+		rgd.Spec.Schema,
+		nodeNames,
+		inspector,
+		typedEnv,
+		typeProvider,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build instance status schema: %w", err)
+	}
+
+	// Update the CRD with the inferred status schema.
+	crd.SetCRDStatus(instanceCRD, *statusSchema, true)
+
+	// Create the instance node with status variables for runtime patching.
+	instance, err := buildInstanceNode(
+		rgd.Spec.Schema.Group,
+		rgd.Spec.Schema.APIVersion,
+		rgd.Spec.Schema.Kind,
+		statusVariables,
+		statusTemplate,
+		inspector,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create instance node: %w", err)
 	}
 
 	resourceGraphDefinition := &Graph{
@@ -353,11 +385,6 @@ func (b *Builder) buildRGResource(
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to extract CEL expressions from schema for resource %s: %w", rgResource.ID, err)
 		}
-
-		// Set ExpectedType on each descriptor by converting schema to CEL type with proper naming
-		for i := range fieldDescriptors {
-			setExpectedTypeOnDescriptor(&fieldDescriptors[i], resourceSchema, rgResource.ID)
-		}
 	}
 
 	templateVariables := make([]*variable.ResourceField, 0, len(fieldDescriptors))
@@ -420,18 +447,11 @@ func (b *Builder) buildRGResource(
 // to determine the order in which the resources should be created in the cluster.
 func (b *Builder) buildDependencyGraph(
 	nodes map[string]*Node,
+	inspector *ast.Inspector,
 ) (
 	*dag.DirectedAcyclicGraph[string], // directed acyclic graph
 	error,
 ) {
-	// Build node names list for CEL environment.
-	nodeNames := append(maps.Keys(nodes), SchemaVarName)
-
-	env, err := krocel.DefaultEnvironment(krocel.WithResourceIDs(nodeNames))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
-	}
-
 	directedAcyclicGraph := dag.NewDirectedAcyclicGraph[string]()
 	for _, node := range nodes {
 		if err := directedAcyclicGraph.AddVertex(node.Meta.ID, node.Meta.Index); err != nil {
@@ -443,7 +463,7 @@ func (b *Builder) buildDependencyGraph(
 		iteratorNames := collectIteratorNames(node)
 
 		// Phase 1: Extract dependencies and classify variables
-		templateDeps, usedIterators, err := extractTemplateDependencies(env, node, nodeNames, iteratorNames)
+		templateDeps, usedIterators, err := extractTemplateDependencies(inspector, node, iteratorNames)
 		if err != nil {
 			return nil, err
 		}
@@ -464,7 +484,7 @@ func (b *Builder) buildDependencyGraph(
 			}
 		}
 
-		forEachDeps, err := extractForEachDependencies(env, node, nodeNames, iteratorNames)
+		forEachDeps, err := extractForEachDependencies(inspector, node, iteratorNames)
 		if err != nil {
 			return nil, err
 		}
@@ -499,16 +519,16 @@ func collectIteratorNames(node *Node) []string {
 //   - For namespaced resources: metadata.name or metadata.namespace
 //   - For cluster-scoped resources: metadata.name only
 func extractTemplateDependencies(
-	env *cel.Env,
+	inspector *ast.Inspector,
 	node *Node,
-	nodeNames, iteratorNames []string,
+	iteratorNames []string,
 ) ([]string, []string, error) {
 	var allDeps []string
 	var iteratorsInIdentity []string
 
 	for _, templateVariable := range node.Variables {
 		for _, expression := range templateVariable.Expressions {
-			nodeDeps, iteratorRefs, err := extractDependencies(env, expression, nodeNames, iteratorNames)
+			nodeDeps, iteratorRefs, err := extractDependencies(inspector, expression, iteratorNames)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to extract dependencies: %w", err)
 			}
@@ -523,7 +543,7 @@ func extractTemplateDependencies(
 				templateVariable.Kind = variable.ResourceVariableKindDynamic
 			}
 
-			templateVariable.AddDependencies(nodeDeps...)
+			// Dependencies are tracked in Expression.References
 			allDeps = append(allDeps, nodeDeps...)
 
 			// Track iterators used in identity fields (name/namespace).
@@ -555,16 +575,16 @@ func extractTemplateDependencies(
 // Iterator variables used in templates (e.g ${item}) are NOT DAG dependencies -
 // they're local bindings resolved during ExpandCollection.
 func extractForEachDependencies(
-	env *cel.Env,
+	inspector *ast.Inspector,
 	node *Node,
-	nodeNames, iteratorNames []string,
+	iteratorNames []string,
 ) ([]string, error) {
 	var allDeps []string
 
 	for _, iter := range node.ForEach {
 		// Only pass iteratorNames - we want to detect iterator cross-references.
 		// schema references in forEach are valid (e.g schema.spec.regions).
-		nodeDeps, iteratorRefs, err := extractDependencies(env, iter.Expression, nodeNames, iteratorNames)
+		nodeDeps, iteratorRefs, err := extractDependencies(inspector, iter.Expression, iteratorNames)
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract dependencies from forEach iterator %q: %w", iter.Name, err)
 		}
@@ -581,49 +601,16 @@ func extractForEachDependencies(
 	return allDeps, nil
 }
 
-// buildInstanceNode builds the instance node. The instance node is
-// the representation of the CR that users will create in their cluster to request
-// the creation of the resources defined in the resource graph definition.
-//
-// Since instances are defined using the "SimpleSchema" format, we use a different
-// approach to build the instance node. Returns the node and the generated CRD.
-func (b *Builder) buildInstanceNode(
+// buildInstanceNode creates the instance node from pre-computed status components.
+// This is called after spec schema, status schema, and CRD have been built separately.
+// Uses the shared inspectorEnv for AST inspection.
+func buildInstanceNode(
 	group, apiVersion, kind string,
-	rgDefinition *v1alpha1.Schema,
-	nodes map[string]*Node,
-	nodeSchemas map[string]*spec.Schema,
-) (*Node, *extv1.CustomResourceDefinition, error) {
-	// The instance resource is the resource users will create in their cluster,
-	// to request the creation of the resources defined in the resource graph definition.
-	//
-	// The instance resource is a Kubernetes resource, differently from typical
-	// CRDs; it doesn't have an OpenAPI schema. Instead, it has a schema defined
-	// using the "SimpleSchema" format, a new standard we created to simplify
-	// CRD declarations.
-
-	// The instance resource is a Kubernetes resource, so it has a GroupVersionKind.
+	statusVariables []variable.FieldDescriptor,
+	statusTemplate map[string]interface{},
+	inspector *ast.Inspector,
+) (*Node, error) {
 	gvr := metadata.GetResourceGraphDefinitionInstanceGVR(group, apiVersion, kind)
-
-	// The instance resource has a schema defined using the "SimpleSchema" format.
-	instanceSpecSchema, err := buildInstanceSpecSchema(rgDefinition)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to build OpenAPI schema for instance: %w", err)
-	}
-
-	instanceStatusSchema, statusVariables, statusTemplate, err := buildStatusSchema(rgDefinition, nodes, nodeSchemas)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to build OpenAPI schema for instance status: %w", err)
-	}
-
-	// Synthesize the CRD for the instance resource.
-	overrideStatusFields := true
-	instanceCRD := crd.SynthesizeCRD(group, apiVersion, kind, *instanceSpecSchema, *instanceStatusSchema, overrideStatusFields, rgDefinition)
-
-	nodeNames := maps.Keys(nodes)
-	env, err := krocel.DefaultEnvironment(krocel.WithResourceIDs(nodeNames))
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create CEL environment: %w", err)
-	}
 
 	// Collect dependencies for instance status fields
 	var instanceDeps []string
@@ -636,9 +623,9 @@ func (b *Builder) buildInstanceNode(
 		// Extract dependencies from ALL expressions in the field (for multi-expression templates)
 		var resourceDeps []string
 		for _, expr := range statusVariable.Expressions {
-			deps, _, err := extractDependencies(env, expr, nodeNames, nil)
+			deps, _, err := extractDependencies(inspector, expr, nil)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to extract dependencies from expression %q: %w", expr, err)
+				return nil, fmt.Errorf("failed to extract dependencies from expression %q: %w", expr, err)
 			}
 			for _, dep := range deps {
 				if !slices.Contains(resourceDeps, dep) {
@@ -647,14 +634,13 @@ func (b *Builder) buildInstanceNode(
 			}
 		}
 		if len(resourceDeps) == 0 {
-			return nil, nil, fmt.Errorf("instance status field must refer to a resource: %s", statusVariable.Path)
+			return nil, fmt.Errorf("instance status field must refer to a resource: %s", statusVariable.Path)
 		}
 		instanceDeps = append(instanceDeps, resourceDeps...)
 
 		instanceStatusVariables = append(instanceStatusVariables, &variable.ResourceField{
 			FieldDescriptor: statusVariable,
 			Kind:            variable.ResourceVariableKindDynamic,
-			Dependencies:    resourceDeps,
 		})
 	}
 
@@ -676,7 +662,7 @@ func (b *Builder) buildInstanceNode(
 		Variables: instanceStatusVariables,
 	}
 
-	return instance, instanceCRD, nil
+	return instance, nil
 }
 
 // buildInstanceSpecSchema builds the instance spec schema that will be
@@ -710,12 +696,14 @@ func buildInstanceSpecSchema(rgSchema *v1alpha1.Schema) (*extv1.JSONSchemaProps,
 
 // buildStatusSchema builds the status schema for the instance resource.
 // The status schema is inferred from the CEL expressions in the status field
-// using CEL type checking.
+// using CEL type checking. Uses the shared inspectorEnv for validation and typed env for compilation.
 // Returns: (schema, fieldDescriptors, statusTemplate, error)
 func buildStatusSchema(
 	rgSchema *v1alpha1.Schema,
-	nodes map[string]*Node,
-	nodeSchemas map[string]*spec.Schema,
+	nodeNames []string,
+	inspector *ast.Inspector,
+	env *cel.Env,
+	typeProvider *krocel.DeclTypeProvider,
 ) (
 	*extv1.JSONSchemaProps,
 	[]variable.FieldDescriptor,
@@ -735,14 +723,24 @@ func buildStatusSchema(
 		return nil, nil, nil, fmt.Errorf("failed to extract CEL expressions from status: %w", err)
 	}
 
-	schemas := collectNodeSchemas(nodes, nodeSchemas)
+	// Instance status expressions can ONLY reference resources, not schema.
+	// At runtime, status is populated after resources are created.
 
-	env, err := krocel.TypedEnvironment(schemas)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create typed CEL environment: %w", err)
+	// Verify status expressions don't reference schema and populate References
+	for _, fieldDescriptor := range fieldDescriptors {
+		for _, expression := range fieldDescriptor.Expressions {
+			result, err := inspectExpressionRestricted(inspector, expression.Original, nodeNames)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("status field %q expression %q: %w", fieldDescriptor.Path, expression.Original, err)
+			}
+			// Populate expression.References for restricted environment compilation
+			for _, dep := range result.ResourceDependencies {
+				if !slices.Contains(expression.References, dep.ID) {
+					expression.References = append(expression.References, dep.ID)
+				}
+			}
+		}
 	}
-
-	provider := krocel.CreateDeclTypeProvider(schemas)
 
 	// Infer types for each status field expression using CEL type checking
 	statusTypeMap := make(map[string]*cel.Type)
@@ -751,7 +749,7 @@ func buildStatusSchema(
 			// Single standalone expression - use its output type
 			expression := fieldDescriptor.Expressions[0]
 
-			checkedAST, err := parseAndCheckCELExpression(env, expression)
+			checkedAST, err := parseCheckAndCompile(env, expression)
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("failed to type-check status expression %q at path %q: %w", expression, fieldDescriptor.Path, err)
 			}
@@ -760,13 +758,13 @@ func buildStatusSchema(
 		} else {
 			// String interpolation - validate all expressions and result is string
 			for _, expression := range fieldDescriptor.Expressions {
-				checkedAST, err := parseAndCheckCELExpression(env, expression)
+				checkedAST, err := parseCheckAndCompile(env, expression)
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("failed to type-check status expression %q at path %q: %w", expression, fieldDescriptor.Path, err)
 				}
 
 				outputType := checkedAST.OutputType()
-				if err := validateExpressionType(outputType, cel.StringType, expression, "status", fieldDescriptor.Path, provider); err != nil {
+				if err := validateExpressionType(outputType, cel.StringType, expression.Original, "status", fieldDescriptor.Path, typeProvider); err != nil {
 					return nil, nil, nil, err
 				}
 			}
@@ -775,7 +773,7 @@ func buildStatusSchema(
 	}
 
 	// convert the CEL types to OpenAPI schema - best effort.
-	statusSchema, err := schema.GenerateSchemaFromCELTypes(statusTypeMap, provider)
+	statusSchema, err := schema.GenerateSchemaFromCELTypes(statusTypeMap, typeProvider)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to generate status schema from CEL types: %w", err)
 	}
@@ -783,25 +781,58 @@ func buildStatusSchema(
 	return statusSchema, fieldDescriptors, unstructuredStatus, nil
 }
 
+// inspectExpressionRestricted uses the shared inspector to parse an expression,
+// then validates that only the allowed identifiers are referenced.
+// This is used for restricted contexts like includeWhen (only schema) or readyWhen (only self).
+func inspectExpressionRestricted(inspector *ast.Inspector, expr string, allowedIdentifiers []string) (ast.ExpressionInspection, error) {
+	result, err := inspector.Inspect(expr)
+	if err != nil {
+		return ast.ExpressionInspection{}, err
+	}
+
+	// Check that only allowed identifiers are referenced
+	for _, dep := range result.ResourceDependencies {
+		if !slices.Contains(allowedIdentifiers, dep.ID) {
+			return ast.ExpressionInspection{}, fmt.Errorf("references unknown identifiers: [%s]", dep.ID)
+		}
+	}
+
+	// Unknown resources are truly unknown (not in the shared inspector's known set)
+	if len(result.UnknownResources) > 0 {
+		var names []string
+		for _, r := range result.UnknownResources {
+			names = append(names, r.ID)
+		}
+		return ast.ExpressionInspection{}, fmt.Errorf("references unknown identifiers: %v", names)
+	}
+	if len(result.UnknownFunctions) > 0 {
+		return ast.ExpressionInspection{}, fmt.Errorf("uses unknown functions: %v", result.UnknownFunctions)
+	}
+	return result, nil
+}
+
 // extractDependencies extracts the dependencies from the given CEL expression.
 // It returns two slices:
 //   - resourceDeps: actual resource dependencies (other resources in the RGD)
 //   - iteratorRefs: references to iterator variables (from forEach dimensions)
 //
-// # Iterator variables are recognized and returned in iteratorRefs for validation
-func extractDependencies(env *cel.Env, expression string, resourceNames []string, iteratorVars []string) (
+// Iterator variables are recognized and returned in iteratorRefs for validation.
+// Also populates expr.References with all referenced identifiers.
+func extractDependencies(inspector *ast.Inspector, expr *krocel.Expression, iteratorVars []string) (
 	resourceDeps []string,
 	iteratorRefs []string,
 	err error,
 ) {
-	// SchemaVarName is always available - add it to known identifiers so it's not flagged as unknown
-	knownIdentifiers := append(resourceNames, SchemaVarName)
-	knownIdentifiers = append(knownIdentifiers, iteratorVars...)
-	inspector := ast.NewInspectorWithEnv(env, knownIdentifiers)
-
-	inspectionResult, err := inspector.Inspect(expression)
+	inspectionResult, err := inspector.Inspect(expr.Original)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to inspect expression: %w", err)
+	}
+
+	// Populate expression references
+	for _, dep := range inspectionResult.ResourceDependencies {
+		if !slices.Contains(expr.References, dep.ID) {
+			expr.References = append(expr.References, dep.ID)
+		}
 	}
 
 	for _, resource := range inspectionResult.ResourceDependencies {
@@ -809,23 +840,31 @@ func extractDependencies(env *cel.Env, expression string, resourceNames []string
 		if resource.ID == SchemaVarName {
 			continue
 		}
-		// Track iterator vars separately for validation
-		if slices.Contains(iteratorVars, resource.ID) {
-			if !slices.Contains(iteratorRefs, resource.ID) {
-				iteratorRefs = append(iteratorRefs, resource.ID)
-			}
-			continue
-		}
 		// Everything else is a resource dependency
 		if !slices.Contains(resourceDeps, resource.ID) {
 			resourceDeps = append(resourceDeps, resource.ID)
 		}
 	}
-	if len(inspectionResult.UnknownResources) > 0 {
-		return nil, nil, fmt.Errorf("found unknown resources in CEL expression: [%v]", inspectionResult.UnknownResources)
+
+	// Handle unknown resources - they might be iterator variables
+	for _, unknown := range inspectionResult.UnknownResources {
+		if slices.Contains(iteratorVars, unknown.ID) {
+			// It's an iterator variable - track it separately
+			if !slices.Contains(iteratorRefs, unknown.ID) {
+				iteratorRefs = append(iteratorRefs, unknown.ID)
+			}
+			// Also add to references
+			if !slices.Contains(expr.References, unknown.ID) {
+				expr.References = append(expr.References, unknown.ID)
+			}
+		} else {
+			// Truly unknown resource
+			return nil, nil, fmt.Errorf("references unknown identifiers: [%s]", unknown.ID)
+		}
 	}
+
 	if len(inspectionResult.UnknownFunctions) > 0 {
-		return nil, nil, fmt.Errorf("found unknown functions in CEL expression: [%v]", inspectionResult.UnknownFunctions)
+		return nil, nil, fmt.Errorf("uses unknown functions: %v", inspectionResult.UnknownFunctions)
 	}
 	return resourceDeps, iteratorRefs, nil
 }
@@ -860,18 +899,12 @@ func parseForEachDimensions(apiDimensions []v1alpha1.ForEachDimension) ([]ForEac
 	return result, nil
 }
 
-// setExpectedTypeOnDescriptor sets the ExpectedType field on a FieldDescriptor.
-// This is the single place where ExpectedType is determined for all field descriptors.
+// resolveSchemaAndTypeName walks through path segments and returns the schema
+// at that location along with a fully-qualified CEL type name.
 //
-// For string templates (multiple expressions like "foo-${expr1}-${expr2}"):
-//   - Always sets to cel.StringType since concatenation produces strings
-//
-// For standalone expressions (single expression like "${expr}"):
-//  1. Parses path into segments (e.g., "spec.containers[0].name" -> ["spec", "containers", [0], "name"])
-//  2. Walks through each segment, building type name and navigating schema:
-//     - Named segments: append to type name, look up in schema
-//     - Index segments: dereference array to element schema, append ".@idx" to type name
-//  3. Converts final schema to CEL type with constructed type name
+// For each segment:
+//   - Named segments: append to type name, look up in schema properties
+//   - Index segments: dereference array to element schema, append ".@idx" to type name
 func resolveSchemaAndTypeName(segments []fieldpath.Segment, rootSchema *spec.Schema, resourceID string) (*spec.Schema, string, error) {
 	typeName := krocel.TypeNamePrefix + resourceID
 	currentSchema := rootSchema
@@ -898,25 +931,25 @@ func resolveSchemaAndTypeName(segments []fieldpath.Segment, rootSchema *spec.Sch
 	return currentSchema, typeName, nil
 }
 
-func setExpectedTypeOnDescriptor(descriptor *variable.FieldDescriptor, rootSchema *spec.Schema, resourceID string) {
+// getExpectedTypeForField computes the expected CEL type for a field descriptor.
+// For standalone expressions, the type is derived from the OpenAPI schema at the path.
+// For string templates, the expected type is always string.
+func getExpectedTypeForField(descriptor *variable.FieldDescriptor, rootSchema *spec.Schema, resourceID string) *cel.Type {
 	if !descriptor.StandaloneExpression {
-		descriptor.ExpectedType = cel.StringType
-		return
+		return cel.StringType
 	}
 
 	segments, err := fieldpath.Parse(descriptor.Path)
 	if err != nil {
-		descriptor.ExpectedType = cel.DynType
-		return
+		return cel.DynType
 	}
 
 	schema, typeName, err := resolveSchemaAndTypeName(segments, rootSchema, resourceID)
 	if err != nil {
-		descriptor.ExpectedType = cel.DynType
-		return
+		return cel.DynType
 	}
 
-	descriptor.ExpectedType = getCelTypeFromSchema(schema, typeName)
+	return getCelTypeFromSchema(schema, typeName)
 }
 
 // getCelTypeFromSchema converts an OpenAPI schema to a CEL type with the given type name
@@ -960,104 +993,74 @@ func lookupSchemaAtField(schema *spec.Schema, field string) *spec.Schema {
 	return nil
 }
 
-// validateNode validates all CEL expressions for a single node:
+// validateAndCompileNode validates and compiles all CEL expressions for a single node:
 // - forEach expressions (collection iteration)
 // - Template expressions (resource field values)
 // - includeWhen expressions (conditional resource creation)
 // - readyWhen expressions (resource readiness conditions)
-func validateNode(node *Node, templatesEnv, schemaEnv *cel.Env, nodeSchema *spec.Schema, typeProvider *krocel.DeclTypeProvider) error {
-	// If this node has forEach iterators, validate them and extend the template environment
-	effectiveTemplatesEnv := templatesEnv
+//
+// Uses the shared inspectorEnv for AST inspection and typed env for compilation.
+func validateAndCompileNode(node *Node, inspector *ast.Inspector, env *cel.Env, nodeSchema *spec.Schema, typeProvider *krocel.DeclTypeProvider) error {
+	// Track iterator types for extending template environment
+	var iteratorTypes map[string]*cel.Type
+
+	// If this node has forEach iterators, validate and compile them
 	if len(node.ForEach) > 0 {
-		// Use templatesEnv for forEach validation since forEach expressions can reference
-		// other nodes (collection chaining), not just schema
-		iteratorTypes, err := validateForEachExpressions(templatesEnv, node)
+		var err error
+		iteratorTypes, err = validateAndCompileForEach(env, node)
 		if err != nil {
 			return err
 		}
-
-		// Extend the templates environment with iterator variables
-		// We need to declare each iterator variable with its inferred type
-		var iteratorDecls []cel.EnvOption
-		for name, celType := range iteratorTypes {
-			iteratorDecls = append(iteratorDecls, cel.Variable(name, celType))
-		}
-
-		effectiveTemplatesEnv, err = templatesEnv.Extend(iteratorDecls...)
-		if err != nil {
-			return fmt.Errorf("failed to extend CEL environment with iterator variables for node %q: %w", node.Meta.ID, err)
-		}
 	}
 
-	// Validate template expressions (with iterator variables in scope if this is a collection)
-	if err := validateTemplateExpressions(effectiveTemplatesEnv, node, typeProvider); err != nil {
+	// Validate and compile template expressions
+	if err := validateAndCompileTemplates(env, node, nodeSchema, typeProvider, iteratorTypes); err != nil {
 		return err
 	}
 
-	// Validate includeWhen expressions if present
+	// Validate and compile includeWhen expressions if present
 	if len(node.IncludeWhen) > 0 {
-		if err := validateIncludeWhenExpressions(schemaEnv, node); err != nil {
+		// includeWhen expressions can ONLY reference the schema (instance spec).
+		// At runtime, includeWhen is evaluated before any resources are created.
+		for _, expression := range node.IncludeWhen {
+			if _, err := inspectExpressionRestricted(inspector, expression.Original, []string{SchemaVarName}); err != nil {
+				return fmt.Errorf("resource %q includeWhen: %w", node.Meta.ID, err)
+			}
+		}
+
+		// Compile includeWhen using the shared typed environment
+		if err := validateAndCompileIncludeWhen(env, node); err != nil {
 			return err
 		}
 	}
 
-	// Validate readyWhen expressions if present
+	// Validate and compile readyWhen expressions if present
 	if len(node.ReadyWhen) > 0 {
 		// readyWhen expressions can ONLY reference the node itself (or 'each' for collections).
-		// At runtime, IsResourceReady/IsCollectionReady only has the resource in scope - no schema
-		// or other nodes. Use includeWhen for schema-based conditional behavior.
-		//
-		// Allowed:
-		//   - Regular: ${nodeID.status.ready == true}
-		//   - Collection: ${each.status.phase == 'Running'}
-		// Not allowed:
-		//   - ${schema.spec.enabled} - schema not in scope at runtime
-		//   - ${otherNode.status.ready} - other nodes not in scope
+		// At runtime, IsResourceReady/IsCollectionReady only has the resource in scope.
 		allowedVar := node.Meta.ID
 		if node.Meta.Type == NodeTypeCollection {
 			allowedVar = EachVarName
 		}
 
 		for _, expression := range node.ReadyWhen {
-			readyEnv, err := krocel.DefaultEnvironment(
-				krocel.WithResourceIDs([]string{allowedVar}),
-			)
-			if err != nil {
-				return fmt.Errorf("failed to create CEL environment for readyWhen: %w", err)
-			}
-			inspector := ast.NewInspectorWithEnv(readyEnv, []string{allowedVar})
-			result, err := inspector.Inspect(expression)
-			if err != nil {
-				return fmt.Errorf("failed to inspect readyWhen expression %q: %w", expression, err)
-			}
-			if len(result.UnknownResources) > 0 {
-				var names []string
-				for _, r := range result.UnknownResources {
-					names = append(names, r.ID)
-				}
-				return fmt.Errorf(
-					"resource %q readyWhen expression %q cannot reference %v - only '%s' is available (use includeWhen for schema-based conditions)",
-					node.Meta.ID, expression, names, allowedVar,
-				)
+			if _, err := inspectExpressionRestricted(inspector, expression.Original, []string{allowedVar}); err != nil {
+				return fmt.Errorf("resource %q readyWhen: %w", node.Meta.ID, err)
 			}
 		}
 
-		// Determine variable name and schema for readyWhen expressions.
-		// Collections use EachVarName with item schema (per-item checks).
-		// Regular nodes use their ID with their full schema.
-		varName := node.Meta.ID
-		sch := nodeSchema
+		// For readyWhen on collections, we need "each" variable which isn't in the shared env.
+		// Create a typed env with just the node schema under the appropriate variable name.
+		readyEnv := env
 		if node.Meta.Type == NodeTypeCollection {
-			varName = EachVarName
-			// nodeSchema is already the item schema (not wrapped as list)
+			var err error
+			readyEnv, err = krocel.TypedEnvironment(map[string]*spec.Schema{EachVarName: nodeSchema})
+			if err != nil {
+				return fmt.Errorf("failed to create CEL environment for readyWhen validation: %w", err)
+			}
 		}
 
-		nodeEnv, err := krocel.TypedEnvironment(map[string]*spec.Schema{varName: sch})
-		if err != nil {
-			return fmt.Errorf("failed to create CEL environment for readyWhen validation: %w", err)
-		}
-
-		if err := validateReadyWhenExpressions(nodeEnv, node); err != nil {
+		if err := validateAndCompileReadyWhen(readyEnv, node); err != nil {
 			return err
 		}
 	}
@@ -1065,35 +1068,43 @@ func validateNode(node *Node, templatesEnv, schemaEnv *cel.Env, nodeSchema *spec
 	return nil
 }
 
-// validateTemplateExpressions validates CEL template expressions for a single node.
-// It type-checks that expressions reference valid fields and return the expected types
-// based on the OpenAPI schemas.
-func validateTemplateExpressions(env *cel.Env, node *Node, typeProvider *krocel.DeclTypeProvider) error {
+// validateAndCompileTemplates validates and compiles CEL template expressions for a single node.
+// For collections with forEach, the env is extended with iterator variable declarations.
+func validateAndCompileTemplates(
+	env *cel.Env,
+	node *Node,
+	nodeSchema *spec.Schema,
+	typeProvider *krocel.DeclTypeProvider,
+	iteratorTypes map[string]*cel.Type,
+) error {
+	// If we have iterator types (from forEach), extend the environment with those declarations
+	compileEnv := env
+	if len(iteratorTypes) > 0 {
+		opts := make([]cel.EnvOption, 0, len(iteratorTypes))
+		for name, typ := range iteratorTypes {
+			opts = append(opts, cel.Variable(name, typ))
+		}
+		var err error
+		compileEnv, err = env.Extend(opts...)
+		if err != nil {
+			return fmt.Errorf("failed to extend CEL environment with iterator types: %w", err)
+		}
+	}
+
 	for _, templateVariable := range node.Variables {
-		if len(templateVariable.Expressions) == 1 {
-			// Single expression - validate against expected types
-			expression := templateVariable.Expressions[0]
+		// Compute expected type for this field
+		expectedType := getExpectedTypeForField(&templateVariable.FieldDescriptor, nodeSchema, node.Meta.ID)
 
-			checkedAST, err := parseAndCheckCELExpression(env, expression)
+		for _, expression := range templateVariable.Expressions {
+			// Parse, type-check, and compile
+			checkedAST, err := parseCheckAndCompile(compileEnv, expression)
 			if err != nil {
-				return fmt.Errorf("failed to type-check template expression %q at path %q: %w", expression, templateVariable.Path, err)
+				return fmt.Errorf("failed to compile template expression %q at path %q: %w", expression.Original, templateVariable.Path, err)
 			}
-			outputType := checkedAST.OutputType()
-			if err := validateExpressionType(outputType, templateVariable.ExpectedType, expression, node.Meta.ID, templateVariable.Path, typeProvider); err != nil {
-				return err
-			}
-		} else if len(templateVariable.Expressions) > 1 {
-			// Multiple expressions - all must be strings for concatenation
-			for _, expression := range templateVariable.Expressions {
-				checkedAST, err := parseAndCheckCELExpression(env, expression)
-				if err != nil {
-					return fmt.Errorf("failed to type-check template expression %q at path %q: %w", expression, templateVariable.Path, err)
-				}
 
-				outputType := checkedAST.OutputType()
-				if err := validateExpressionType(outputType, templateVariable.ExpectedType, expression, node.Meta.ID, templateVariable.Path, typeProvider); err != nil {
-					return err
-				}
+			outputType := checkedAST.OutputType()
+			if err := validateExpressionType(outputType, expectedType, expression.Original, node.Meta.ID, templateVariable.Path, typeProvider); err != nil {
+				return err
 			}
 		}
 	}
@@ -1128,11 +1139,11 @@ func validateExpressionType(outputType, expectedType *cel.Type, expression, reso
 	)
 }
 
-// parseAndCheckCELExpression parses and type-checks a CEL expression.
-// Returns the checked AST on success, or the raw CEL error on failure.
-// Callers should wrap the error with appropriate context.
-func parseAndCheckCELExpression(env *cel.Env, expression string) (*cel.Ast, error) {
-	parsedAST, issues := env.Parse(expression)
+// parseCheckAndCompile parses, type-checks, and compiles a CEL expression.
+// On success, it sets expr.Program and returns the checked AST.
+// Callers should wrap errors with appropriate context.
+func parseCheckAndCompile(env *cel.Env, expr *krocel.Expression) (*cel.Ast, error) {
+	parsedAST, issues := env.Parse(expr.Original)
 	if issues != nil && issues.Err() != nil {
 		return nil, issues.Err()
 	}
@@ -1142,15 +1153,22 @@ func parseAndCheckCELExpression(env *cel.Env, expression string) (*cel.Ast, erro
 		return nil, issues.Err()
 	}
 
+	// Compile to a reusable Program
+	program, err := env.Program(checkedAST)
+	if err != nil {
+		return nil, fmt.Errorf("compile: %w", err)
+	}
+	expr.Program = program
+
 	return checkedAST, nil
 }
 
 // validateConditionExpression validates a single condition expression (includeWhen or readyWhen).
 // It parses, type-checks, and verifies the expression returns bool or optional_type(bool).
-func validateConditionExpression(env *cel.Env, expression, conditionType, resourceID string) error {
-	checkedAST, err := parseAndCheckCELExpression(env, expression)
+func validateConditionExpression(env *cel.Env, expr *krocel.Expression, conditionType, resourceID string) error {
+	checkedAST, err := parseCheckAndCompile(env, expr)
 	if err != nil {
-		return fmt.Errorf("failed to type-check %s expression %q in resource %q: %w", conditionType, expression, resourceID, err)
+		return fmt.Errorf("failed to type-check %s expression %q in resource %q: %w", conditionType, expr.Original, resourceID, err)
 	}
 
 	// Verify the expression returns bool or optional_type(bool)
@@ -1158,17 +1176,16 @@ func validateConditionExpression(env *cel.Env, expression, conditionType, resour
 	if !krocel.IsBoolOrOptionalBool(outputType) {
 		return fmt.Errorf(
 			"%s expression %q in resource %q must return bool or optional_type(bool), but returns %q",
-			conditionType, expression, resourceID, outputType.String(),
+			conditionType, expr.Original, resourceID, outputType.String(),
 		)
 	}
 
 	return nil
 }
 
-// validateIncludeWhenExpressions validates that includeWhen expressions:
-// 1. Only reference the "schema" variable
-// 2. Return bool or optional_type(bool)
-func validateIncludeWhenExpressions(env *cel.Env, node *Node) error {
+// validateAndCompileIncludeWhen validates and compiles includeWhen expressions.
+// These expressions must only reference the "schema" variable and return bool.
+func validateAndCompileIncludeWhen(env *cel.Env, node *Node) error {
 	for _, expression := range node.IncludeWhen {
 		if err := validateConditionExpression(env, expression, "includeWhen", node.Meta.ID); err != nil {
 			return err
@@ -1177,8 +1194,8 @@ func validateIncludeWhenExpressions(env *cel.Env, node *Node) error {
 	return nil
 }
 
-// validateReadyWhenExpressions validates readyWhen expressions for a single node.
-func validateReadyWhenExpressions(env *cel.Env, node *Node) error {
+// validateAndCompileReadyWhen validates and compiles readyWhen expressions for a single node.
+func validateAndCompileReadyWhen(env *cel.Env, node *Node) error {
 	for _, expression := range node.ReadyWhen {
 		if err := validateConditionExpression(env, expression, "readyWhen", node.Meta.ID); err != nil {
 			return err
@@ -1187,7 +1204,7 @@ func validateReadyWhenExpressions(env *cel.Env, node *Node) error {
 	return nil
 }
 
-// validateForEachExpressions validates forEach expressions for a collection node.
+// validateAndCompileForEach validates and compiles forEach expressions for a collection node.
 // It returns a map of iterator variable names to their inferred CEL types.
 //
 // Each forEach expression must:
@@ -1196,7 +1213,7 @@ func validateReadyWhenExpressions(env *cel.Env, node *Node) error {
 //
 // The inferred element type of each list is used to declare the iterator variable
 // in the CEL environment for validating template expressions.
-func validateForEachExpressions(env *cel.Env, node *Node) (map[string]*cel.Type, error) {
+func validateAndCompileForEach(env *cel.Env, node *Node) (map[string]*cel.Type, error) {
 	if len(node.ForEach) == 0 {
 		return nil, nil
 	}
@@ -1204,8 +1221,8 @@ func validateForEachExpressions(env *cel.Env, node *Node) (map[string]*cel.Type,
 	iteratorTypes := make(map[string]*cel.Type, len(node.ForEach))
 
 	for _, iter := range node.ForEach {
-		// Parse and type-check the forEach expression
-		checkedAST, err := parseAndCheckCELExpression(env, iter.Expression)
+		// Parse, type-check, and compile the forEach expression
+		checkedAST, err := parseCheckAndCompile(env, iter.Expression)
 		if err != nil {
 			return nil, fmt.Errorf("node %q: forEach iterator %q: %w", node.Meta.ID, iter.Name, err)
 		}
@@ -1224,24 +1241,19 @@ func validateForEachExpressions(env *cel.Env, node *Node) (map[string]*cel.Type,
 	return iteratorTypes, nil
 }
 
-// getSchemaWithoutStatus returns a schema from the CRD with the status field removed.
+// getSchemaWithoutStatus extracts a spec.Schema from a CRD for CEL validation.
+// It includes spec and metadata but excludes status, since status references
+// are not allowed in RGD expressions.
 func getSchemaWithoutStatus(crd *extv1.CustomResourceDefinition) (*spec.Schema, error) {
-	crdCopy := crd.DeepCopy()
-
-	// TODO(a-hilaly) expand this function when we start support CRD upgrades.
-	if len(crdCopy.Spec.Versions) != 1 {
-		return nil, fmt.Errorf("expected CRD to have exactly one version, got %d versions: multi-version CRDs not yet supported", len(crdCopy.Spec.Versions))
+	if len(crd.Spec.Versions) != 1 {
+		return nil, fmt.Errorf("expected CRD to have exactly one version, got %d versions", len(crd.Spec.Versions))
 	}
-	if crdCopy.Spec.Versions[0].Schema == nil {
-		return nil, fmt.Errorf("expected CRD version to have schema defined, but schema is nil")
+	if crd.Spec.Versions[0].Schema == nil {
+		return nil, fmt.Errorf("expected CRD version to have schema defined")
 	}
 
-	openAPISchema := crdCopy.Spec.Versions[0].Schema.OpenAPIV3Schema
-
-	if openAPISchema.Properties == nil {
-		openAPISchema.Properties = make(map[string]extv1.JSONSchemaProps)
-	}
-
+	// Copy the schema and remove status
+	openAPISchema := crd.Spec.Versions[0].Schema.OpenAPIV3Schema.DeepCopy()
 	delete(openAPISchema.Properties, "status")
 
 	specSchema, err := schema.ConvertJSONSchemaPropsToSpecSchema(openAPISchema)
@@ -1249,10 +1261,12 @@ func getSchemaWithoutStatus(crd *extv1.CustomResourceDefinition) (*spec.Schema, 
 		return nil, err
 	}
 
+	// Add full ObjectMeta schema for CEL validation
 	if specSchema.Properties == nil {
 		specSchema.Properties = make(map[string]spec.Schema)
 	}
 	specSchema.Properties["metadata"] = schema.ObjectMetaSchema
+
 	return specSchema, nil
 }
 

--- a/pkg/graph/node.go
+++ b/pkg/graph/node.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 )
 
@@ -96,8 +97,8 @@ type NodeMeta struct {
 type ForEachDimension struct {
 	// Name is the iterator variable name (e.g., "region")
 	Name string
-	// Expression is the CEL expression that returns a list (e.g., "schema.spec.regions")
-	Expression string
+	// Expression is the compiled CEL expression that returns a list (e.g., "schema.spec.regions")
+	Expression *krocel.Expression
 }
 
 // Node is the immutable node spec produced by the builder.
@@ -115,13 +116,13 @@ type Node struct {
 	// Variables holds the CEL expression fields found in the template.
 	Variables []*variable.ResourceField
 
-	// IncludeWhen are CEL expressions that must all evaluate to true
+	// IncludeWhen are compiled CEL expressions that must all evaluate to true
 	// for this resource to be included. Empty means always include.
-	IncludeWhen []string
+	IncludeWhen []*krocel.Expression
 
-	// ReadyWhen are CEL expressions that must all evaluate to true
+	// ReadyWhen are compiled CEL expressions that must all evaluate to true
 	// for this resource to be considered ready.
-	ReadyWhen []string
+	ReadyWhen []*krocel.Expression
 
 	// ForEach holds the forEach dimensions for collection resources.
 	// nil or empty means this is not a collection.
@@ -158,7 +159,6 @@ func (n *Node) DeepCopy() *Node {
 		for i, v := range n.Variables {
 			copyVar := *v
 			copyVar.Expressions = slices.Clone(v.Expressions)
-			copyVar.Dependencies = slices.Clone(v.Dependencies)
 			cp.Variables[i] = &copyVar
 		}
 	}

--- a/pkg/graph/parser/conditions.go
+++ b/pkg/graph/parser/conditions.go
@@ -17,18 +17,15 @@ package parser
 import (
 	"fmt"
 	"strings"
+
+	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 )
 
-// This function parses resource condition expressions.
-// These expressions need to be standalone expressions
-// so, this function also does some validation.
-// At the end we return the expressions with '${}' removed
-//
-// To be honest I wouldn't necessarily call it parse, since
-// we are mostly just validating, without caring what's in
-// the expression. Maybe we can rename it in the future 🤔
-func ParseConditionExpressions(conditions []string) ([]string, error) {
-	expressions := make([]string, 0, len(conditions))
+// ParseConditionExpressions parses resource condition expressions (readyWhen, includeWhen).
+// These must be standalone expressions (${...}). Returns Expression objects with
+// Original set; References and Program are populated later by builder.
+func ParseConditionExpressions(conditions []string) ([]*krocel.Expression, error) {
+	expressions := make([]*krocel.Expression, 0, len(conditions))
 
 	for _, e := range conditions {
 		ok, err := isStandaloneExpression(e)
@@ -40,7 +37,7 @@ func ParseConditionExpressions(conditions []string) ([]string, error) {
 		}
 		expr := strings.TrimPrefix(e, "${")
 		expr = strings.TrimSuffix(expr, "}")
-		expressions = append(expressions, expr)
+		expressions = append(expressions, &krocel.Expression{Original: expr})
 	}
 
 	return expressions, nil

--- a/pkg/graph/parser/schemaless.go
+++ b/pkg/graph/parser/schemaless.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/cel-go/cel"
+	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 )
 
@@ -61,8 +61,7 @@ func parseSchemalessResource(resource interface{}, path string) ([]variable.Fiel
 			expr := strings.TrimPrefix(field, "${")
 			expr = strings.TrimSuffix(expr, "}")
 			expressionsFields = append(expressionsFields, variable.FieldDescriptor{
-				Expressions:          []string{expr},
-				ExpectedType:         cel.DynType, // No schema, so we use dynamic type
+				Expressions:          []*krocel.Expression{{Original: expr}},
 				Path:                 path,
 				StandaloneExpression: true,
 			})
@@ -74,8 +73,7 @@ func parseSchemalessResource(resource interface{}, path string) ([]variable.Fiel
 			if len(expressions) > 0 {
 				// String template in schemaless parsing - always produces string
 				expressionsFields = append(expressionsFields, variable.FieldDescriptor{
-					Expressions:          expressions,
-					ExpectedType:         cel.StringType,
+					Expressions:          krocel.NewUncompiledSlice(expressions...),
 					Path:                 path,
 					StandaloneExpression: false,
 				})

--- a/pkg/graph/parser/schemaless_test.go
+++ b/pkg/graph/parser/schemaless_test.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"testing"
 
+	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 )
 
@@ -30,7 +31,7 @@ func areEqualExpressionFields(a, b []variable.FieldDescriptor) bool {
 	sort.Slice(b, func(i, j int) bool { return b[i].Path < b[j].Path })
 
 	for i := range a {
-		if !equalStrings(a[i].Expressions, b[i].Expressions) ||
+		if !equalExprs(a[i].Expressions, b[i].Expressions) ||
 			a[i].Path != b[i].Path ||
 			a[i].StandaloneExpression != b[i].StandaloneExpression {
 			return false
@@ -84,7 +85,7 @@ func TestParseSchemalessResource(t *testing.T) {
 			},
 			want: []variable.FieldDescriptor{
 				{
-					Expressions:          []string{"resource.value"},
+					Expressions:          krocel.NewUncompiledSlice("resource.value"),
 					Path:                 "field",
 					StandaloneExpression: true,
 				},
@@ -100,7 +101,7 @@ func TestParseSchemalessResource(t *testing.T) {
 			},
 			want: []variable.FieldDescriptor{
 				{
-					Expressions:          []string{"nested.value"},
+					Expressions:          krocel.NewUncompiledSlice("nested.value"),
 					Path:                 "outer.inner",
 					StandaloneExpression: true,
 				},
@@ -117,12 +118,12 @@ func TestParseSchemalessResource(t *testing.T) {
 			},
 			want: []variable.FieldDescriptor{
 				{
-					Expressions:          []string{"array[0]"},
+					Expressions:          krocel.NewUncompiledSlice("array[0]"),
 					Path:                 "array[0]",
 					StandaloneExpression: true,
 				},
 				{
-					Expressions:          []string{"array[1]"},
+					Expressions:          krocel.NewUncompiledSlice("array[1]"),
 					Path:                 "array[1]",
 					StandaloneExpression: true,
 				},
@@ -136,7 +137,7 @@ func TestParseSchemalessResource(t *testing.T) {
 			},
 			want: []variable.FieldDescriptor{
 				{
-					Expressions: []string{"expr1", "expr2"},
+					Expressions: krocel.NewUncompiledSlice("expr1", "expr2"),
 					Path:        "field",
 				},
 			},
@@ -157,12 +158,12 @@ func TestParseSchemalessResource(t *testing.T) {
 			},
 			want: []variable.FieldDescriptor{
 				{
-					Expressions:          []string{"string.value"},
+					Expressions:          krocel.NewUncompiledSlice("string.value"),
 					Path:                 "string",
 					StandaloneExpression: true,
 				},
 				{
-					Expressions:          []string{"array.value"},
+					Expressions:          krocel.NewUncompiledSlice("array.value"),
 					Path:                 "nested.array[0]",
 					StandaloneExpression: true,
 				},
@@ -219,7 +220,7 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 			},
 			want: []variable.FieldDescriptor{
 				{
-					Expressions:          []string{"deeply.nested.value"},
+					Expressions:          krocel.NewUncompiledSlice("deeply.nested.value"),
 					Path:                 "level1.level2.level3.level4",
 					StandaloneExpression: true,
 				},
@@ -240,12 +241,12 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 			},
 			want: []variable.FieldDescriptor{
 				{
-					Expressions:          []string{"expr1"},
+					Expressions:          krocel.NewUncompiledSlice("expr1"),
 					Path:                 "array[0]",
 					StandaloneExpression: true,
 				},
 				{
-					Expressions:          []string{"expr2"},
+					Expressions:          krocel.NewUncompiledSlice("expr2"),
 					Path:                 "array[3].nested",
 					StandaloneExpression: true,
 				},
@@ -260,12 +261,12 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 			},
 			want: []variable.FieldDescriptor{
 				{
-					Expressions:          []string{""},
+					Expressions:          krocel.NewUncompiledSlice(""),
 					Path:                 "empty1",
 					StandaloneExpression: true,
 				},
 				{
-					Expressions:          []string{"    "},
+					Expressions:          krocel.NewUncompiledSlice("    "),
 					Path:                 "empty2",
 					StandaloneExpression: true,
 				},
@@ -308,31 +309,31 @@ func TestParseSchemalessResourceEdgeCases(t *testing.T) {
 			},
 			want: []variable.FieldDescriptor{
 				{
-					Expressions:          []string{"string.value"},
+					Expressions:          krocel.NewUncompiledSlice("string.value"),
 					Path:                 "string",
 					StandaloneExpression: true,
 				},
 				{
-					Expressions:          []string{"array.value"},
+					Expressions:          krocel.NewUncompiledSlice("array.value"),
 					Path:                 "nested.array[0]",
 					StandaloneExpression: true,
 				},
 				{
-					Expressions: []string{"expr1", "expr2"},
+					Expressions: krocel.NewUncompiledSlice("expr1", "expr2"),
 					Path:        "complex.field",
 				},
 				{
-					Expressions:          []string{"nested.value"},
+					Expressions:          krocel.NewUncompiledSlice("nested.value"),
 					Path:                 "complex.nested.inner",
 					StandaloneExpression: true,
 				},
 				{
-					Expressions:          []string{"expr4"},
+					Expressions:          krocel.NewUncompiledSlice("expr4"),
 					Path:                 "complex.array[1]",
 					StandaloneExpression: true,
 				},
 				{
-					Expressions:          []string{"expr5"},
+					Expressions:          krocel.NewUncompiledSlice("expr5"),
 					Path:                 "complex.array[2]",
 					StandaloneExpression: true,
 				},

--- a/pkg/graph/variable/variable_test.go
+++ b/pkg/graph/variable/variable_test.go
@@ -20,58 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestResourceFieldAddDependencies(t *testing.T) {
-	tests := []struct {
-		name              string
-		initialDeps       []string
-		depsToAdd         []string
-		expectedFinalDeps []string
-	}{
-		{
-			name:              "add new dependencies",
-			initialDeps:       []string{"resource1", "resource2"},
-			depsToAdd:         []string{"resource3", "resource4"},
-			expectedFinalDeps: []string{"resource1", "resource2", "resource3", "resource4"},
-		},
-		{
-			name:              "add duplicate dependencies",
-			initialDeps:       []string{"resource1", "resource2"},
-			depsToAdd:         []string{"resource2", "resource3"},
-			expectedFinalDeps: []string{"resource1", "resource2", "resource3"},
-		},
-		{
-			name:              "add to empty dependencies",
-			initialDeps:       []string{},
-			depsToAdd:         []string{"resource1", "resource2"},
-			expectedFinalDeps: []string{"resource1", "resource2"},
-		},
-		{
-			name:              "add empty dependencies",
-			initialDeps:       []string{"resource1", "resource2"},
-			depsToAdd:         []string{},
-			expectedFinalDeps: []string{"resource1", "resource2"},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			rf := ResourceField{
-				Dependencies: tc.initialDeps,
-			}
-
-			rf.AddDependencies(tc.depsToAdd...)
-
-			assert.ElementsMatch(t, tc.expectedFinalDeps, rf.Dependencies)
-
-			seen := make(map[string]bool)
-			for _, dep := range rf.Dependencies {
-				assert.False(t, seen[dep], "Duplicate dependency found: %s", dep)
-				seen[dep] = true
-			}
-		})
-	}
-}
-
 func TestResourceVariableKind(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/runtime/node.go
+++ b/pkg/runtime/node.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 	"github.com/kubernetes-sigs/kro/pkg/runtime/resolver"
@@ -79,17 +78,13 @@ func (n *Node) IsIgnored() (bool, error) {
 		return false, nil
 	}
 
-	// includeWhen only allows schema references; restrict env/context to schema.
-	env, err := buildEnv([]string{graph.InstanceNodeID}, nil)
-	if err != nil {
-		return false, err
-	}
+	// includeWhen only allows schema references; restrict context to schema.
 	ctx := n.buildContext(graph.InstanceNodeID)
 
 	for _, expr := range n.includeWhenExprs {
-		val, err := evalBoolExpr(env, expr, ctx)
+		val, err := evalBoolExpr(expr, ctx)
 		if err != nil {
-			return false, fmt.Errorf("includeWhen %q: %w", expr.Expression, err)
+			return false, fmt.Errorf("includeWhen %q: %w", expr.Expression.Original, err)
 		}
 		if !val {
 			return true, nil
@@ -271,18 +266,15 @@ func (n *Node) hardResolveCollection(vars []*variable.ResourceField, setIndexLab
 		return []*unstructured.Unstructured{}, nil
 	}
 
-	// Build iteration env with all iterator names added as singles (dyn, not list).
-	singles, collections, _ := n.contextDependencyIDs(nil)
-	iteratorNames := make([]string, 0, len(n.Spec.ForEach))
-	for _, dim := range n.Spec.ForEach {
-		iteratorNames = append(iteratorNames, dim.Name)
-	}
-	allSingles := append(singles, iteratorNames...)
-	iterEnv, err := buildEnv(allSingles, collections)
-	if err != nil {
-		return nil, err
-	}
 	baseCtx := n.buildContext()
+
+	// Build a map from expression string to expressionEvaluationState for iteration expressions.
+	iterExprStates := make(map[string]*expressionEvaluationState, len(n.templateExprs))
+	for _, expr := range n.templateExprs {
+		if expr.Kind.IsIteration() {
+			iterExprStates[expr.Expression.Original] = expr
+		}
+	}
 
 	expanded := make([]*unstructured.Unstructured, 0, len(items))
 	for idx, iterCtx := range items {
@@ -294,15 +286,17 @@ func (n *Node) hardResolveCollection(vars []*variable.ResourceField, setIndexLab
 		maps.Copy(ctx, baseCtx)
 		maps.Copy(ctx, iterCtx)
 
-		for expr := range iterExprs {
-			val, err := evalRawCEL(iterEnv, expr, ctx)
+		// Evaluate iteration expressions (not cached - different context per iteration).
+		for exprStr := range iterExprs {
+			exprState := iterExprStates[exprStr]
+			val, err := exprState.Expression.Eval(ctx)
 			if err != nil {
 				if isCELDataPending(err) {
 					return nil, ErrDataPending
 				}
-				return nil, fmt.Errorf("collection iteration eval %q: %w", expr, err)
+				return nil, fmt.Errorf("collection iteration eval %q: %w", exprStr, err)
 			}
-			values[expr] = val
+			values[exprStr] = val
 		}
 
 		desired := n.Spec.Template.DeepCopy()
@@ -341,7 +335,7 @@ func (n *Node) softResolve() ([]*unstructured.Unstructured, error) {
 	for _, v := range n.templateVars {
 		complete := true
 		for _, expr := range v.Expressions {
-			if _, ok := values[expr]; !ok {
+			if _, ok := values[expr.Original]; !ok {
 				complete = false
 				break
 			}
@@ -388,11 +382,6 @@ func (n *Node) evaluateExprsFiltered(exprs map[string]struct{}, continueOnPendin
 		return map[string]any{}, false, nil
 	}
 
-	singles, collections, _ := n.contextDependencyIDs(nil)
-	env, err := buildEnv(singles, collections)
-	if err != nil {
-		return nil, false, err
-	}
 	ctx := n.buildContext()
 
 	capacity := len(n.templateExprs)
@@ -406,12 +395,12 @@ func (n *Node) evaluateExprsFiltered(exprs map[string]struct{}, continueOnPendin
 			continue
 		}
 		if exprs != nil {
-			if _, ok := exprs[expr.Expression]; !ok {
+			if _, ok := exprs[expr.Expression.Original]; !ok {
 				continue
 			}
 		}
 		if !expr.Resolved {
-			val, err := evalExprAny(env, expr, ctx)
+			val, err := evalExprAny(expr, ctx)
 			if err != nil {
 				if isCELDataPending(err) {
 					hasPending = true
@@ -425,7 +414,7 @@ func (n *Node) evaluateExprsFiltered(exprs map[string]struct{}, continueOnPendin
 			expr.Resolved = true
 			expr.ResolvedValue = val
 		}
-		values[expr.Expression] = expr.ResolvedValue
+		values[expr.Expression.Original] = expr.ResolvedValue
 	}
 	return values, hasPending, nil
 }
@@ -460,15 +449,15 @@ func (n *Node) exprSetsForVars(
 
 	exprKinds := make(map[string]variable.ResourceVariableKind, len(n.templateExprs))
 	for _, expr := range n.templateExprs {
-		exprKinds[expr.Expression] = expr.Kind
+		exprKinds[expr.Expression.Original] = expr.Kind
 	}
 
 	for _, v := range vars {
 		for _, expr := range v.Expressions {
-			if kind, ok := exprKinds[expr]; ok && kind.IsIteration() {
-				iterExprs[expr] = struct{}{}
+			if kind, ok := exprKinds[expr.Original]; ok && kind.IsIteration() {
+				iterExprs[expr.Original] = struct{}{}
 			} else {
-				baseExprs[expr] = struct{}{}
+				baseExprs[expr.Original] = struct{}{}
 			}
 		}
 	}
@@ -484,7 +473,7 @@ func (n *Node) upsertToTemplate(base *unstructured.Unstructured, values map[stri
 		if len(v.Expressions) == 0 {
 			continue
 		}
-		if val, ok := values[v.Expressions[0]]; ok {
+		if val, ok := values[v.Expressions[0].Original]; ok {
 			_ = res.UpsertValueAtPath(v.Path, val)
 		}
 	}
@@ -528,20 +517,15 @@ func (n *Node) isSingleResourceReady() (bool, error) {
 	}
 
 	nodeID := n.Spec.Meta.ID
-	env, err := krocel.DefaultEnvironment(krocel.WithResourceIDs([]string{nodeID}))
-	if err != nil {
-		return false, err
-	}
-
 	ctx := map[string]any{nodeID: n.observed[0].Object}
 
 	for _, expr := range n.readyWhenExprs {
-		result, err := evalBoolExpr(env, expr, ctx)
+		result, err := evalBoolExpr(expr, ctx)
 		if err != nil {
 			if isCELDataPending(err) {
 				return false, nil
 			}
-			return false, fmt.Errorf("readyWhen %q: %w", expr.Expression, err)
+			return false, fmt.Errorf("readyWhen %q: %w", expr.Expression.Original, err)
 		}
 		if !result {
 			return false, nil
@@ -562,28 +546,22 @@ func (n *Node) isCollectionReady() (bool, error) {
 	}
 
 	// Collection readyWhen uses "each" (single item) only.
-	env, err := krocel.DefaultEnvironment(
-		krocel.WithResourceIDs([]string{graph.EachVarName}),
-	)
-	if err != nil {
-		return false, err
-	}
-
+	// Each item has different context, so we evaluate directly (not cached).
 	for i, obj := range n.observed {
 		ctx := map[string]any{graph.EachVarName: obj.Object}
 		for _, expr := range n.readyWhenExprs {
 			// readyWhen for collections must NOT be cached - each item has different "each" context.
-			// Use evalRawCEL directly instead of evalBoolExpr.
-			val, err := evalRawCEL(env, expr.Expression, ctx)
+			// Use Expression.Eval directly instead of evalBoolExpr.
+			val, err := expr.Expression.Eval(ctx)
 			if err != nil {
 				if isCELDataPending(err) {
 					return false, nil
 				}
-				return false, fmt.Errorf("readyWhen %q (item %d): %w", expr.Expression, i, err)
+				return false, fmt.Errorf("readyWhen %q (item %d): %w", expr.Expression.Original, i, err)
 			}
 			result, ok := val.(bool)
 			if !ok {
-				return false, fmt.Errorf("readyWhen %q did not return bool", expr.Expression)
+				return false, fmt.Errorf("readyWhen %q did not return bool", expr.Expression.Original)
 			}
 			if !result {
 				return false, nil
@@ -601,15 +579,10 @@ func (n *Node) evaluateForEach() ([]map[string]any, error) {
 	}
 
 	ctx := n.buildContext()
-	singles, collections, _ := n.contextDependencyIDs(nil)
-	env, err := buildEnv(singles, collections)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build forEach env: %w", err)
-	}
 
 	dimensions := make([]evaluatedDimension, len(n.Spec.ForEach))
 	for i, dim := range n.Spec.ForEach {
-		values, err := evalListExpr(env, n.forEachExprs[i], ctx)
+		values, err := evalListExpr(n.forEachExprs[i], ctx)
 		if err != nil {
 			if isCELDataPending(err) {
 				return nil, ErrDataPending

--- a/pkg/runtime/node_test.go
+++ b/pkg/runtime/node_test.go
@@ -17,10 +17,12 @@ package runtime
 import (
 	"testing"
 
+	"github.com/google/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 )
@@ -582,7 +584,7 @@ func TestNode_EvaluateExprs(t *testing.T) {
 					withDep(schema).build()
 				n.templateExprs = []*expressionEvaluationState{
 					{
-						Expression:    "schema.spec.name",
+						Expression:    krocel.NewUncompiled("schema.spec.name"),
 						Kind:          variable.ResourceVariableKindStatic,
 						Resolved:      true,
 						ResolvedValue: "cached-name",
@@ -796,28 +798,9 @@ func TestNode_IsCollectionReady_WithCEL(t *testing.T) {
 			wantErr:    true,
 			errContain: "division by zero",
 		},
-		{
-			name: "schema is not available in readyWhen",
-			node: func() *Node {
-				schema := newTestNode("schema", graph.NodeTypeInstance).
-					withObserved(map[string]any{
-						"spec": map[string]any{"minReplicas": int64(2)},
-					}).build()
-				return newTestNode("pods", graph.NodeTypeCollection).
-					withDep(schema).
-					withDesired(
-						newUnstructured("v1", "Pod", "ns", "pod-1"),
-						newUnstructured("v1", "Pod", "ns", "pod-2"),
-					).
-					withObserved(
-						map[string]any{"status": map[string]any{"replicas": int64(1)}},
-						map[string]any{"status": map[string]any{"replicas": int64(1)}},
-					).
-					withReadyWhen("each.status.replicas >= schema.spec.minReplicas").build()
-			},
-			wantErr:    true,
-			errContain: "undeclared reference",
-		},
+		// Note: The test case "schema is not available in readyWhen" was removed because
+		// this constraint is now enforced at compile time by the graph builder, not at runtime.
+		// The builder validates that readyWhen expressions only reference self or "each".
 	}
 
 	for _, tt := range tests {
@@ -1098,7 +1081,7 @@ func TestNode_EvaluateForEach(t *testing.T) {
 				n := newTestNode("buckets", graph.NodeTypeCollection).
 					withDep(schema).
 					withForEach("schema.spec.regions").build()
-				n.Spec.ForEach = []graph.ForEachDimension{{Name: "region", Expression: "schema.spec.regions"}}
+				n.Spec.ForEach = []graph.ForEachDimension{{Name: "region", Expression: krocel.NewUncompiled("schema.spec.regions")}}
 				return n
 			}(),
 			wantLen: 2,
@@ -1117,8 +1100,8 @@ func TestNode_EvaluateForEach(t *testing.T) {
 					withDep(schema).
 					withForEach("schema.spec.regions", "schema.spec.azs").build()
 				n.Spec.ForEach = []graph.ForEachDimension{
-					{Name: "region", Expression: "schema.spec.regions"},
-					{Name: "az", Expression: "schema.spec.azs"},
+					{Name: "region", Expression: krocel.NewUncompiled("schema.spec.regions")},
+					{Name: "az", Expression: krocel.NewUncompiled("schema.spec.azs")},
 				}
 				return n
 			}(),
@@ -1136,7 +1119,7 @@ func TestNode_EvaluateForEach(t *testing.T) {
 				n := newTestNode("buckets", graph.NodeTypeCollection).
 					withDep(schema).
 					withForEach("schema.spec.regions").build()
-				n.Spec.ForEach = []graph.ForEachDimension{{Name: "region", Expression: "schema.spec.regions"}}
+				n.Spec.ForEach = []graph.ForEachDimension{{Name: "region", Expression: krocel.NewUncompiled("schema.spec.regions")}}
 				return n
 			}(),
 			wantLen: 0,
@@ -1187,7 +1170,7 @@ func TestNode_HardResolveCollection(t *testing.T) {
 						"kind":       "ConfigMap",
 						"metadata":   map[string]any{"name": "${region}"},
 					}).build()
-				n.Spec.ForEach = []graph.ForEachDimension{{Name: "region", Expression: "schema.spec.regions"}}
+				n.Spec.ForEach = []graph.ForEachDimension{{Name: "region", Expression: krocel.NewUncompiled("schema.spec.regions")}}
 				return n
 			}(),
 			wantLen: 0,
@@ -1213,7 +1196,7 @@ func TestNode_HardResolveCollection(t *testing.T) {
 						"kind":       "ConfigMap",
 						"metadata":   map[string]any{"name": "${schema.spec.name + '-' + region}"},
 					}).build()
-				n.Spec.ForEach = []graph.ForEachDimension{{Name: "region", Expression: "schema.spec.regions"}}
+				n.Spec.ForEach = []graph.ForEachDimension{{Name: "region", Expression: krocel.NewUncompiled("schema.spec.regions")}}
 				return n
 			}(),
 			wantLen: 2,
@@ -1238,7 +1221,7 @@ func TestNode_HardResolveCollection(t *testing.T) {
 					withTemplateVar("data.result", "item.value / item.divisor").
 					withTemplateExpr("item.value / item.divisor", variable.ResourceVariableKindIteration).
 					build()
-				n.Spec.ForEach = []graph.ForEachDimension{{Name: "item", Expression: "schema.spec.items"}}
+				n.Spec.ForEach = []graph.ForEachDimension{{Name: "item", Expression: krocel.NewUncompiled("schema.spec.items")}}
 				return n
 			}(),
 			wantErr:    true,
@@ -1273,6 +1256,35 @@ func TestNode_HardResolveCollection(t *testing.T) {
 // -----------------------------------------------------------------------------
 // Test Helpers - Builder pattern for creating test Nodes
 // -----------------------------------------------------------------------------
+
+var testEnv = func() *cel.Env {
+	env, err := krocel.DefaultEnvironment(krocel.WithResourceIDs([]string{
+		"schema", "vpc", "subnet", "deployment", "configmap",
+		"pods", "test", "each", "item", "region", "az", "iterator",
+		"child", "parent", "grandparent", "ignoredParent", "missing",
+		"buckets", "external", "a", "b", "policy", "configs", "results",
+		"optional", "subnets",
+	}))
+	if err != nil {
+		panic(err)
+	}
+	return env
+}()
+
+func mustCompileTestExpr(expr string) *krocel.Expression {
+	celAST, issues := testEnv.Compile(expr)
+	if issues != nil && issues.Err() != nil {
+		panic(issues.Err())
+	}
+	program, err := testEnv.Program(celAST)
+	if err != nil {
+		panic(err)
+	}
+	return &krocel.Expression{
+		Original: expr,
+		Program:  program,
+	}
+}
 
 // testNodeBuilder provides a fluent API for constructing test Nodes.
 type testNodeBuilder struct {
@@ -1329,7 +1341,7 @@ func (b *testNodeBuilder) withDesired(objects ...*unstructured.Unstructured) *te
 func (b *testNodeBuilder) withIncludeWhen(exprs ...string) *testNodeBuilder {
 	for _, expr := range exprs {
 		b.includeWhenExprs = append(b.includeWhenExprs, &expressionEvaluationState{
-			Expression: expr,
+			Expression: mustCompileTestExpr(expr),
 			Kind:       variable.ResourceVariableKindIncludeWhen,
 		})
 	}
@@ -1339,7 +1351,7 @@ func (b *testNodeBuilder) withIncludeWhen(exprs ...string) *testNodeBuilder {
 // withResolvedIncludeWhen adds a pre-resolved includeWhen expression.
 func (b *testNodeBuilder) withResolvedIncludeWhen(expr string, value bool) *testNodeBuilder {
 	b.includeWhenExprs = append(b.includeWhenExprs, &expressionEvaluationState{
-		Expression:    expr,
+		Expression:    krocel.NewUncompiled(expr),
 		Kind:          variable.ResourceVariableKindIncludeWhen,
 		Resolved:      true,
 		ResolvedValue: value,
@@ -1351,7 +1363,7 @@ func (b *testNodeBuilder) withResolvedIncludeWhen(expr string, value bool) *test
 func (b *testNodeBuilder) withReadyWhen(exprs ...string) *testNodeBuilder {
 	for _, expr := range exprs {
 		b.readyWhenExprs = append(b.readyWhenExprs, &expressionEvaluationState{
-			Expression: expr,
+			Expression: mustCompileTestExpr(expr),
 			Kind:       variable.ResourceVariableKindReadyWhen,
 		})
 	}
@@ -1362,7 +1374,7 @@ func (b *testNodeBuilder) withReadyWhen(exprs ...string) *testNodeBuilder {
 func (b *testNodeBuilder) withForEach(exprs ...string) *testNodeBuilder {
 	for _, expr := range exprs {
 		b.forEachExprs = append(b.forEachExprs, &expressionEvaluationState{
-			Expression: expr,
+			Expression: mustCompileTestExpr(expr),
 			Kind:       variable.ResourceVariableKindIteration,
 		})
 	}
@@ -1372,7 +1384,7 @@ func (b *testNodeBuilder) withForEach(exprs ...string) *testNodeBuilder {
 // withTemplateExpr adds template expressions.
 func (b *testNodeBuilder) withTemplateExpr(expr string, kind variable.ResourceVariableKind) *testNodeBuilder {
 	b.templateExprs = append(b.templateExprs, &expressionEvaluationState{
-		Expression: expr,
+		Expression: mustCompileTestExpr(expr),
 		Kind:       kind,
 	})
 	return b
@@ -1383,7 +1395,7 @@ func (b *testNodeBuilder) withTemplateVar(path string, exprs ...string) *testNod
 	b.templateVars = append(b.templateVars, &variable.ResourceField{
 		FieldDescriptor: variable.FieldDescriptor{
 			Path:                 path,
-			Expressions:          exprs,
+			Expressions:          krocel.NewUncompiledSlice(exprs...),
 			StandaloneExpression: true,
 		},
 	})

--- a/pkg/runtime/resolver/resolver.go
+++ b/pkg/runtime/resolver/resolver.go
@@ -100,7 +100,7 @@ func (r *Resolver) resolveField(field variable.FieldDescriptor) ResolutionResult
 	}
 
 	if field.StandaloneExpression {
-		expr := field.Expressions[0]
+		expr := field.Expressions[0].Original
 		resolvedValue, ok := r.data[expr]
 		if !ok {
 			result.Error = fmt.Errorf("no data provided for expression: %s", expr)
@@ -120,12 +120,12 @@ func (r *Resolver) resolveField(field variable.FieldDescriptor) ResolutionResult
 
 		replaced := strValue
 		for _, expr := range field.Expressions {
-			replacement, ok := r.data[expr]
+			replacement, ok := r.data[expr.Original]
 			if !ok {
-				result.Error = fmt.Errorf("no data provided for expression: %s", expr)
+				result.Error = fmt.Errorf("no data provided for expression: %s", expr.Original)
 				return result
 			}
-			replaced = strings.ReplaceAll(replaced, "${"+expr+"}", fmt.Sprintf("%v", replacement))
+			replaced = strings.ReplaceAll(replaced, "${"+expr.Original+"}", fmt.Sprintf("%v", replacement))
 		}
 
 		// setValueAtPath cannot fail here: if getValueFromPath succeeded,

--- a/pkg/runtime/resolver/resolver_test.go
+++ b/pkg/runtime/resolver/resolver_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 )
 
@@ -459,7 +460,7 @@ func TestResolveField(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:                 "spec.field",
-				Expressions:          []string{"notProvided"},
+				Expressions:          krocel.NewUncompiledSlice("notProvided"),
 				StandaloneExpression: true,
 			},
 			want: ResolutionResult{
@@ -480,7 +481,7 @@ func TestResolveField(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:                 "spec.field",
-				Expressions:          []string{"value"},
+				Expressions:          krocel.NewUncompiledSlice("value"),
 				StandaloneExpression: true,
 			},
 			want: ResolutionResult{
@@ -502,7 +503,7 @@ func TestResolveField(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:        "spec.field",
-				Expressions: []string{"value1", "value2"},
+				Expressions: krocel.NewUncompiledSlice("value1", "value2"),
 			},
 			want: ResolutionResult{
 				Path:     "spec.field",
@@ -524,7 +525,7 @@ func TestResolveField(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:                 "spec.array[0]",
-				Expressions:          []string{"value"},
+				Expressions:          krocel.NewUncompiledSlice("value"),
 				StandaloneExpression: true,
 			},
 			want: ResolutionResult{
@@ -543,7 +544,7 @@ func TestResolveField(t *testing.T) {
 			data: map[string]interface{}{},
 			field: variable.FieldDescriptor{
 				Path:                 "spec.field",
-				Expressions:          []string{"missing"},
+				Expressions:          krocel.NewUncompiledSlice("missing"),
 				StandaloneExpression: true,
 			},
 			want: ResolutionResult{
@@ -561,7 +562,7 @@ func TestResolveField(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:                 "spec.nonexistent.field",
-				Expressions:          []string{"value"},
+				Expressions:          krocel.NewUncompiledSlice("value"),
 				StandaloneExpression: true,
 			},
 			want: ResolutionResult{
@@ -581,7 +582,7 @@ func TestResolveField(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:        "spec.field",
-				Expressions: []string{"value"},
+				Expressions: krocel.NewUncompiledSlice("value"),
 			},
 			want: ResolutionResult{
 				Path:  "spec.field",
@@ -606,7 +607,7 @@ func TestResolveField(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:                 "spec.nested.array[0].field",
-				Expressions:          []string{"value"},
+				Expressions:          krocel.NewUncompiledSlice("value"),
 				StandaloneExpression: true,
 			},
 			want: ResolutionResult{
@@ -629,7 +630,7 @@ func TestResolveField(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:        "spec.field",
-				Expressions: []string{"count", "name", "active"},
+				Expressions: krocel.NewUncompiledSlice("count", "name", "active"),
 			},
 			want: ResolutionResult{
 				Path:     "spec.field",
@@ -656,7 +657,7 @@ func TestResolveField(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:        `spec.containers[2].image`,
-				Expressions: []string{"image.name", "image.tag"},
+				Expressions: krocel.NewUncompiledSlice("image.name", "image.tag"),
 			},
 			want: ResolutionResult{
 				Path:     "spec.containers[2].image",
@@ -674,7 +675,7 @@ func TestResolveField(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:                 ".field",
-				Expressions:          []string{"value"},
+				Expressions:          krocel.NewUncompiledSlice("value"),
 				StandaloneExpression: true,
 			},
 			want: ResolutionResult{
@@ -696,7 +697,7 @@ func TestResolveField(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:        "spec.field",
-				Expressions: []string{"value1", "value2"},
+				Expressions: krocel.NewUncompiledSlice("value1", "value2"),
 			},
 			want: ResolutionResult{
 				Path:     "spec.field",
@@ -747,7 +748,7 @@ func TestResolveDynamicArrayIndexes(t *testing.T) {
 
 	field := variable.FieldDescriptor{
 		Path:                 "spec.array[1]",
-		Expressions:          []string{"value"},
+		Expressions:          krocel.NewUncompiledSlice("value"),
 		StandaloneExpression: true,
 	}
 
@@ -782,7 +783,7 @@ func TestResolver(t *testing.T) {
 		summary := r.Resolve([]variable.FieldDescriptor{
 			{
 				Path:        "spec.field",
-				Expressions: []string{"value", "suffix"},
+				Expressions: krocel.NewUncompiledSlice("value", "suffix"),
 			},
 		})
 		assert.Equal(t, 1, summary.TotalExpressions)
@@ -807,12 +808,12 @@ func TestResolver(t *testing.T) {
 		summary := r.Resolve([]variable.FieldDescriptor{
 			{
 				Path:                 "spec.field1",
-				Expressions:          []string{"value1"},
+				Expressions:          krocel.NewUncompiledSlice("value1"),
 				StandaloneExpression: true,
 			},
 			{
 				Path:                 "spec.field2",
-				Expressions:          []string{"value2"},
+				Expressions:          krocel.NewUncompiledSlice("value2"),
 				StandaloneExpression: true,
 			},
 		})
@@ -880,7 +881,7 @@ func TestResolveFieldWithEmptyBraces(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:                 "metadata.annotations",
-				Expressions:          []string{"includeAnnotations ? annotations : {}"},
+				Expressions:          krocel.NewUncompiledSlice("includeAnnotations ? annotations : {}"),
 				StandaloneExpression: true,
 			},
 			want: ResolutionResult{
@@ -903,7 +904,7 @@ func TestResolveFieldWithEmptyBraces(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:                 "spec.config",
-				Expressions:          []string{"has(schema.config) && includeConfig ? schema.config : {}"},
+				Expressions:          krocel.NewUncompiledSlice("has(schema.config) && includeConfig ? schema.config : {}"),
 				StandaloneExpression: true,
 			},
 			want: ResolutionResult{
@@ -926,7 +927,7 @@ func TestResolveFieldWithEmptyBraces(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:                 "data.field",
-				Expressions:          []string{"condition ? {} : {}"},
+				Expressions:          krocel.NewUncompiledSlice("condition ? {} : {}"),
 				StandaloneExpression: true,
 			},
 			want: ResolutionResult{
@@ -947,7 +948,7 @@ func TestResolveFieldWithEmptyBraces(t *testing.T) {
 			},
 			field: variable.FieldDescriptor{
 				Path:        "spec.value",
-				Expressions: []string{"expr ? value : {}"},
+				Expressions: krocel.NewUncompiledSlice("expr ? value : {}"),
 			},
 			want: ResolutionResult{
 				Path:     "spec.value",

--- a/pkg/runtime/state.go
+++ b/pkg/runtime/state.go
@@ -14,7 +14,10 @@
 
 package runtime
 
-import "github.com/kubernetes-sigs/kro/pkg/graph/variable"
+import (
+	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
+	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
+)
 
 // expressionEvaluationState tracks per-expression evaluation state.
 // Expressions are cached globally and shared via pointers - if the same
@@ -22,8 +25,9 @@ import "github.com/kubernetes-sigs/kro/pkg/graph/variable"
 //
 // This design mirrors the old runtime's proven caching architecture.
 type expressionEvaluationState struct {
-	// Expression is the CEL expression string.
-	Expression string
+	// Expression holds the CEL expression with its pre-compiled Program.
+	// The Program was compiled at graph build time and is reused here.
+	Expression *krocel.Expression
 
 	// Dependencies is the list of resource IDs this expression depends on.
 	// All dependencies must be resolved/ready before evaluation.


### PR DESCRIPTION
CEL Programs are stateless and thread safe, designed to compile once and
evaluate many times. Previously, we created and discarded CEL environments
on every expression evaluation at runtime: parse the string, compile to
AST, create Program, evaluate, then throw everything away. At build time,
we performed type checking but discarded the compiled Programs. This
wasted work that could be preserved.

This patch introduces an `Expression` struct holding both the original
CEL string and its compiled `Program`. The parser creates `Expression`
objects with only `Original` set. The builder uses a lightweight inspector
env for dependency extraction (just identifier names, no schemas), then a
single `TypedEnvironment` with all schemas for compilation. Following
Kubernetes CEL patterns: create one env at init, compile all expressions
against it, use AST inspection for scope validation. Compiled Programs
are preserved in `Expression.Program` and reused directly at runtime,
skipping parse and compile phases entirely.