### PR TITLE
feat(compat): detect default value changes as non-breaking in schema comparison

### DIFF
--- a/pkg/graph/crd/compat/changes.go
+++ b/pkg/graph/crd/compat/changes.go
@@ -23,12 +23,13 @@ type ChangeType string
 
 const (
 	// Breaking change types
-	PropertyRemoved ChangeType = "PROPERTY_REMOVED"
-	TypeChanged     ChangeType = "TYPE_CHANGED"
-	RequiredAdded   ChangeType = "REQUIRED_ADDED"
-	EnumRestricted  ChangeType = "ENUM_RESTRICTED"
-	PatternChanged  ChangeType = "PATTERN_CHANGED"
-	PatternAdded    ChangeType = "PATTERN_ADDED"
+	PropertyRemoved        ChangeType = "PROPERTY_REMOVED"
+	TypeChanged            ChangeType = "TYPE_CHANGED"
+	RequiredAdded          ChangeType = "REQUIRED_ADDED"
+	EnumRestricted         ChangeType = "ENUM_RESTRICTED"
+	PatternChanged         ChangeType = "PATTERN_CHANGED"
+	PatternAdded           ChangeType = "PATTERN_ADDED"
+	RequiredDefaultRemoved ChangeType = "REQUIRED_DEFAULT_REMOVED"
 
 	// Non-breaking change types
 	PropertyAdded      ChangeType = "PROPERTY_ADDED"
@@ -156,10 +157,12 @@ func (c Change) Description() string {
 		return fmt.Sprintf("Validation pattern %s was added", c.NewValue)
 	case PatternRemoved:
 		return fmt.Sprintf("Validation pattern %s was removed", c.OldValue)
+	case RequiredDefaultRemoved:
+		return fmt.Sprintf("Default value removed from required field %s", c.OldValue)
 	case DescriptionChanged:
-		return "Description field was changed"
+		return fmt.Sprintf("Description field was changed from %s to %s", c.OldValue, c.NewValue)
 	case DefaultChanged:
-		return "Default value was changed"
+		return fmt.Sprintf("Default value was changed from %s to %s", c.OldValue, c.NewValue)
 	default:
 		return fmt.Sprintf("Unknown change to %s", c.Path)
 	}

--- a/pkg/graph/crd/compat/schema.go
+++ b/pkg/graph/crd/compat/schema.go
@@ -14,6 +14,8 @@
 package compat
 
 import (
+	"bytes"
+
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
@@ -50,8 +52,18 @@ func compare(path string, oldSchema, newSchema *v1.JSONSchemaProps) *Report {
 		result.AddNonBreakingChange(
 			path+".description",
 			DescriptionChanged,
-			"",
-			"",
+			oldSchema.Description,
+			newSchema.Description,
+		)
+	}
+
+	// default value changes are non-breaking
+	if !defaultsEqual(oldSchema.Default, newSchema.Default) {
+		result.AddNonBreakingChange(
+			path+".default",
+			DefaultChanged,
+			getDefaultValue(oldSchema.Default),
+			getDefaultValue(newSchema.Default),
 		)
 	}
 
@@ -95,6 +107,13 @@ func compare(path string, oldSchema, newSchema *v1.JSONSchemaProps) *Report {
 	compareArrayItems(path, oldSchema, newSchema, result)
 
 	return result
+}
+
+func getDefaultValue(val *v1.JSON) string {
+	if val == nil {
+		return ""
+	}
+	return string(val.Raw)
 }
 
 // compareProperties checks for added, removed, or changed properties
@@ -179,6 +198,23 @@ func compareRequiredFields(path string, oldSchema, newSchema *v1.JSONSchemaProps
 			result.AddNonBreakingChange(path+".required", RequiredRemoved, req, "")
 		}
 	}
+
+	// Check for required fields with default value removed.
+	// If a field is required in both old and new schemas but its default value
+	// was removed, new instances can no longer omit the field and rely on the
+	// default being populated automatically.
+	for req := range newRequiredSet {
+		if !existingProps[req] || !oldRequiredSet[req] {
+			continue
+		}
+		oldProp := oldSchema.Properties[req]
+		newProp := newSchema.Properties[req]
+		oldHasDefault := oldProp.Default != nil && len(oldProp.Default.Raw) > 0
+		newHasDefault := newProp.Default != nil && len(newProp.Default.Raw) > 0
+		if oldHasDefault && !newHasDefault {
+			result.AddBreakingChange(path+".required", RequiredDefaultRemoved, req, "")
+		}
+	}
 }
 
 // compareEnumValues checks for changes to enum values
@@ -225,6 +261,19 @@ func compareArrayItems(path string, oldSchema, newSchema *v1.JSONSchemaProps, re
 			result.AddNonBreakingChange(path+".items", PropertyAdded, "", "")
 		}
 	}
+}
+
+// defaultsEqual compares two JSON default values for equality.
+// Two defaults are equal if they are both nil, or both non-nil with
+// identical Raw byte content.
+func defaultsEqual(a, b *v1.JSON) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return bytes.Equal(a.Raw, b.Raw)
 }
 
 // toStringSet converts a string slice to a map for O(1) lookups

