### PR TITLE
chore(ci): add `-race` for all unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ ifeq ($(WHAT),integration)
 		-coverpkg=github.com/kubernetes-sigs/kro/pkg/... \
 		./test/integration/suites/...
 else ifeq ($(WHAT),unit)
-	go test -v ./pkg/... -coverprofile unit-cover.out
+	go test -race -v ./pkg/... -coverprofile unit-cover.out
 else
 	@echo "Error: WHAT must be either 'unit' or 'integration'"
 	@echo "Usage: make test WHAT=unit|integration"


### PR DESCRIPTION
There were quite a few concurrency issues related to us not catching race errors lately. since we dont have a runtime issue with our tests, lets add the go data race detection to all unit tests to improve safety