### PR TITLE
promote nicslatts to emeritus-kro-maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,11 +14,11 @@ aliases:
     - jakobmoellerdev
     - jlbutler
     - matthchr
-    - nicslatts
   kro-reviewers:
     - michaelhtm
     - n3wscott
   emeritus-kro-maintainers:
     - eqe-aws
+    - nicslatts
     - rynowak
 


### PR DESCRIPTION
@nicslatts  is a founding member of the project and his impact and contributions will be felt in perpetuity. 

Per his request, I am submitting this PR to move him from active to emeritus maintainer as his day job has taken him away from the project for the foreseeable future. 

Thanks for the ideation, contributions, and collaboration Nic!