### PR TITLE
Fix ResourceGraphDefinition delete predicate handling

### DIFF
--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -104,8 +104,7 @@ func (r *ResourceGraphDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) e
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("ResourceGraphDefinition").
-		For(&v1alpha1.ResourceGraphDefinition{}).
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		For(&v1alpha1.ResourceGraphDefinition{}, builder.WithPredicates(resourceGraphDefinitionPrimaryWatchPredicate())).
 		WithOptions(
 			ctrlrtcontroller.Options{
 				LogConstructor:          logConstructor,
@@ -128,6 +127,40 @@ func (r *ResourceGraphDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) e
 			}),
 		).
 		Complete(reconcile.AsReconciler[*v1alpha1.ResourceGraphDefinition](mgr.GetClient(), r))
+}
+
+// resourceGraphDefinitionPrimaryWatchPredicate returns a predicate that decides
+// which ResourceGraphDefinition events trigger a reconcile.
+//
+// The default GenerationChangedPredicate is insufficient here because Kubernetes
+// does NOT bump .metadata.generation when .metadata.deletionTimestamp is set.
+// That means a plain generation check silently drops the update that kicks off
+// finalizer-driven cleanup, and the controller never runs its delete path until
+// the final delete event — by which point the object is already gone from the API
+// server.
+//
+// This predicate reconciles when:
+//   - spec changes  (generation changed), or
+//   - deletion begins (deletionTimestamp transitions from zero to non-zero).
+//
+// It skips:
+//   - status-only updates (generation and deletion state unchanged),
+//   - delete events (object is already removed; nothing left to reconcile).
+func resourceGraphDefinitionPrimaryWatchPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+
+			oldDeleting := !e.ObjectOld.GetDeletionTimestamp().IsZero()
+			newDeleting := !e.ObjectNew.GetDeletionTimestamp().IsZero()
+			return e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration() || oldDeleting != newDeleting
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return false
+		},
+	}
 }
 
 // findRGDsForCRD returns a list of reconcile requests for the ResourceGraphDefinition

--- a/pkg/controller/resourcegraphdefinition/controller_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_test.go
@@ -40,7 +40,9 @@ import (
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
@@ -811,5 +813,88 @@ func TestReconcile(t *testing.T) {
 			result, err := reconciler.Reconcile(context.Background(), rgd)
 			tt.check(t, result, err, c, rgd, manager)
 		})
+	}
+}
+
+func TestResourceGraphDefinitionPrimaryWatchPredicate(t *testing.T) {
+	t.Parallel()
+
+	pred := resourceGraphDefinitionPrimaryWatchPredicate()
+	deletionTime := metav1.NewTime(time.Unix(123, 0))
+	testCases := []struct {
+		name string
+		run  func(predicate.Predicate) bool
+		want bool
+	}{
+		{
+			name: "accepts generation changes",
+			run: func(pred predicate.Predicate) bool {
+				return pred.Update(event.UpdateEvent{
+					ObjectOld: newPredicateTestRGD(1, nil),
+					ObjectNew: newPredicateTestRGD(2, nil),
+				})
+			},
+			want: true,
+		},
+		{
+			name: "accepts deletion timestamp transitions",
+			run: func(pred predicate.Predicate) bool {
+				return pred.Update(event.UpdateEvent{
+					ObjectOld: newPredicateTestRGD(1, nil),
+					ObjectNew: newPredicateTestRGD(1, &deletionTime),
+				})
+			},
+			want: true,
+		},
+		{
+			name: "ignores status only updates",
+			run: func(pred predicate.Predicate) bool {
+				return pred.Update(event.UpdateEvent{
+					ObjectOld: newPredicateTestRGD(1, nil),
+					ObjectNew: newPredicateTestRGD(1, nil),
+				})
+			},
+			want: false,
+		},
+		{
+			name: "ignores updates after deletion already started",
+			run: func(pred predicate.Predicate) bool {
+				return pred.Update(event.UpdateEvent{
+					ObjectOld: newPredicateTestRGD(1, &deletionTime),
+					ObjectNew: newPredicateTestRGD(1, &deletionTime),
+				})
+			},
+			want: false,
+		},
+		{
+			name: "keeps create events enabled",
+			run: func(pred predicate.Predicate) bool {
+				return pred.Create(event.CreateEvent{Object: newPredicateTestRGD(1, nil)})
+			},
+			want: true,
+		},
+		{
+			name: "ignores delete events",
+			run: func(pred predicate.Predicate) bool {
+				return pred.Delete(event.DeleteEvent{Object: newPredicateTestRGD(1, nil)})
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		if got := tc.run(pred); got != tc.want {
+			t.Errorf("%s: got %t, want %t", tc.name, got, tc.want)
+		}
+	}
+}
+
+func newPredicateTestRGD(generation int64, deletionTimestamp *metav1.Time) *v1alpha1.ResourceGraphDefinition {
+	return &v1alpha1.ResourceGraphDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-rgd",
+			Generation:        generation,
+			DeletionTimestamp: deletionTimestamp,
+		},
 	}
 }


### PR DESCRIPTION
Allow the primary ResourceGraphDefinition watch to reconcile when the
deletion timestamp changes, not just when generation changes. This fixes
finalizer-driven cleanup paths that were skipped on delete.

Also add table-driven predicate tests covering generation changes,
deletion timestamp transitions, and ignored status-only updates.

Closes https://github.com/kubernetes-sigs/kro/pull/1037