### PR TITLE
fix(applyset): preserve prune scope on UID conflicts and requeue retry

### DIFF
--- a/pkg/controller/instance/applyset/applyset.go
+++ b/pkg/controller/instance/applyset/applyset.go
@@ -336,12 +336,12 @@ func (a *ApplySet) Prune(ctx context.Context, opts PruneOptions) (*PruneResult, 
 	}
 
 	// List and delete orphans
-	pruned, err := a.prune(ctx, pruneMappings, scopeNamespaces, opts.KeepUIDs, opts.Concurrency)
+	pruned, conflicts, err := a.prune(ctx, pruneMappings, scopeNamespaces, opts.KeepUIDs, opts.Concurrency)
 	if err != nil {
 		return nil, err
 	}
 
-	return &PruneResult{Pruned: pruned}, nil
+	return &PruneResult{Pruned: pruned, Conflicts: conflicts}, nil
 }
 
 func (a *ApplySet) applyResource(
@@ -454,7 +454,7 @@ func (a *ApplySet) prune(
 	namespaces sets.Set[string],
 	keepUIDs sets.Set[types.UID],
 	concurrency int,
-) ([]PruneResultItem, error) {
+) ([]PruneResultItem, int, error) {
 	// Track candidates with their GVR for deletion
 	type pruneCandidate struct {
 		obj *unstructured.Unstructured
@@ -522,7 +522,7 @@ func (a *ApplySet) prune(
 		})
 	}
 	if err := listGroup.Wait(); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	// Delete candidates concurrently
@@ -538,17 +538,36 @@ func (a *ApplySet) prune(
 
 	var mu sync.Mutex
 	var results []PruneResultItem
+	conflicts := 0
 
 	for _, c := range candidates {
 		eg.Go(func() error {
+			uid := c.obj.GetUID()
+			deleteOpts := metav1.DeleteOptions{
+				Preconditions: &metav1.Preconditions{UID: &uid},
+			}
 			var err error
 			if c.obj.GetNamespace() != "" {
-				err = a.client.Resource(c.gvr).Namespace(c.obj.GetNamespace()).Delete(egCtx, c.obj.GetName(), metav1.DeleteOptions{})
+				err = a.client.Resource(c.gvr).Namespace(c.obj.GetNamespace()).Delete(egCtx, c.obj.GetName(), deleteOpts)
 			} else {
-				err = a.client.Resource(c.gvr).Delete(egCtx, c.obj.GetName(), metav1.DeleteOptions{})
+				err = a.client.Resource(c.gvr).Delete(egCtx, c.obj.GetName(), deleteOpts)
 			}
 
-			if err != nil && !apierrors.IsNotFound(err) {
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				if apierrors.IsConflict(err) {
+					a.log.V(2).Info("skipped prune due to UID mismatch (resource recreated)",
+						"name", c.obj.GetName(),
+						"namespace", c.obj.GetNamespace(),
+						"gvr", c.gvr.String(),
+					)
+					mu.Lock()
+					conflicts++
+					mu.Unlock()
+					return nil
+				}
 				return fmt.Errorf("delete %s/%s: %w", c.obj.GetNamespace(), c.obj.GetName(), err)
 			}
 
@@ -566,10 +585,10 @@ func (a *ApplySet) prune(
 	}
 
 	if err := eg.Wait(); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return results, nil
+	return results, conflicts, nil
 }
 
 func (a *ApplySet) parentAnnotationSets() (sets.Set[schema.GroupKind], sets.Set[string]) {

--- a/pkg/controller/instance/applyset/applyset_test.go
+++ b/pkg/controller/instance/applyset/applyset_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -588,6 +589,177 @@ func TestPrune(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrune_UIDPrecondition(t *testing.T) {
+	ctx := t.Context()
+	mapper := newTestRESTMapper()
+
+	parent := &testParent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-instance",
+			Namespace: "default",
+			UID:       types.UID("test-parent-uid"),
+			Annotations: map[string]string{
+				ApplySetGKsAnnotation:                  "ConfigMap",
+				ApplySetAdditionalNamespacesAnnotation: "default",
+			},
+		},
+		gvk: schema.GroupVersionKind{Group: "kro.run", Version: "v1alpha1", Kind: "TestKind"},
+	}
+	applySetID := ID(parent)
+
+	t.Run("uid matches - resource pruned", func(t *testing.T) {
+		orphan := newConfigMap("orphan-cm", "default")
+		orphan.SetLabels(map[string]string{
+			ApplysetPartOfLabel: applySetID,
+		})
+		orphan.SetUID(types.UID("orphan-uid"))
+
+		client := newFakeDynamicClient(orphan)
+		addSSAReactor(client)
+
+		applier := New(Config{
+			Client:          client,
+			RESTMapper:      mapper,
+			Log:             logr.Discard(),
+			ParentNamespace: "default",
+		}, parent)
+
+		resources := []Resource{
+			{ID: "cm1", Object: newConfigMap("cm1", "default")},
+		}
+		result, _, err := applier.Apply(ctx, resources, ApplyMode{})
+		if err != nil {
+			t.Fatalf("Apply() error = %v", err)
+		}
+
+		projectMeta, err := applier.Project(resources)
+		if err != nil {
+			t.Fatalf("Project() error = %v", err)
+		}
+		pruneResult, err := applier.Prune(ctx, PruneOptions{
+			KeepUIDs: result.ObservedUIDs(),
+			Scope:    projectMeta.PruneScope(),
+		})
+		if err != nil {
+			t.Fatalf("Prune() error = %v", err)
+		}
+		if len(pruneResult.Pruned) != 1 {
+			t.Errorf("Prune() pruned %d resources, want 1", len(pruneResult.Pruned))
+		}
+		if pruneResult.Conflicts != 0 {
+			t.Errorf("Prune() conflicts = %d, want 0", pruneResult.Conflicts)
+		}
+	})
+
+	t.Run("uid mismatch - resource not pruned", func(t *testing.T) {
+		originalUID := types.UID("original-uid")
+		recreatedUID := types.UID("new-uid")
+
+		// Orphan as seen by LIST at prune start.
+		listedOrphan := newConfigMap("orphan-cm", "default")
+		listedOrphan.SetLabels(map[string]string{
+			ApplysetPartOfLabel: applySetID,
+		})
+		listedOrphan.SetUID(originalUID)
+
+		// Simulate: between LIST and DELETE, the resource was recreated with a new UID.
+		// The fake client stores the recreated object (new UID), while LIST is forced
+		// to return the old object (old UID). DELETE must carry old UID precondition.
+		recreated := newConfigMap("orphan-cm", "default")
+		recreated.SetLabels(map[string]string{
+			ApplysetPartOfLabel: applySetID,
+		})
+		recreated.SetUID(recreatedUID)
+
+		client := newFakeDynamicClient(recreated)
+		addSSAReactor(client)
+
+		client.PrependReactor("list", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			listAction, ok := action.(k8stesting.ListAction)
+			if !ok || listAction.GetNamespace() != "default" {
+				return false, nil, nil
+			}
+			list := &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMapList",
+				},
+				Items: []unstructured.Unstructured{
+					*listedOrphan.DeepCopy(),
+				},
+			}
+			return true, list, nil
+		})
+
+		// Intercept DELETE calls and return 409 Conflict when UID doesn't match
+		client.PrependReactor("delete", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			deleteAction, ok := action.(k8stesting.DeleteAction)
+			if !ok {
+				return false, nil, nil
+			}
+			if deleteAction.GetName() == "orphan-cm" {
+				opts := deleteAction.GetDeleteOptions()
+				if opts.Preconditions == nil || opts.Preconditions.UID == nil {
+					t.Fatalf("delete options missing UID precondition")
+				}
+				if got := *opts.Preconditions.UID; got != originalUID {
+					t.Fatalf("delete UID precondition = %q, want %q", got, originalUID)
+				}
+
+				return true, nil, apierrors.NewConflict(
+					schema.GroupResource{Group: "", Resource: "configmaps"},
+					"orphan-cm",
+					errors.New("the UID in the precondition does not match the UID in record"),
+				)
+			}
+			return false, nil, nil
+		})
+
+		applier := New(Config{
+			Client:          client,
+			RESTMapper:      mapper,
+			Log:             logr.Discard(),
+			ParentNamespace: "default",
+		}, parent)
+
+		resources := []Resource{
+			{ID: "cm1", Object: newConfigMap("cm1", "default")},
+		}
+		result, _, err := applier.Apply(ctx, resources, ApplyMode{})
+		if err != nil {
+			t.Fatalf("Apply() error = %v", err)
+		}
+
+		projectMeta, err := applier.Project(resources)
+		if err != nil {
+			t.Fatalf("Project() error = %v", err)
+		}
+		pruneResult, err := applier.Prune(ctx, PruneOptions{
+			KeepUIDs: result.ObservedUIDs(),
+			Scope:    projectMeta.PruneScope(),
+		})
+		if err != nil {
+			t.Fatalf("Prune() error = %v, want nil (409 Conflict should be ignored)", err)
+		}
+		if len(pruneResult.Pruned) != 0 {
+			t.Errorf("Prune() pruned %d resources, want 0 (UID mismatch should skip)", len(pruneResult.Pruned))
+		}
+		if pruneResult.Conflicts != 1 {
+			t.Errorf("Prune() conflicts = %d, want 1", pruneResult.Conflicts)
+		}
+
+		// Verify the resource still exists in the fake client
+		cmGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+		gotObj, getErr := client.Resource(cmGVR).Namespace("default").Get(ctx, "orphan-cm", metav1.GetOptions{})
+		if getErr != nil {
+			t.Errorf("Resource orphan-cm should still exist after UID mismatch, but Get() returned: %v", getErr)
+		}
+		if gotObj.GetUID() != recreatedUID {
+			t.Errorf("Resource orphan-cm UID = %q, want %q", gotObj.GetUID(), recreatedUID)
+		}
+	})
 }
 
 func TestErrors_ShouldPreventPrune(t *testing.T) {

--- a/pkg/controller/instance/applyset/result.go
+++ b/pkg/controller/instance/applyset/result.go
@@ -30,12 +30,20 @@ type ApplyResult struct {
 // PruneResult contains outcomes for prune operations.
 // All items in Pruned are successful deletes (errors return from Prune directly).
 type PruneResult struct {
-	Pruned []PruneResultItem
+	Pruned    []PruneResultItem
+	Conflicts int
 }
 
 // HasPruned returns true if any resources were pruned.
 func (r *PruneResult) HasPruned() bool {
 	return len(r.Pruned) > 0
+}
+
+// HasConflicts returns true if prune encountered UID precondition conflicts.
+// These are safe skips (resource was recreated), but callers may choose to
+// requeue and retry prune while keeping superset prune scope.
+func (r *PruneResult) HasConflicts() bool {
+	return r.Conflicts > 0
 }
 
 // ApplyResultItem is the outcome of applying a single resource.

--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -73,6 +73,7 @@ func (c *Controller) reconcileNodes(rcx *ReconcileContext) error {
 	// ---------------------------------------------------------
 	// 4. Prune orphans (when desired is fully resolved)
 	// ---------------------------------------------------------
+	pruneNeedsRetry := false
 	//
 	// Prune is intentionally gated by two independent conditions:
 	//   1) prune == true  -> all desired objects were resolvable (no ErrDataPending)
@@ -83,11 +84,12 @@ func (c *Controller) reconcileNodes(rcx *ReconcileContext) error {
 	// omitted from the apply set. Keeping both checks visible prevents  regressions
 	// where one gate gets removed and prune becomes unsafe.
 	if prune && result.Errors() == nil {
-		pruned, err := c.pruneOrphans(rcx, applier, result, supersetPatch, batchMeta)
+		pruned, needsRetry, err := c.pruneOrphans(rcx, applier, result, supersetPatch, batchMeta)
 		if err != nil {
 			return err
 		}
 		clusterMutated = clusterMutated || pruned
+		pruneNeedsRetry = pruneNeedsRetry || needsRetry
 	}
 
 	// ---------------------------------------------------------
@@ -104,6 +106,9 @@ func (c *Controller) reconcileNodes(rcx *ReconcileContext) error {
 
 	if lastUnresolved != "" {
 		return rcx.delayedRequeue(fmt.Errorf("waiting for unresolved resource %q", lastUnresolved))
+	}
+	if pruneNeedsRetry {
+		return rcx.delayedRequeue(fmt.Errorf("prune encountered UID conflicts; retrying"))
 	}
 	if clusterMutated {
 		return rcx.delayedRequeue(fmt.Errorf("cluster mutated"))
@@ -140,28 +145,37 @@ func (c *Controller) processNodes(
 }
 
 // pruneOrphans deletes previously managed resources that are not in the current
-// apply set and then shrinks parent applyset metadata.
+// apply set. It shrinks parent applyset metadata only when prune completes
+// without UID conflicts.
 func (c *Controller) pruneOrphans(
 	rcx *ReconcileContext,
 	applier *applyset.ApplySet,
 	result *applyset.ApplyResult,
 	supersetPatch applyset.Metadata,
 	batchMeta applyset.Metadata,
-) (bool, error) {
+) (bool, bool, error) {
 	pruneScope := supersetPatch.PruneScope()
 	pruneResult, err := applier.Prune(rcx.Ctx, applyset.PruneOptions{
 		KeepUIDs: result.ObservedUIDs(),
 		Scope:    pruneScope,
 	})
 	if err != nil {
-		return false, rcx.delayedRequeue(fmt.Errorf("prune failed: %w", err))
+		return false, false, rcx.delayedRequeue(fmt.Errorf("prune failed: %w", err))
+	}
+
+	// Keep superset metadata and retry prune on UID conflicts.
+	if pruneResult.HasConflicts() {
+		rcx.Log.V(1).Info("prune skipped resources due to UID conflicts; keeping superset applyset metadata for retry",
+			"conflicts", pruneResult.Conflicts,
+		)
+		return pruneResult.HasPruned(), true, nil
 	}
 
 	// Prune succeeded (errors return directly), safe to shrink metadata
 	if err := c.patchInstanceWithApplySetMetadata(rcx, batchMeta); err != nil {
 		rcx.Log.V(1).Info("failed to shrink instance annotations", "error", err)
 	}
-	return pruneResult.HasPruned(), nil
+	return pruneResult.HasPruned(), false, nil
 }
 
 // createApplySet constructs an applyset configured for the current instance.


### PR DESCRIPTION
Prune now tracks UID precondition conflicts (409) separately from successful deletes.
Conflicts remain non-fatal, but are surfaced to reconcile so we can retry prune without
extra API GET calls.

When conflicts occur, keep superset applyset annotations (do not shrink to batch metadata)
and requeue. This preserves prune scope across retries and allows eventual cleanup once
the race settles. On conflict free prune, metadata still shrinks as before.

Also updates applyset unit tests to assert conflict counting behavior.
