### PR TITLE
Fix flaky validate RGD status integration test

### DIFF
--- a/test/integration/suites/core/validation_test.go
+++ b/test/integration/suites/core/validation_test.go
@@ -218,7 +218,7 @@ var _ = Describe("Validation", func() {
 		It("should reject RGDs with plain fileds (no expression)", func(ctx SpecContext) {
 			rgd := generator.NewResourceGraphDefinition("test-k8s-invalid-status",
 				generator.WithSchema(
-					"TestK8sValidation", "v1alpha1",
+					"TestK8sInvalidStatus", "v1alpha1",
 					map[string]interface{}{
 						"name": "string",
 					},


### PR DESCRIPTION
Two tests in validation_test.go were using the same RGD name `test-k8s-valid` and schema kind `TestK8sValidation`, causing a conflict when they ran in parallel or randomized order — the second test would fail trying to create an RGD that was still terminating from the first.

Renamed the second test's RGD to `test-k8s-invalid-status` and schema kind to `TestK8sInvalidStatus` to fix the collision.