### PR TITLE
add jakobmoellerdev to kro-maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,10 +11,10 @@ aliases:
     - barney-s
     - bridgetkromhout
     - cheftako
+    - jakobmoellerdev
     - jlbutler
     - matthchr
     - nicslatts
-    - jakobmoellerdev
   kro-reviewers:
     - michaelhtm
     - n3wscott


### PR DESCRIPTION
Proposal to add Jakob as a kro maintainer. 

Following Kubernetes community past practice, this PR initiates a 1-week lazy consensus period for adding Jakob to kro-maintainers (which aliases to approvers for the project).

Please feel free to comment on this PR. If there are no objections, we will plan on merging Wednesday, Feb 11, 2026.

Context:

Jakob has been super impactful since his first contribution last March. He's been on the active reviewers list since we established it. He has authored 35 merged PRs (with 2 currently open), reviewed 100+ PRs to date, and has been actively involved in maintenance and release project activities.

Some callouts:

  1. Core Feature Development
  - PR #611: "feat: child object watch and resource reconciliation based on informers" - Major
  architectural feature
  - PR #712: "feat: add concurrency support in applyset operations" - Performance enhancement
  - PR #884: "refactor(cel/ast): rewrite inspector to use native CEL AST and improve analysis accuracy" -
   Significant refactor of CEL handling

  2. Critical Bug Fixes
  - PR #616: "fix!: properly shutdown controller manager and dynamic controller" - Breaking change
  addressing critical shutdown issues
  - PR #863: "fix: prevent panic due to missing runtime" - Stability fix
  - PR #833: "fix: various fixes on static type analysis in our structural type checking" - Core type
  system improvements

  3. Infrastructure & Tooling
  - PR #792: "chore: add presubmit scripts for integration tests, e2e tests, and image builds" - CI/CD
  improvements
  - PR #642: "chore(ci): add stale bot workflow for issue and PR management" - Project automation
  - PR #963: "chore: dependency bumps" - Regular maintenance work

  4. Release Management
  - Multiple release cutoff PRs: #989 (0.8.1), #979 (0.8.0), #896 (0.7.1), #865 (0.7.0), #834 (0.6.3),
  #831 (0.6.2), #739 (0.5.0)

Thanks @jakobmoellerdev for all of your ongoing contributions to the project, and for being open to expanding your scope.

This PR is my official +1 as a current maintainer.