### PR TITLE
Add RGD controller metrics

### DIFF
--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -17,6 +17,7 @@ package resourcegraphdefinition
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/go-logr/logr"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -196,12 +197,15 @@ func (r *ResourceGraphDefinitionReconciler) Reconcile(
 	o *v1alpha1.ResourceGraphDefinition,
 ) (ctrl.Result, error) {
 	if !o.DeletionTimestamp.IsZero() {
+		startTime := time.Now()
 		if err := r.cleanupResourceGraphDefinition(ctx, o); err != nil {
 			return ctrl.Result{}, err
 		}
 		if err := r.setUnmanaged(ctx, o); err != nil {
 			return ctrl.Result{}, err
 		}
+		deletionDuration.WithLabelValues(o.Spec.Schema.Kind).Observe(time.Since(startTime).Seconds())
+		deletionsTotal.WithLabelValues(o.Spec.Schema.Kind).Inc()
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile.go
@@ -117,8 +117,15 @@ func (r *ResourceGraphDefinitionReconciler) setupMicroController(
 // reconcileResourceGraphDefinitionGraph processes the resource graph definition to build a dependency graph
 // and extract resource information
 func (r *ResourceGraphDefinitionReconciler) reconcileResourceGraphDefinitionGraph(_ context.Context, rgd *v1alpha1.ResourceGraphDefinition) (*graph.Graph, []v1alpha1.ResourceInformation, error) {
+	startTime := time.Now()
+	defer func() {
+		graphBuildDuration.WithLabelValues(rgd.Spec.Schema.Kind).Observe(time.Since(startTime).Seconds())
+		graphBuildTotal.WithLabelValues(rgd.Spec.Schema.Kind).Inc()
+	}()
+
 	processedRGD, err := r.rgBuilder.NewResourceGraphDefinition(rgd, r.rgdConfig)
 	if err != nil {
+		graphBuildErrorsTotal.WithLabelValues(rgd.Spec.Schema.Kind).Inc()
 		return nil, nil, newGraphError(err)
 	}
 

--- a/pkg/controller/resourcegraphdefinition/controller_status.go
+++ b/pkg/controller/resourcegraphdefinition/controller_status.go
@@ -40,11 +40,17 @@ func (r *ResourceGraphDefinitionReconciler) updateStatus(
 	log, _ := logr.FromContext(ctx)
 	log.V(1).Info("calculating resource graph definition status and conditions")
 
+	oldState := o.Status.State
+
 	// Set status.state.
 	if rgdConditionTypes.For(o).IsRootReady() {
 		o.Status.State = v1alpha1.ResourceGraphDefinitionStateActive
 	} else {
 		o.Status.State = v1alpha1.ResourceGraphDefinitionStateInactive
+	}
+
+	if oldState != o.Status.State && oldState != "" && o.Spec.Schema != nil {
+		stateTransitionsTotal.WithLabelValues(o.Spec.Schema.Kind, string(oldState), string(o.Status.State)).Inc()
 	}
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/pkg/controller/resourcegraphdefinition/metrics.go
+++ b/pkg/controller/resourcegraphdefinition/metrics.go
@@ -1,0 +1,92 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcegraphdefinition
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	rgdLabels = []string{"rgd_kind"}
+
+	graphBuildTotal       *prometheus.CounterVec
+	graphBuildDuration    *prometheus.HistogramVec
+	graphBuildErrorsTotal *prometheus.CounterVec
+	stateTransitionsTotal *prometheus.CounterVec
+	deletionsTotal        *prometheus.CounterVec
+	deletionDuration      *prometheus.HistogramVec
+)
+
+func init() {
+	graphBuildTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "rgd_graph_build_total",
+			Help: "Total number of resource graph builds",
+		},
+		rgdLabels,
+	)
+
+	graphBuildDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "rgd_graph_build_duration_seconds",
+			Help:    "Duration of resource graph builds in seconds",
+			Buckets: prometheus.DefBuckets,
+		},
+		rgdLabels,
+	)
+
+	graphBuildErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "rgd_graph_build_errors_total",
+			Help: "Total number of resource graph build errors",
+		},
+		rgdLabels,
+	)
+
+	stateTransitionsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "rgd_state_transitions_total",
+			Help: "Total number of RGD state transitions",
+		},
+		append(rgdLabels, "from", "to"),
+	)
+
+	deletionsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "rgd_deletions_total",
+			Help: "Total number of RGD deletions",
+		},
+		rgdLabels,
+	)
+
+	deletionDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "rgd_deletion_duration_seconds",
+			Help:    "Duration of RGD deletions in seconds",
+			Buckets: prometheus.DefBuckets,
+		},
+		rgdLabels,
+	)
+
+	metrics.Registry.MustRegister(
+		graphBuildTotal,
+		graphBuildDuration,
+		graphBuildErrorsTotal,
+		stateTransitionsTotal,
+		deletionsTotal,
+		deletionDuration,
+	)
+}

