### PR TITLE
fix: remove the rgd labels from managed resources

### DIFF
--- a/pkg/metadata/selectors.go
+++ b/pkg/metadata/selectors.go
@@ -30,16 +30,20 @@ func NewInstanceSelector(instance metav1.Object) metav1.LabelSelector {
 	}
 }
 
+// NewResourceGraphDefinitionSelector returns a selector matching resources that
+// carry RGD labels (CRDs and instances). Child resources managed by an instance
+// do NOT carry RGD labels; use NewInstanceSelector to find child resources.
 func NewResourceGraphDefinitionSelector(resourceGraphDefinition metav1.Object) metav1.LabelSelector {
 	return metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			ResourceGraphDefinitionIDLabel: string(resourceGraphDefinition.GetUID()),
-			// ResourceGraphDefinitionNameLabel: resourceGraphDefinition.GetName(),
-			// ResourceGraphDefinitionNamespaceLabel: resourceGraphDefinition.GetNamespace(),
 		},
 	}
 }
 
+// NewInstanceAndResourceGraphDefinitionSelector returns a selector combining
+// instance and RGD labels. Only matches resources that carry both — typically
+// instances themselves, not child resources (which do not carry RGD labels).
 func NewInstanceAndResourceGraphDefinitionSelector(instance metav1.Object, resourceGraphDefinition metav1.Object) metav1.LabelSelector {
 	return metav1.LabelSelector{
 		MatchLabels: map[string]string{
@@ -49,6 +53,10 @@ func NewInstanceAndResourceGraphDefinitionSelector(instance metav1.Object, resou
 	}
 }
 
+// NewNodeAndInstanceAndResourceGraphDefinitionSelector returns a selector
+// combining node, instance, and RGD labels. Only matches resources that carry
+// all three — child resources do not carry RGD labels, so this selector will
+// not match them. Use NewInstanceSelector for child resource lookups.
 func NewNodeAndInstanceAndResourceGraphDefinitionSelector(node metav1.Object, instance metav1.Object, resourceGraphDefinition metav1.Object) metav1.LabelSelector {
 	return metav1.LabelSelector{
 		MatchLabels: map[string]string{

--- a/test/integration/suites/core/annotation_label_test.go
+++ b/test/integration/suites/core/annotation_label_test.go
@@ -160,9 +160,11 @@ var _ = Describe("Labels and Annotations", func() {
 			HaveKeyWithValue(metadata.InstanceKindLabel, "TestApply"),
 			HaveKeyWithValue(metadata.KROVersionLabel, "devel"),
 			HaveKeyWithValue(metadata.OwnedLabel, "true"),
-			HaveKeyWithValue(metadata.ResourceGraphDefinitionIDLabel, string(rgd.GetUID())),
-			HaveKeyWithValue(metadata.ResourceGraphDefinitionNameLabel, rgd.GetName()),
 		), "config map should be created as part of apply set managed by instance created through rgd")
+		Expect(cfgMap.GetLabels()).ToNot(HaveKey(metadata.ResourceGraphDefinitionIDLabel),
+			"child resource should not have RGD ID label (RGD labels are only applied to CRDs)")
+		Expect(cfgMap.GetLabels()).ToNot(HaveKey(metadata.ResourceGraphDefinitionNameLabel),
+			"child resource should not have RGD name label (RGD labels are only applied to CRDs)")
 	})
 
 })

--- a/website/docs/docs/concepts/15-instances.md
+++ b/website/docs/docs/concepts/15-instances.md
@@ -75,7 +75,6 @@ When kro manages an instance, it applies these labels and annotations:
 | `kro.run/kro-version` | Version of kro managing the instance |
 | `kro.run/resource-graph-definition-id` | UID of the ResourceGraphDefinition |
 | `kro.run/resource-graph-definition-name` | Name of the ResourceGraphDefinition |
-| `app.kubernetes.io/managed-by` | Set to `"kro"` (standard Kubernetes recommended label) |
 | `applyset.kubernetes.io/id` | Unique ApplySet identifier (hash of name.namespace.kind.group) |
 
 **Annotations:**
@@ -89,16 +88,22 @@ When kro manages an instance, it applies these labels and annotations:
 </TabItem>
 <TabItem value="managed" label="Managed Resource Metadata">
 
-Resources created by kro (Deployments, Services, ConfigMaps, etc.) receive all the instance labels, plus additional labels to trace back to the specific instance:
+Resources created by kro (Deployments, Services, ConfigMaps, etc.) receive labels for ownership tracking and resource discovery. These labels are distinct from the instance's own labels — notably, child resources do **not** carry `resource-graph-definition-*` labels since ownership is tracked via the [ApplySet specification](https://git.k8s.io/enhancements/keps/sig-cli/3659-kubectl-apply-prune).
 
-**Labels (in addition to instance labels):**
+**Labels:**
 
 | Label | Description |
 |-------|-------------|
+| `kro.run/owned` | Set to `"true"` to indicate kro manages this resource |
+| `kro.run/kro-version` | Version of kro managing the resource |
 | `kro.run/instance-id` | UID of the instance that created this resource |
 | `kro.run/instance-name` | Name of the instance |
 | `kro.run/instance-namespace` | Namespace of the instance |
-| `kro.run/node-id` | The resource ID from the RGD (e.g., `workerPods`) |
+| `kro.run/instance-group` | API group of the instance |
+| `kro.run/instance-version` | API version of the instance |
+| `kro.run/instance-kind` | Kind of the instance |
+| `app.kubernetes.io/managed-by` | Set to `"kro"` |
+| `kro.run/node-id` | Resource ID from the RGD |
 | `applyset.kubernetes.io/part-of` | Links the resource to its parent instance (matches the instance's `applyset.kubernetes.io/id`) |
 
 **Collection-specific labels** (only on resources created via `forEach`):


### PR DESCRIPTION
- Updated child resource labeling logic to exclude RGD-specific labels, aligning ownership tracking with ApplySet and avoiding conflicts and "flip-flopping" with ownership when using instances from other RGDs inside the resources
- Update logic in controllers and integration tests to prevent unnecessary RGD labels on child resources.
- Also updates our docs with our actual label values set.