### PR TITLE
fix(graph): handle additionalProperties in schema lookups

### DIFF
--- a/pkg/testutil/k8s/discovery.go
+++ b/pkg/testutil/k8s/discovery.go
@@ -404,6 +404,43 @@ func NewFakeResolver() (*FakeResolver, *fake.FakeDiscovery) {
 				},
 			},
 		},
+		// ConfigMap
+		{Version: "v1", Kind: "ConfigMap"}: {
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"metadata":   metadataSchema(),
+					"data": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+							},
+						},
+					},
+					"binaryData": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		// CRDs
 		{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}: {
 			SchemaProps: spec.SchemaProps{
@@ -505,6 +542,12 @@ func NewFakeResolver() (*FakeResolver, *fake.FakeDiscovery) {
 					Name:       "pods",
 					Namespaced: true,
 					Kind:       "Pod",
+					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+				{
+					Name:       "configmaps",
+					Namespaced: true,
+					Kind:       "ConfigMap",
 					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 				},
 			},


### PR DESCRIPTION
Another bug surfaced from https://github.com/kubernetes-sigs/kro/issues/17#issuecomment-3843929563 The schema lookup function didn't 
handle OpenAPI additionalProperties, which is how Kubernetes defines map types
like ConfigMap.data. When validating CEL expressions that write to
ConfigMap.data fields, the type checker couldn't resolve the field
schema and failed to catch type mismatches.

Renamed lookupSchemaAtPath to lookupSchemaAtField since it now only
handles single field resolution (the caller already splits paths). When
a field isn't found in Properties, it now checks AdditionalProperties
before giving up. This lets the CEL type checker properly validate
expressions like `data.myKey = ${someList}` and catch when a list is
assigned where a string is expected.