### PR TITLE
build: group Dependabot npm and Go security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+    schedule:
+      interval: "weekly"
+    # Keep Go PR noise limited to grouped security fixes unless version updates
+    # are explicitly enabled later.
+    open-pull-requests-limit: 0
+    groups:
+      go-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    directories:
+      - "/tools/lsp/client"
+      - "/website"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      npm-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+


### PR DESCRIPTION
Add a repository-level Dependabot config for the npm and Go modules in
this repo.

Group security updates into batched PRs for website, tools/lsp/client,
the root module, cmd/kro, and tools/lsp/server to reduce Dependabot
noise.