### PR TITLE
fix(docs): Wrong schema apiVersion definition in RGD chaining

### DIFF
--- a/website/docs/docs/advanced/02-rgd-chaining.md
+++ b/website/docs/docs/advanced/02-rgd-chaining.md
@@ -25,7 +25,7 @@ metadata:
   name: full-stack-app
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: FullStackApp
     spec:
       name: string
@@ -72,7 +72,7 @@ metadata:
   name: database
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: Database
     spec:
       size: string | default="small"
@@ -144,7 +144,7 @@ metadata:
   name: web-application
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: WebApplication
     spec:
       name: string

--- a/website/versioned_docs/version-0.7.0/docs/advanced/02-rgd-chaining.md
+++ b/website/versioned_docs/version-0.7.0/docs/advanced/02-rgd-chaining.md
@@ -25,7 +25,7 @@ metadata:
   name: full-stack-app
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: FullStackApp
     spec:
       name: string
@@ -72,7 +72,7 @@ metadata:
   name: database
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: Database
     spec:
       size: string | default="small"
@@ -144,7 +144,7 @@ metadata:
   name: web-application
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: WebApplication
     spec:
       name: string

--- a/website/versioned_docs/version-0.7.1/docs/advanced/02-rgd-chaining.md
+++ b/website/versioned_docs/version-0.7.1/docs/advanced/02-rgd-chaining.md
@@ -25,7 +25,7 @@ metadata:
   name: full-stack-app
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: FullStackApp
     spec:
       name: string
@@ -72,7 +72,7 @@ metadata:
   name: database
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: Database
     spec:
       size: string | default="small"
@@ -144,7 +144,7 @@ metadata:
   name: web-application
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: WebApplication
     spec:
       name: string

--- a/website/versioned_docs/version-0.8.0/docs/advanced/02-rgd-chaining.md
+++ b/website/versioned_docs/version-0.8.0/docs/advanced/02-rgd-chaining.md
@@ -25,7 +25,7 @@ metadata:
   name: full-stack-app
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: FullStackApp
     spec:
       name: string
@@ -72,7 +72,7 @@ metadata:
   name: database
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: Database
     spec:
       size: string | default="small"
@@ -144,7 +144,7 @@ metadata:
   name: web-application
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: WebApplication
     spec:
       name: string

--- a/website/versioned_docs/version-0.8.1/docs/advanced/02-rgd-chaining.md
+++ b/website/versioned_docs/version-0.8.1/docs/advanced/02-rgd-chaining.md
@@ -25,7 +25,7 @@ metadata:
   name: full-stack-app
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: FullStackApp
     spec:
       name: string
@@ -72,7 +72,7 @@ metadata:
   name: database
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: Database
     spec:
       size: string | default="small"
@@ -144,7 +144,7 @@ metadata:
   name: web-application
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: WebApplication
     spec:
       name: string

--- a/website/versioned_docs/version-0.8.2/docs/advanced/02-rgd-chaining.md
+++ b/website/versioned_docs/version-0.8.2/docs/advanced/02-rgd-chaining.md
@@ -25,7 +25,7 @@ metadata:
   name: full-stack-app
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: FullStackApp
     spec:
       name: string
@@ -72,7 +72,7 @@ metadata:
   name: database
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: Database
     spec:
       size: string | default="small"
@@ -144,7 +144,7 @@ metadata:
   name: web-application
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: WebApplication
     spec:
       name: string

--- a/website/versioned_docs/version-0.8.3/docs/advanced/02-rgd-chaining.md
+++ b/website/versioned_docs/version-0.8.3/docs/advanced/02-rgd-chaining.md
@@ -25,7 +25,7 @@ metadata:
   name: full-stack-app
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: FullStackApp
     spec:
       name: string
@@ -72,7 +72,7 @@ metadata:
   name: database
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: Database
     spec:
       size: string | default="small"
@@ -144,7 +144,7 @@ metadata:
   name: web-application
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: WebApplication
     spec:
       name: string

--- a/website/versioned_docs/version-0.8.4/docs/advanced/02-rgd-chaining.md
+++ b/website/versioned_docs/version-0.8.4/docs/advanced/02-rgd-chaining.md
@@ -25,7 +25,7 @@ metadata:
   name: full-stack-app
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: FullStackApp
     spec:
       name: string
@@ -72,7 +72,7 @@ metadata:
   name: database
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: Database
     spec:
       size: string | default="small"
@@ -144,7 +144,7 @@ metadata:
   name: web-application
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: WebApplication
     spec:
       name: string

--- a/website/versioned_docs/version-0.8.5/docs/advanced/02-rgd-chaining.md
+++ b/website/versioned_docs/version-0.8.5/docs/advanced/02-rgd-chaining.md
@@ -25,7 +25,7 @@ metadata:
   name: full-stack-app
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: FullStackApp
     spec:
       name: string
@@ -72,7 +72,7 @@ metadata:
   name: database
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: Database
     spec:
       size: string | default="small"
@@ -144,7 +144,7 @@ metadata:
   name: web-application
 spec:
   schema:
-    apiVersion: kro.run/v1alpha1
+    apiVersion: v1alpha1
     kind: WebApplication
     spec:
       name: string


### PR DESCRIPTION
Hi!

This PR fixed the wrong use of apiVersion in `advanced/rgd-chaining` page. 

In schema, apiVersion should only mention the version and not the group, such:
`apiVersion: v1alpha1`

And not:
`apiVersion: kro.run/v1alpha1`