--- a/website/docs/docs/advanced/04-metrics.md
+++ b/website/docs/docs/advanced/04-metrics.md
@@ -76,6 +76,19 @@ metrics:
 | `cel_expr_eval_total` | Counter | Total number of CEL expression evaluations | ALPHA |
 | `cel_expr_eval_duration_seconds` | Histogram | Duration of CEL expression evaluations in seconds | ALPHA |
 
+## ResourceGraphDefinition Controller Metrics
+
+All RGD controller metrics include the label `rgd_kind` (the schema kind of the ResourceGraphDefinition).
+
+| Metric | Type | Description | Stability |
+|--------|------|-------------|-----------|
+| `rgd_graph_build_total` | Counter | Total number of RGD graph validations during reconciliation | ALPHA |
+| `rgd_graph_build_duration_seconds` | Histogram | Duration of RGD graph validations in seconds | ALPHA |
+| `rgd_graph_build_errors_total` | Counter | Total number of RGD graph validation errors | ALPHA |
+| `rgd_state_transitions_total` | Counter | Total number of RGD state transitions (additional labels: `from`, `to`) | ALPHA |
+| `rgd_deletions_total` | Counter | Total number of RGD deletions | ALPHA |
+| `rgd_deletion_duration_seconds` | Histogram | Duration of RGD deletions in seconds | ALPHA |
+
 ## Controller Runtime Metrics
 
 The RGD reconciler uses controller-runtime and exposes its [standard metrics](https://book.kubebuilder.io/reference/metrics.html):


### PR DESCRIPTION
Add RGD controller metrics

- rgd_graph_build_total
- rgd_graph_build_duration_seconds
- rgd_graph_build_errors_total
- rgd_state_transitions_total
- rgd_deletions_total
- rgd_deletion_duration_seconds

Example
```
rgd_graph_build_duration_seconds_bucket{rgd_kind="JobDeployment",le="0.005"} 0
rgd_graph_build_duration_seconds_bucket{rgd_kind="JobDeployment",le="0.01"} 0
rgd_graph_build_duration_seconds_bucket{rgd_kind="JobDeployment",le="0.025"} 0
rgd_graph_build_duration_seconds_bucket{rgd_kind="JobDeployment",le="0.05"} 0
rgd_graph_build_duration_seconds_bucket{rgd_kind="JobDeployment",le="0.1"} 0
rgd_graph_build_duration_seconds_bucket{rgd_kind="JobDeployment",le="0.25"} 0
rgd_graph_build_duration_seconds_bucket{rgd_kind="JobDeployment",le="0.5"} 0
rgd_graph_build_duration_seconds_bucket{rgd_kind="JobDeployment",le="1"} 1
rgd_graph_build_duration_seconds_bucket{rgd_kind="JobDeployment",le="2.5"} 1
rgd_graph_build_duration_seconds_bucket{rgd_kind="JobDeployment",le="5"} 1
rgd_graph_build_duration_seconds_bucket{rgd_kind="JobDeployment",le="10"} 1
rgd_graph_build_duration_seconds_bucket{rgd_kind="JobDeployment",le="+Inf"} 1
rgd_graph_build_duration_seconds_sum{rgd_kind="JobDeployment"} 0.711111247
rgd_graph_build_duration_seconds_count{rgd_kind="JobDeployment"} 1
rgd_graph_build_duration_seconds_bucket{rgd_kind="Something",le="0.005"} 2
rgd_graph_build_duration_seconds_bucket{rgd_kind="Something",le="0.01"} 14
rgd_graph_build_duration_seconds_bucket{rgd_kind="Something",le="0.025"} 14
rgd_graph_build_duration_seconds_bucket{rgd_kind="Something",le="0.05"} 14
rgd_graph_build_duration_seconds_bucket{rgd_kind="Something",le="0.1"} 14
rgd_graph_build_duration_seconds_bucket{rgd_kind="Something",le="0.25"} 14
rgd_graph_build_duration_seconds_bucket{rgd_kind="Something",le="0.5"} 14
rgd_graph_build_duration_seconds_bucket{rgd_kind="Something",le="1"} 15
rgd_graph_build_duration_seconds_bucket{rgd_kind="Something",le="2.5"} 15
rgd_graph_build_duration_seconds_bucket{rgd_kind="Something",le="5"} 15
rgd_graph_build_duration_seconds_bucket{rgd_kind="Something",le="10"} 15
rgd_graph_build_duration_seconds_bucket{rgd_kind="Something",le="+Inf"} 15
rgd_graph_build_duration_seconds_sum{rgd_kind="Something"} 0.916312575
rgd_graph_build_duration_seconds_count{rgd_kind="Something"} 15
rgd_graph_build_duration_seconds_sum{rgd_kind="JobDeployment"} 0.711111247
rgd_graph_build_duration_seconds_count{rgd_kind="JobDeployment"} 1
rgd_graph_build_duration_seconds_sum{rgd_kind="Something"} 0.916312575
rgd_graph_build_duration_seconds_count{rgd_kind="Something"} 15
rgd_graph_build_errors_total{rgd_kind="Something"} 13
rgd_graph_build_total{rgd_kind="JobDeployment"} 1
rgd_graph_build_total{rgd_kind="Something"} 15
rgd_state_transitions_total{from="Inactive",rgd_kind="Something",to="Active"} 1
```