### PR TITLE
fix: validate status schema

### DIFF
--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -204,6 +204,20 @@ func TestGraphBuilder_Validation(t *testing.T) {
 		errMsg                      string
 	}{
 		{
+			name: "invalid status",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					nil,
+					map[string]interface{}{
+						"status": "string", // Invalid reference
+					},
+				),
+			},
+			wantErr: true,
+			errMsg:  "status fields without expressions are not supported",
+		},
+		{
 			name: "invalid resource type",
 			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(

--- a/pkg/graph/parser/parser.go
+++ b/pkg/graph/parser/parser.go
@@ -188,7 +188,7 @@ func parseObject(field map[string]interface{}, schema *spec.Schema, path string,
 		// fields. This is particularly important for handling custom resources and fields that
 		// may contain arbitrary nested structures with potential CEL expressions.
 		if hasStructuralSchemaMarkerEnabled(schema, xKubernetesPreserveUnknownFields) {
-			expressions, err := parseSchemalessResource(field, path)
+			expressions, _, err := parseSchemalessResource(field, path)
 			if err != nil {
 				return nil, err
 			}
@@ -225,7 +225,7 @@ func parseArray(field []interface{}, schema *spec.Schema, path string, expectedT
 		// fields. This is particularly important for handling custom resources and fields that
 		// may contain arbitrary nested structures with potential CEL expressions.
 		if hasStructuralSchemaMarkerEnabled(schema, xKubernetesPreserveUnknownFields) {
-			expressions, err := parseSchemalessResource(field, path)
+			expressions, _, err := parseSchemalessResource(field, path)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/graph/parser/schemaless.go
+++ b/pkg/graph/parser/schemaless.go
@@ -24,38 +24,41 @@ import (
 
 // ParseSchemalessResource extracts CEL expressions without a schema, this is useful
 // when the schema is not available. e.g RGI statuses
-func ParseSchemalessResource(resource map[string]interface{}) ([]variable.FieldDescriptor, error) {
+func ParseSchemalessResource(resource map[string]interface{}) ([]variable.FieldDescriptor, []string, error) {
 	return parseSchemalessResource(resource, "")
 }
 
 // parseSchemalessResource is a helper function that recursively
 // extracts expressions from a resource. It uses a depth first search to traverse
 // the resource and extract expressions from string fields
-func parseSchemalessResource(resource interface{}, path string) ([]variable.FieldDescriptor, error) {
+func parseSchemalessResource(resource interface{}, path string) ([]variable.FieldDescriptor, []string, error) {
 	var expressionsFields []variable.FieldDescriptor
+	var allPlainFieldPaths []string
 	switch field := resource.(type) {
 	case map[string]interface{}:
 		for field, value := range field {
 			fieldPath := joinPathAndFieldName(path, field)
-			fieldExpressions, err := parseSchemalessResource(value, fieldPath)
+			fieldExpressions, plainFieldPaths, err := parseSchemalessResource(value, fieldPath)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			expressionsFields = append(expressionsFields, fieldExpressions...)
+			allPlainFieldPaths = append(allPlainFieldPaths, plainFieldPaths...)
 		}
 	case []interface{}:
 		for i, item := range field {
 			itemPath := fmt.Sprintf("%s[%d]", path, i)
-			itemExpressions, err := parseSchemalessResource(item, itemPath)
+			itemExpressions, plainFieldPaths, err := parseSchemalessResource(item, itemPath)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			expressionsFields = append(expressionsFields, itemExpressions...)
+			allPlainFieldPaths = append(allPlainFieldPaths, plainFieldPaths...)
 		}
 	case string:
 		ok, err := isStandaloneExpression(field)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if ok {
 			expr := strings.TrimPrefix(field, "${")
@@ -68,7 +71,7 @@ func parseSchemalessResource(resource interface{}, path string) ([]variable.Fiel
 		} else {
 			expressions, err := extractExpressions(field)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if len(expressions) > 0 {
 				// String template in schemaless parsing - always produces string
@@ -77,11 +80,13 @@ func parseSchemalessResource(resource interface{}, path string) ([]variable.Fiel
 					Path:                 path,
 					StandaloneExpression: false,
 				})
+			} else {
+				allPlainFieldPaths = append(allPlainFieldPaths, path)
 			}
 		}
 
 	default:
-		// Ignore other types
+		allPlainFieldPaths = append(allPlainFieldPaths, path)
 	}
-	return expressionsFields, nil
+	return expressionsFields, allPlainFieldPaths, nil
 }

--- a/test/integration/suites/core/validation_test.go
+++ b/test/integration/suites/core/validation_test.go
@@ -214,6 +214,37 @@ var _ = Describe("Validation", func() {
 		})
 	})
 
+	Context("RGD Status", func() {
+		It("should reject RGDs with plain fileds (no expression)", func(ctx SpecContext) {
+			rgd := generator.NewResourceGraphDefinition("test-k8s-valid",
+				generator.WithSchema(
+					"TestK8sValidation", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					// status field
+					map[string]interface{}{
+						"name": "string",
+					},
+				),
+				generator.WithResource("validResource", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "test-config",
+					},
+				}, nil, nil),
+			)
+
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+
+			expectRGDInactiveWithError(ctx, rgd, "failed to build instance status schema: "+
+				"status fields without expressions are not supported")
+
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+	})
+
 	Context("Kind Names", func() {
 		It("should validate correct kind names", func(ctx SpecContext) {
 			validKinds := []string{


### PR DESCRIPTION
Currently, when the RGD instance status schema is processed, the CRD it
generates only contains the status fields that contain a CEL expression.
This can mislead users who define typed fields as instance status.

With this PR, we return an error if an RGD has status fields with no CEL
expressions