### PR TITLE
fix: flaky validate RGD status test

### DIFF
--- a/test/integration/suites/core/validation_test.go
+++ b/test/integration/suites/core/validation_test.go
@@ -216,7 +216,7 @@ var _ = Describe("Validation", func() {
 
 	Context("RGD Status", func() {
 		It("should reject RGDs with plain fileds (no expression)", func(ctx SpecContext) {
-			rgd := generator.NewResourceGraphDefinition("test-k8s-valid",
+			rgd := generator.NewResourceGraphDefinition("test-k8s-invalid-status",
 				generator.WithSchema(
 					"TestK8sValidation", "v1alpha1",
 					map[string]interface{}{


### PR DESCRIPTION
Validate RGD status test was using the same RGD name as another integration
test. This caused to sometimes fail with [`RGD already exists`](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kro/1032/presubmits-integration-tests/2020979183517175808) error