### PR TITLE
refactor(cel): Move cel conversion functions to separate package

### DIFF
--- a/pkg/cel/conversion/conversions.go
+++ b/pkg/cel/conversion/conversions.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cel
+package conversion
 
 import (
 	"errors"

--- a/pkg/cel/conversion/conversions_test.go
+++ b/pkg/cel/conversion/conversions_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cel
+package conversion
 
 import (
 	"encoding/json"

--- a/pkg/cel/expression.go
+++ b/pkg/cel/expression.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 
 	"github.com/google/cel-go/cel"
+
+	"github.com/kubernetes-sigs/kro/pkg/cel/conversion"
 )
 
 // Expression wraps a CEL expression with its compiled program and metadata.
@@ -72,7 +74,7 @@ func (e *Expression) Eval(ctx map[string]any) (any, error) {
 		return nil, fmt.Errorf("eval %q: %w", e.Original, err)
 	}
 
-	native, err := GoNativeType(out)
+	native, err := conversion.GoNativeType(out)
 	if err != nil {
 		return nil, fmt.Errorf("convert %q: %w", e.Original, err)
 	}

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 	"github.com/kubernetes-sigs/kro/pkg/cel/ast"
+	"github.com/kubernetes-sigs/kro/pkg/cel/conversion"
 	"github.com/kubernetes-sigs/kro/pkg/graph/crd"
 	"github.com/kubernetes-sigs/kro/pkg/graph/dag"
 	"github.com/kubernetes-sigs/kro/pkg/graph/fieldpath"
@@ -1177,7 +1178,7 @@ func validateConditionExpression(env *cel.Env, expr *krocel.Expression, conditio
 
 	// Verify the expression returns bool or optional_type(bool)
 	outputType := checkedAST.OutputType()
-	if !krocel.IsBoolOrOptionalBool(outputType) {
+	if !conversion.IsBoolOrOptionalBool(outputType) {
 		return fmt.Errorf(
 			"%s expression %q in resource %q must return bool or optional_type(bool), but returns %q",
 			conditionType, expr.Original, resourceID, outputType.String(),


### PR DESCRIPTION
Moves conversion functions into pkg/cel/conversion package to allow cel libraries to import without circular dependencies

in preparation for json lib addition https://github.com/kubernetes-sigs/kro/pull/1033/changes#r2795702495