### PR TITLE
feat: allow RGD authors to maintain multiple versions (#482)

### DIFF
--- a/api/v1alpha1/resourcegraphdefinition_types.go
+++ b/api/v1alpha1/resourcegraphdefinition_types.go
@@ -53,12 +53,12 @@ type Schema struct {
 	Kind string `json:"kind,omitempty"`
 	// APIVersion is the version identifier for the generated CRD.
 	// Must follow Kubernetes versioning conventions (v1, v1alpha1, v1beta1, etc.).
-	// This field is immutable after creation.
+	// When updating this field, kro will automatically add the new version to the underlying CRD
+	// while keeping old versions served. The new version becomes the storage version.
 	// Example: "v1alpha1", "v1", "v2beta1"
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^v[0-9]+(alpha[0-9]+|beta[0-9]+)?$`
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="apiVersion is immutable"
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Group is the API group for the generated CRD. Together with APIVersion and Kind,
 	// it forms the complete GVK (Group-Version-Kind) identifier.

--- a/helm/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/helm/crds/kro.run_resourcegraphdefinitions.yaml
@@ -231,13 +231,11 @@ spec:
                     description: |-
                       APIVersion is the version identifier for the generated CRD.
                       Must follow Kubernetes versioning conventions (v1, v1alpha1, v1beta1, etc.).
-                      This field is immutable after creation.
+                      When updating this field, kro will automatically add the new version to the underlying CRD
+                      while keeping old versions served. The new version becomes the storage version.
                       Example: "v1alpha1", "v1", "v2beta1"
                     pattern: ^v[0-9]+(alpha[0-9]+|beta[0-9]+)?$
                     type: string
-                    x-kubernetes-validations:
-                    - message: apiVersion is immutable
-                      rule: self == oldSelf
                   group:
                     default: kro.run
                     description: |-

--- a/pkg/client/crd_test.go
+++ b/pkg/client/crd_test.go
@@ -1,0 +1,118 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestMergeVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		newCRD   *v1.CustomResourceDefinition
+		oldCRD   *v1.CustomResourceDefinition
+		expected []v1.CustomResourceDefinitionVersion
+	}{
+		{
+			name: "Preserve old version not in new CRD",
+			newCRD: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{Name: "v1beta1", Storage: true, Served: true},
+					},
+				},
+			},
+			oldCRD: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{Name: "v1alpha1", Storage: true, Served: true},
+					},
+				},
+			},
+			expected: []v1.CustomResourceDefinitionVersion{
+				{Name: "v1beta1", Storage: true, Served: true},
+				{Name: "v1alpha1", Storage: false, Served: true},
+			},
+		},
+		{
+			name: "Do not duplicate existing version",
+			newCRD: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{Name: "v1alpha1", Storage: true, Served: true},
+					},
+				},
+			},
+			oldCRD: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{Name: "v1alpha1", Storage: true, Served: true},
+					},
+				},
+			},
+			expected: []v1.CustomResourceDefinitionVersion{
+				{Name: "v1alpha1", Storage: true, Served: true},
+			},
+		},
+		{
+			name: "Handle multiple old versions",
+			newCRD: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{Name: "v1", Storage: true, Served: true},
+					},
+				},
+			},
+			oldCRD: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{Name: "v1beta1", Storage: false, Served: true},
+						{Name: "v1alpha1", Storage: true, Served: true},
+					},
+				},
+			},
+			expected: []v1.CustomResourceDefinitionVersion{
+				{Name: "v1", Storage: true, Served: true},
+				{Name: "v1beta1", Storage: false, Served: true},
+				{Name: "v1alpha1", Storage: false, Served: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapper := &CRDWrapper{}
+			wrapper.mergeVersions(tt.newCRD, tt.oldCRD)
+
+			assert.Equal(t, len(tt.expected), len(tt.newCRD.Spec.Versions))
+
+			for _, expectedVer := range tt.expected {
+				found := false
+				for _, actualVer := range tt.newCRD.Spec.Versions {
+					if actualVer.Name == expectedVer.Name {
+						found = true
+						assert.Equal(t, expectedVer.Storage, actualVer.Storage, "Storage flag mismatch for version %s", expectedVer.Name)
+						assert.Equal(t, expectedVer.Served, actualVer.Served, "Served flag mismatch for version %s", expectedVer.Name)
+						break
+					}
+				}
+				assert.True(t, found, "Expected version %s not found in result", expectedVer.Name)
+			}
+		})
+	}
+}

--- a/website/versioned_docs/version-0.7.1/api/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/website/versioned_docs/version-0.7.1/api/crds/kro.run_resourcegraphdefinitions.yaml
@@ -211,13 +211,11 @@ spec:
                     description: |-
                       APIVersion is the version identifier for the generated CRD.
                       Must follow Kubernetes versioning conventions (v1, v1alpha1, v1beta1, etc.).
-                      This field is immutable after creation.
+                      When updating this field, kro will automatically add the new version to the underlying CRD
+                      while keeping old versions served. The new version becomes the storage version.
                       Example: "v1alpha1", "v1", "v2beta1"
                     pattern: ^v[0-9]+(alpha[0-9]+|beta[0-9]+)?$
                     type: string
-                    x-kubernetes-validations:
-                    - message: apiVersion is immutable
-                      rule: self == oldSelf
                   group:
                     default: kro.run
                     description: |-


### PR DESCRIPTION
## Description
This PR implements the **core versioning logic** for `ResourceGraphDefinition`, allowing users to update the `apiVersion` schema without breaking existing resources or being blocked by validation.


## Why this approach? (Addressing Complexity)
While explicitly listing `previousSchemas` (as originally proposed) offers visibility, it requires a complex schema migration engine. This PR enables versioning **now** using native Kubernetes CRD mechanics. This does not preclude adding `previousSchemas` in a future PR for better visibility, but unblocks the core feature today.

fixes(#482)