### PR TITLE
Fix empty arrays being converted to null instead of []

### DIFF
--- a/pkg/cel/conversions.go
+++ b/pkg/cel/conversions.go
@@ -73,7 +73,7 @@ func convertList(v ref.Val) (interface{}, error) {
 	if !ok {
 		return v.ConvertToNative(reflect.TypeOf([]interface{}{}))
 	}
-	var result []interface{}
+	result := make([]interface{}, 0)
 	it := lister.Iterator()
 	for it.HasNext() == types.True {
 		elem := it.Next()

--- a/pkg/cel/conversions_test.go
+++ b/pkg/cel/conversions_test.go
@@ -24,6 +24,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGoNativeType_EmptyList(t *testing.T) {
+	env, err := cel.NewEnv()
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`[]`)
+	require.NoError(t, issues.Err())
+
+	prog, err := env.Program(ast)
+	require.NoError(t, err)
+
+	val, _, err := prog.Eval(map[string]interface{}{})
+	require.NoError(t, err)
+
+	native, err := GoNativeType(val)
+	require.NoError(t, err)
+
+	list, ok := native.([]interface{})
+	require.True(t, ok, "Expected []interface{}, got %T", native)
+	assert.NotNil(t, list)
+	assert.Equal(t, 0, len(list))
+}
+
 func TestGoNativeType_ListMap(t *testing.T) {
 	env, err := cel.NewEnv()
 	require.NoError(t, err)


### PR DESCRIPTION
resolves https://github.com/kubernetes-sigs/kro/issues/1024

Empty CEL lists were converted to nil slices in `convertList` because
the result variable was declared with no-value- `var`instead of `make`.
When serialized to JSON, nil slices become `null` rather than empty
arrays, causing downstream validation failures when users pass empty
arrays through schema fields