--- a/pkg/graph/crd/compat/schema_test.go
+++ b/pkg/graph/crd/compat/schema_test.go
@@ -168,6 +168,73 @@ func TestCompareSchemas(t *testing.T) {
 			oldSchema: nil,
 			newSchema: nil,
 		},
+		{
+			name: "default value added - non-breaking",
+			oldSchema: &v1.JSONSchemaProps{
+				Type: "string",
+			},
+			newSchema: &v1.JSONSchemaProps{
+				Type:    "string",
+				Default: &v1.JSON{Raw: []byte(`"hello"`)},
+			},
+			nonBreakingCount: 1,
+		},
+		{
+			name: "default value removed - non-breaking",
+			oldSchema: &v1.JSONSchemaProps{
+				Type:    "string",
+				Default: &v1.JSON{Raw: []byte(`"hello"`)},
+			},
+			newSchema: &v1.JSONSchemaProps{
+				Type: "string",
+			},
+			nonBreakingCount: 1,
+		},
+		{
+			name: "default value changed - non-breaking",
+			oldSchema: &v1.JSONSchemaProps{
+				Type:    "integer",
+				Default: &v1.JSON{Raw: []byte("42")},
+			},
+			newSchema: &v1.JSONSchemaProps{
+				Type:    "integer",
+				Default: &v1.JSON{Raw: []byte("100")},
+			},
+			nonBreakingCount: 1,
+		},
+		{
+			name: "same default value - no changes",
+			oldSchema: &v1.JSONSchemaProps{
+				Type:    "string",
+				Default: &v1.JSON{Raw: []byte(`"hello"`)},
+			},
+			newSchema: &v1.JSONSchemaProps{
+				Type:    "string",
+				Default: &v1.JSON{Raw: []byte(`"hello"`)},
+			},
+		},
+		{
+			name: "default value changed in nested property - non-breaking",
+			oldSchema: &v1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]v1.JSONSchemaProps{
+					"timeout": {
+						Type:    "string",
+						Default: &v1.JSON{Raw: []byte(`"1m30s"`)},
+					},
+				},
+			},
+			newSchema: &v1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]v1.JSONSchemaProps{
+					"timeout": {
+						Type:    "string",
+						Default: &v1.JSON{Raw: []byte(`"2m"`)},
+					},
+				},
+			},
+			nonBreakingCount: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -399,6 +466,39 @@ func TestCompareRequiredFields(t *testing.T) {
 			},
 			oldRequired:      []string{"prop1"},
 			nonBreakingCount: 1,
+		},
+		{
+			name: "required field default removed - breaking",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {
+					Type:    "string",
+					Default: &v1.JSON{Raw: []byte(`"hello"`)},
+				},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+			oldRequired:       []string{"prop1"},
+			newRequired:       []string{"prop1"},
+			breakingCount:     1,
+			checkBreakingType: RequiredDefaultRemoved,
+		},
+		{
+			name: "required field default kept - no breaking change",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {
+					Type:    "string",
+					Default: &v1.JSON{Raw: []byte(`"hello"`)},
+				},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {
+					Type:    "string",
+					Default: &v1.JSON{Raw: []byte(`"world"`)},
+				},
+			},
+			oldRequired: []string{"prop1"},
+			newRequired: []string{"prop1"},
 		},
 		{
 			name: "ignore newly added property in required check",

--- a/test/integration/suites/core/crd_test.go
+++ b/test/integration/suites/core/crd_test.go
@@ -398,6 +398,40 @@ var _ = Describe("CRD", func() {
 				g.Expect(props["spec"].Properties["field2"].Type).To(Equal("integer"))
 			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
+			// Update RGD with non-breaking change: change the default value
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Add field2 - this is a non-breaking change
+				rgd.Spec.Schema.Spec = toRawExtension(map[string]interface{}{
+					"field1": "string",
+					"field2": "integer | default=52",
+				})
+
+				err = env.Client.Update(ctx, rgd)
+				g.Expect(err).ToNot(HaveOccurred())
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Verify RGD stays active and CRD is updated
+			crd = &apiextensionsv1.CustomResourceDefinition{}
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+
+				err = env.Client.Get(ctx, types.NamespacedName{
+					Name: "nonbreakingtests.kro.run",
+				}, crd)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Verify new field exists in CRD
+				props := crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties
+				g.Expect(props["spec"].Properties).To(HaveKey("field2"))
+				g.Expect(props["spec"].Properties["field2"].Type).To(Equal("integer"))
+				g.Expect(props["spec"].Properties["field2"].Default.Raw).To(Equal([]byte("52")))
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
 			// Cleanup
 			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
 		})


### PR DESCRIPTION
Issue [#1088](https://github.com/kubernetes-sigs/kro/issues/1088)

The CRD schema compatibility checker did not account for changes to
default values, causing them to be silently ignored during RGD updates.
Add default value comparison logic that classifies additions, removals,
and modifications of defaults as non-breaking changes.