### PR TITLE
test(instance): harden instance reconciler coverage

### DIFF
--- a/pkg/controller/instance/context_test.go
+++ b/pkg/controller/instance/context_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubernetes-sigs/kro/pkg/requeue"
+)
+
+func TestContextHelpersAndStateTransitions(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph())
+
+	require.NotNil(t, controller)
+	require.NotNil(t, rcx.Mark)
+	require.NotNil(t, rcx.StateManager)
+
+	delayed := rcx.delayedRequeue(errors.New("retry"))
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, delayed, &retryAfter)
+	assert.Equal(t, 2*time.Second, retryAfter.Duration())
+
+	clusterScoped := newClusterScopedInstanceObject("cluster-demo")
+	_, clusterRCX, raw := newControllerAndContext(t, clusterScoped, newTestGraph())
+	_, err := clusterRCX.InstanceClient().Get(context.Background(), clusterScoped.GetName(), metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotNil(t, raw)
+
+	state := &NodeState{}
+	state.SetInProgress()
+	assert.Equal(t, NodeStateInProgress, state.State)
+	state.SetReady()
+	assert.Equal(t, NodeStateSynced, state.State)
+	state.SetSkipped()
+	assert.Equal(t, NodeStateSkipped, state.State)
+	state.SetDeleted()
+	assert.Equal(t, NodeStateDeleted, state.State)
+	state.SetDeleting()
+	assert.Equal(t, NodeStateDeleting, state.State)
+	state.SetWaitingForReadiness(errors.New("waiting"))
+	assert.Equal(t, NodeStateWaitingForReadiness, state.State)
+	state.SetError(errors.New("boom"))
+	assert.Equal(t, NodeStateError, state.State)
+
+	manager := newStateManager()
+	manager.NewNodeState("a").SetReady()
+	manager.NewNodeState("b").SetSkipped()
+	manager.Update()
+	assert.Equal(t, InstanceStateActive, manager.State)
+
+	manager.ReconcileErr = errors.New("boom")
+	manager.Update()
+	assert.Equal(t, InstanceStateError, manager.State)
+
+	manager.ReconcileErr = requeue.NeededAfter(errors.New("later"), time.Second)
+	manager.State = InstanceStateInProgress
+	rcx.StateManager = manager
+	rcx.updateInstanceState()
+	assert.Equal(t, InstanceStateInProgress, rcx.StateManager.State)
+
+	manager = newStateManager()
+	manager.NewNodeState("waiting").SetWaitingForReadiness(nil)
+	manager.Update()
+	assert.Equal(t, InstanceStateInProgress, manager.State)
+
+	manager.State = InstanceStateDeleting
+	manager.Update()
+	assert.Equal(t, InstanceStateDeleting, manager.State)
+}

--- a/pkg/controller/instance/controller_test.go
+++ b/pkg/controller/instance/controller_test.go
@@ -1,0 +1,249 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8stesting "k8s.io/client-go/testing"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/kubernetes-sigs/kro/pkg/graph"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
+	"github.com/kubernetes-sigs/kro/pkg/requeue"
+)
+
+func TestApplyManagedFinalizerAndLabels(t *testing.T) {
+	tests := []struct {
+		name            string
+		presetFinalizer bool
+		presetLabels    bool
+		wantActions     int
+		wantSameObject  bool
+	}{
+		{
+			name:            "no patch needed",
+			presetFinalizer: true,
+			presetLabels:    true,
+			wantSameObject:  true,
+		},
+		{
+			name:        "patches missing finalizer and labels",
+			wantActions: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			if tt.presetFinalizer {
+				metadata.SetInstanceFinalizer(instance)
+			}
+			if tt.presetLabels {
+				metadata.NewKROMetaLabeler().ApplyLabels(instance)
+			}
+
+			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
+			patched, err := controller.applyManagedFinalizerAndLabels(rcx)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantActions, len(raw.Actions()))
+			assert.Equal(t, tt.wantSameObject, patched == rcx.Instance)
+			assert.True(t, metadata.HasInstanceFinalizer(patched))
+			for key, value := range metadata.NewKROMetaLabeler().Labels() {
+				assert.Equal(t, value, patched.GetLabels()[key])
+			}
+		})
+	}
+}
+
+func TestApplyManagedFinalizerAndLabelsError(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
+	raw.PrependReactor("patch", "webapps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		return true, nil, errors.New("patch failed")
+	})
+
+	_, err := controller.applyManagedFinalizerAndLabels(rcx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed applying managed finalizer/labels")
+}
+
+func TestEnsureManagedRefreshesInstanceState(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph())
+
+	require.NoError(t, controller.ensureManaged(rcx))
+	assert.True(t, metadata.HasInstanceFinalizer(rcx.Instance))
+	assert.Equal(t, metav1.ConditionTrue, conditionByType(t, rcx.Instance, InstanceManaged).Status)
+}
+
+func TestReconcileInstanceLoad(t *testing.T) {
+	tests := []struct {
+		name    string
+		objects []apimachineryruntime.Object
+		getErr  string
+		request types.NamespacedName
+		wantErr string
+	}{
+		{
+			name:    "instance not found",
+			request: types.NamespacedName{Name: "missing", Namespace: "default"},
+		},
+		{
+			name:    "load errors are returned",
+			objects: []apimachineryruntime.Object{newInstanceObject("demo", "default")},
+			getErr:  "get failed",
+			request: types.NamespacedName{Name: "demo", Namespace: "default"},
+			wantErr: "get failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := newControllerTestDynamicClient(t, tt.objects...)
+			if tt.getErr != "" {
+				raw.PrependReactor("get", "webapps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+					return true, nil, errors.New(tt.getErr)
+				})
+			}
+
+			controller, _ := newControllerUnderTest(t, raw, newTestGraph())
+			err := controller.Reconcile(context.Background(), ctrl.Request{NamespacedName: tt.request})
+
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestReconcileStatusPaths(t *testing.T) {
+	tests := []struct {
+		name                string
+		instanceLabels      map[string]string
+		wantState           string
+		wantConditionType   string
+		wantConditionStatus metav1.ConditionStatus
+	}{
+		{
+			name:                "empty graph converges to active",
+			wantState:           string(InstanceStateActive),
+			wantConditionType:   Ready,
+			wantConditionStatus: metav1.ConditionTrue,
+		},
+		{
+			name:                "suspended reconciliation sets condition",
+			instanceLabels:      map[string]string{metadata.InstanceReconcileLabel: "disabled"},
+			wantState:           string(InstanceStateActive),
+			wantConditionType:   ReconciliationSuspended,
+			wantConditionStatus: metav1.ConditionTrue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			instance.SetLabels(tt.instanceLabels)
+
+			raw := newControllerTestDynamicClient(t, instance.DeepCopy())
+			controller, _ := newControllerUnderTest(t, raw, newTestGraph())
+			err := controller.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()},
+			})
+			require.NoError(t, err)
+
+			stored := getStoredParentObject(t, raw)
+			state, found, err := unstructured.NestedString(stored.Object, "status", "state")
+			require.NoError(t, err)
+			require.True(t, found)
+			assert.Equal(t, tt.wantState, state)
+			assert.Equal(t, tt.wantConditionStatus, conditionByType(t, stored, tt.wantConditionType).Status)
+		})
+	}
+}
+
+func TestReconcileDeletionRemovesFinalizer(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	metadata.SetInstanceFinalizer(instance)
+	now := metav1.NewTime(time.Now())
+	instance.SetDeletionTimestamp(&now)
+
+	raw := newControllerTestDynamicClient(t, instance.DeepCopy())
+	controller, _ := newControllerUnderTest(t, raw, newTestGraph())
+
+	err := controller.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()},
+	})
+	require.NoError(t, err)
+
+	stored := getStoredParentObject(t, raw)
+	assert.False(t, metadata.HasInstanceFinalizer(stored))
+	assert.Equal(t, metav1.ConditionUnknown, conditionByType(t, stored, ResourcesReady).Status)
+}
+
+func TestReconcileResourceMutationRequestsRequeue(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	resourceNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	raw := newControllerTestDynamicClient(t, instance.DeepCopy())
+	controller, _ := newControllerUnderTest(t, raw, newTestGraph(resourceNode))
+
+	err := controller.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()},
+	})
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, err, &retryAfter)
+
+	stored := getStoredParentObject(t, raw)
+	assert.Equal(t, metav1.ConditionFalse, conditionByType(t, stored, ResourcesReady).Status)
+}
+
+func TestReconcileManagedStateFailureMarksStatus(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	raw := newControllerTestDynamicClient(t, instance.DeepCopy())
+	raw.PrependReactor("patch", "webapps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		return true, nil, errors.New("patch failed")
+	})
+
+	controller, _ := newControllerUnderTest(t, raw, newTestGraph())
+	err := controller.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()},
+	})
+	require.Error(t, err)
+
+	stored := getStoredParentObject(t, raw)
+	assert.Equal(t, metav1.ConditionFalse, conditionByType(t, stored, InstanceManaged).Status)
+}

--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -1,0 +1,368 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+
+	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
+	"github.com/kubernetes-sigs/kro/pkg/graph"
+	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
+	"github.com/kubernetes-sigs/kro/pkg/requeue"
+)
+
+func TestPlanNodesForDeletionSkipsUnresolvedIdentityAndPicksLastExistingNode(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+
+	pendingNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "pending",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": controllerTestDeployGVK.GroupVersion().String(),
+				"kind":       controllerTestDeployGVK.Kind,
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}",
+				},
+			},
+		},
+		Variables: []*variable.ResourceField{
+			standaloneField("metadata.name", mustCompileControllerExpr(t, "schema.spec.name", "schema"), variable.ResourceVariableKindStatic),
+		},
+	}
+	existingNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(pendingNode, existingNode), newDeploymentObject("demo", "default"))
+	node, err := controller.planNodesForDeletion(rcx)
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	assert.Equal(t, "deploy", node.Spec.Meta.ID)
+	assert.Equal(t, NodeStateDeleted, rcx.StateManager.NodeStates["pending"].State)
+	assert.Equal(t, NodeStateInProgress, rcx.StateManager.NodeStates["deploy"].State)
+}
+
+func TestPlanNodesForDeletionSkipsIgnoredExternalAndMissingNodes(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
+	_ = unstructured.SetNestedField(instance.Object, false, "spec", "enabled")
+
+	ignoredNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "ignored",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("ignored", ""),
+		IncludeWhen: []*krocel.Expression{
+			mustCompileControllerExpr(t, "schema.spec.enabled", "schema"),
+		},
+	}
+	externalNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "external",
+			Type:       graph.NodeTypeExternal,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: newConfigMapObject("external", ""),
+	}
+	collectionNode := newDeletionCollectionNode(t, "configs")
+	missingNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "missing",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("missing", ""),
+	}
+
+	currentCollection := newConfigMapObject("one", "default")
+	currentCollection.SetLabels(map[string]string{
+		metadata.InstanceIDLabel: string(instance.GetUID()),
+		metadata.NodeIDLabel:     "configs",
+	})
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(ignoredNode, externalNode, collectionNode, missingNode), currentCollection)
+	node, err := controller.planNodesForDeletion(rcx)
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	assert.Equal(t, "configs", node.Spec.Meta.ID)
+	assert.Equal(t, NodeStateSkipped, rcx.StateManager.NodeStates["ignored"].State)
+	assert.Equal(t, NodeStateSkipped, rcx.StateManager.NodeStates["external"].State)
+	assert.Equal(t, NodeStateDeleted, rcx.StateManager.NodeStates["missing"].State)
+}
+
+func TestPlanNodesForDeletionErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		node      *graph.Node
+		configure func(*unstructured.Unstructured)
+		verb      string
+		resource  string
+		wantErr   string
+	}{
+		{
+			name: "list errors bubble up for collection nodes",
+			node: newDeletionCollectionNode(t, "configs"),
+			configure: func(instance *unstructured.Unstructured) {
+				_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
+			},
+			verb:     "list",
+			resource: "configmaps",
+			wantErr:  "list failed",
+		},
+		{
+			name: "get errors bubble up for resource nodes",
+			node: &graph.Node{
+				Meta: graph.NodeMeta{
+					ID:         "deploy",
+					Type:       graph.NodeTypeResource,
+					GVR:        controllerTestDeployGVR,
+					Namespaced: true,
+				},
+				Template: newDeploymentObject("demo", ""),
+			},
+			verb:     "get",
+			resource: "deployments",
+			wantErr:  "get failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			if tt.configure != nil {
+				tt.configure(instance)
+			}
+
+			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(tt.node))
+			raw.PrependReactor(tt.verb, tt.resource, func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+				return true, nil, errors.New(tt.wantErr)
+			})
+
+			_, err := controller.planNodesForDeletion(rcx)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestDeleteTarget(t *testing.T) {
+	tests := []struct {
+		name        string
+		observed    []*unstructured.Unstructured
+		deleteErr   string
+		wantState   string
+		wantErrText string
+	}{
+		{
+			name:      "marks deleted when there are no targets",
+			wantState: NodeStateDeleted,
+		},
+		{
+			name:      "marks deleted when the target no longer exists",
+			observed:  []*unstructured.Unstructured{newDeploymentObject("gone", "default")},
+			wantState: NodeStateDeleted,
+		},
+		{
+			name:      "marks deleting when the API accepted deletion",
+			observed:  []*unstructured.Unstructured{newDeploymentObject("demo", "default")},
+			wantState: NodeStateDeleting,
+		},
+		{
+			name:        "marks error when deletion fails",
+			observed:    []*unstructured.Unstructured{newDeploymentObject("demo", "default")},
+			deleteErr:   "delete failed",
+			wantState:   NodeStateError,
+			wantErrText: "delete failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			resourceNode := &graph.Node{
+				Meta: graph.NodeMeta{
+					ID:         "deploy",
+					Type:       graph.NodeTypeResource,
+					GVR:        controllerTestDeployGVR,
+					Namespaced: true,
+				},
+				Template: newDeploymentObject("demo", ""),
+			}
+
+			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(resourceNode), newDeploymentObject("demo", "default"))
+			node := rcx.Runtime.Nodes()[0]
+			node.SetObserved(tt.observed)
+
+			if tt.deleteErr != "" {
+				raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+					return true, nil, errors.New(tt.deleteErr)
+				})
+			}
+
+			state := rcx.StateManager.NewNodeState(tt.name)
+			err := controller.deleteTarget(rcx, node, state)
+			if tt.wantErrText != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrText)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantState, state.State)
+		})
+	}
+}
+
+func TestReconcileDeletionRequeuesWhileChildDeletionInFlight(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	node := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(node), newDeploymentObject("demo", "default"))
+	err := controller.reconcileDeletion(rcx)
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, err, &retryAfter)
+	assert.Equal(t, InstanceStateDeleting, rcx.StateManager.State)
+}
+
+func TestSetUnmanaged(t *testing.T) {
+	tests := []struct {
+		name          string
+		withFinalizer bool
+		patchErr      string
+		wantErrText   string
+		wantSame      bool
+		wantManaged   bool
+	}{
+		{
+			name:        "returns the original object when finalizer is absent",
+			wantSame:    true,
+			wantManaged: false,
+		},
+		{
+			name:          "removes the managed finalizer when present",
+			withFinalizer: true,
+			wantManaged:   false,
+		},
+		{
+			name:          "returns patch errors",
+			withFinalizer: true,
+			patchErr:      "patch failed",
+			wantErrText:   "failed to update unmanaged state",
+			wantManaged:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			if tt.withFinalizer {
+				metadata.SetInstanceFinalizer(instance)
+			}
+
+			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
+			if tt.patchErr != "" {
+				raw.PrependReactor("patch", "webapps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+					return true, nil, errors.New(tt.patchErr)
+				})
+			}
+
+			patched, err := controller.setUnmanaged(rcx, rcx.Instance)
+			if tt.wantErrText != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrText)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSame, patched == rcx.Instance)
+			assert.Equal(t, tt.wantManaged, metadata.HasInstanceFinalizer(patched))
+		})
+	}
+}
+
+func TestRemoveFinalizerMarksInstanceNotManagedOnError(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	metadata.SetInstanceFinalizer(instance)
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
+	raw.PrependReactor("patch", "webapps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		return true, nil, errors.New("patch failed")
+	})
+
+	err := controller.removeFinalizer(rcx)
+	require.Error(t, err)
+	assert.Equal(t, metav1.ConditionFalse, conditionByType(t, rcx.Instance, InstanceManaged).Status)
+}
+
+func newDeletionCollectionNode(t *testing.T, id string) *graph.Node {
+	t.Helper()
+
+	return &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         id,
+			Type:       graph.NodeTypeCollection,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": controllerTestCMGVK.GroupVersion().String(),
+				"kind":       controllerTestCMGVK.Kind,
+				"metadata": map[string]interface{}{
+					"name": "${item}",
+				},
+			},
+		},
+		Variables: []*variable.ResourceField{
+			standaloneField("metadata.name", mustCompileControllerExpr(t, "item", "item"), variable.ResourceVariableKindIteration),
+		},
+		ForEach: []graph.ForEachDimension{{
+			Name:       "item",
+			Expression: mustCompileControllerExpr(t, "schema.spec.items", "schema"),
+		}},
+	}
+}

--- a/pkg/controller/instance/instance_state_test.go
+++ b/pkg/controller/instance/instance_state_test.go
@@ -44,64 +44,58 @@ func TestNodeErrors(t *testing.T) {
 	err2 := errors.New("error 2")
 	singleErr := errors.New("node failed")
 
-	tests := map[string]struct {
-		nodeStates     map[string]*NodeState
-		expectError    bool
-		expectedErrors []error
+	tests := []struct {
+		name       string
+		nodeStates map[string]*NodeState
+		wantErrors []error
 	}{
-		"no errors": {
+		{
+			name: "no errors",
 			nodeStates: map[string]*NodeState{
 				"resource1": {State: "ACTIVE", Err: nil},
 				"resource2": {State: "ACTIVE", Err: nil},
 			},
-			expectError:    false,
-			expectedErrors: nil,
 		},
-		"single error": {
+		{
+			name: "single error",
 			nodeStates: map[string]*NodeState{
 				"resource1": {State: "FAILED", Err: singleErr},
 				"resource2": {State: "ACTIVE", Err: nil},
 			},
-			expectError:    true,
-			expectedErrors: []error{singleErr},
+			wantErrors: []error{singleErr},
 		},
-		"multiple errors": {
+		{
+			name: "multiple errors",
 			nodeStates: map[string]*NodeState{
 				"resource1": {State: "FAILED", Err: err1},
 				"resource2": {State: "FAILED", Err: err2},
 			},
-			expectError:    true,
-			expectedErrors: []error{err1, err2},
+			wantErrors: []error{err1, err2},
 		},
-		"empty node states": {
-			nodeStates:     map[string]*NodeState{},
-			expectError:    false,
-			expectedErrors: nil,
+		{
+			name:       "empty node states",
+			nodeStates: map[string]*NodeState{},
 		},
 	}
 
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			state := &StateManager{
-				NodeStates: tt.nodeStates,
-			}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &StateManager{NodeStates: tt.nodeStates}
+			err := state.NodeErrors()
 
-			err := state.NodeErrors() // no filter, include all errors
-
-			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-
-				// Check that all expected errors are contained in the result
-				for _, expectedErr := range tt.expectedErrors {
-					if !errors.Is(err, expectedErr) {
-						t.Errorf("expected error to contain %v, got %v", expectedErr, err)
-					}
-				}
-			} else {
+			if len(tt.wantErrors) == 0 {
 				if err != nil {
 					t.Errorf("expected no error, got %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			for _, wantErr := range tt.wantErrors {
+				if !errors.Is(err, wantErr) {
+					t.Errorf("expected error to contain %v, got %v", wantErr, err)
 				}
 			}
 		})

--- a/pkg/controller/instance/resources_test.go
+++ b/pkg/controller/instance/resources_test.go
@@ -1,0 +1,974 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	k8stesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
+	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
+	"github.com/kubernetes-sigs/kro/pkg/graph"
+	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
+	"github.com/kubernetes-sigs/kro/pkg/requeue"
+	krt "github.com/kubernetes-sigs/kro/pkg/runtime"
+)
+
+func TestProcessNodesReturnsDataPending(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	pendingNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": controllerTestDeployGVK.GroupVersion().String(),
+				"kind":       controllerTestDeployGVK.Kind,
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}",
+				},
+			},
+		},
+		Variables: []*variable.ResourceField{
+			standaloneField("metadata.name", mustCompileControllerExpr(t, "schema.spec.name", "schema"), variable.ResourceVariableKindStatic),
+		},
+	}
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(pendingNode))
+	resources, err := controller.processNodes(rcx)
+	require.Error(t, err)
+	assert.True(t, krt.IsDataPending(err))
+	assert.Empty(t, resources)
+}
+
+func TestReconcileNodesPaths(t *testing.T) {
+	tests := []struct {
+		name                  string
+		node                  *graph.Node
+		wantErr               string
+		wantRequeue           bool
+		wantState             InstanceState
+		wantToolingAnnotation bool
+	}{
+		{
+			name:                  "empty graph reconcile nodes returns cleanly",
+			wantState:             InstanceStateActive,
+			wantToolingAnnotation: true,
+		},
+		{
+			name: "child apply mutation asks for requeue",
+			node: &graph.Node{
+				Meta: graph.NodeMeta{
+					ID:         "deploy",
+					Type:       graph.NodeTypeResource,
+					GVR:        controllerTestDeployGVR,
+					Namespaced: true,
+				},
+				Template: newDeploymentObject("demo", ""),
+			},
+			wantRequeue: true,
+		},
+		{
+			name: "missing REST mapping requeues from project",
+			node: &graph.Node{
+				Meta: graph.NodeMeta{
+					ID:         "mystery",
+					Type:       graph.NodeTypeResource,
+					GVR:        schema.GroupVersionResource{Group: "unknown.example", Version: "v1", Resource: "mysteries"},
+					Namespaced: true,
+				},
+				Template: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "unknown.example/v1",
+						"kind":       "Mystery",
+						"metadata": map[string]interface{}{
+							"name": "mystery",
+						},
+					},
+				},
+			},
+			wantRequeue: true,
+			wantErr:     "project failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			graphToUse := newTestGraph()
+			if tt.node != nil {
+				graphToUse = newTestGraph(tt.node)
+			}
+
+			controller, rcx, raw := newControllerAndContext(t, instance, graphToUse)
+			err := controller.reconcileNodes(rcx)
+
+			if tt.wantRequeue {
+				var retryAfter *requeue.RequeueNeededAfter
+				require.ErrorAs(t, err, &retryAfter)
+				if tt.wantErr != "" {
+					assert.Contains(t, err.Error(), tt.wantErr)
+				}
+				assert.NotEqual(t, InstanceStateError, rcx.StateManager.State)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantState, rcx.StateManager.State)
+			stored := getStoredParentObject(t, raw)
+			_, ok := stored.GetAnnotations()[applyset.ApplySetToolingAnnotation]
+			assert.Equal(t, tt.wantToolingAnnotation, ok)
+		})
+	}
+}
+
+func TestProcessNodePaths(t *testing.T) {
+	disabled := false
+	tests := []struct {
+		name            string
+		specEnabled     *bool
+		node            *graph.Node
+		currentObjs     []apimachineryruntime.Object
+		reactorVerb     string
+		reactorResource string
+		reactorErr      string
+		wantResources   int
+		wantSkipApply   bool
+		wantState       string
+		wantErr         string
+	}{
+		{
+			name:        "ignored node becomes skip apply",
+			specEnabled: &disabled,
+			node: &graph.Node{
+				Meta: graph.NodeMeta{
+					ID:         "deploy",
+					Type:       graph.NodeTypeResource,
+					GVR:        controllerTestDeployGVR,
+					Namespaced: true,
+				},
+				Template: newDeploymentObject("demo", ""),
+				IncludeWhen: []*krocel.Expression{
+					mustCompileControllerExpr(t, "schema.spec.enabled", "schema"),
+				},
+			},
+			wantResources: 1,
+			wantSkipApply: true,
+			wantState:     NodeStateSkipped,
+		},
+		{
+			name: "resource get error marks node error",
+			node: &graph.Node{
+				Meta: graph.NodeMeta{
+					ID:         "deploy",
+					Type:       graph.NodeTypeResource,
+					GVR:        controllerTestDeployGVR,
+					Namespaced: true,
+				},
+				Template: newDeploymentObject("demo", ""),
+			},
+			reactorVerb:     "get",
+			reactorResource: "deployments",
+			reactorErr:      "get failed",
+			wantState:       NodeStateError,
+			wantErr:         "get failed",
+		},
+		{
+			name: "external ref waits for missing object",
+			node: &graph.Node{
+				Meta: graph.NodeMeta{
+					ID:         "external",
+					Type:       graph.NodeTypeExternal,
+					GVR:        controllerTestCMGVR,
+					Namespaced: true,
+				},
+				Template: newConfigMapObject("missing", ""),
+			},
+			wantState: NodeStateWaitingForReadiness,
+		},
+		{
+			name: "external ref becomes ready when object exists",
+			node: &graph.Node{
+				Meta: graph.NodeMeta{
+					ID:         "external",
+					Type:       graph.NodeTypeExternal,
+					GVR:        controllerTestCMGVR,
+					Namespaced: true,
+				},
+				Template: newConfigMapObject("present", ""),
+			},
+			currentObjs: []apimachineryruntime.Object{newConfigMapObject("present", "default")},
+			wantState:   NodeStateSynced,
+		},
+		{
+			name: "desired resolution errors mark node error",
+			node: &graph.Node{
+				Meta: graph.NodeMeta{
+					ID:         "deploy",
+					Type:       graph.NodeTypeResource,
+					GVR:        controllerTestDeployGVR,
+					Namespaced: true,
+				},
+				Template: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": controllerTestDeployGVK.GroupVersion().String(),
+						"kind":       controllerTestDeployGVK.Kind,
+						"metadata": map[string]interface{}{
+							"name": "${1 / 0}",
+						},
+					},
+				},
+				Variables: []*variable.ResourceField{
+					standaloneField("metadata.name", mustCompileControllerExpr(t, "1 / 0"), variable.ResourceVariableKindStatic),
+				},
+			},
+			wantState: NodeStateError,
+			wantErr:   "division by zero",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			if tt.specEnabled != nil {
+				_ = unstructured.SetNestedField(instance.Object, *tt.specEnabled, "spec", "enabled")
+			}
+
+			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(tt.node), tt.currentObjs...)
+			if tt.reactorErr != "" {
+				raw.PrependReactor(tt.reactorVerb, tt.reactorResource, func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+					return true, nil, errors.New(tt.reactorErr)
+				})
+			}
+
+			resources, err := controller.processNode(rcx, rcx.Runtime.Nodes()[0])
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Len(t, resources, tt.wantResources)
+			if tt.wantResources > 0 {
+				assert.Equal(t, tt.wantSkipApply, resources[0].SkipApply)
+			}
+
+			assert.Equal(t, tt.wantState, rcx.StateManager.NodeStates[tt.node.Meta.ID].State)
+		})
+	}
+}
+
+func TestProcessNodeCollectionTypes(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
+
+	collectionNode := newCollectionNodeForResources(t, "configs")
+	externalCollection := newExternalCollectionNodeForResources(t, nil)
+
+	currentCollection := newConfigMapObject("one", "default")
+	currentCollection.SetLabels(map[string]string{
+		metadata.InstanceIDLabel: string(instance.GetUID()),
+		metadata.NodeIDLabel:     "configs",
+	})
+	currentExternal := newConfigMapObject("ext", "default")
+	currentExternal.SetLabels(map[string]string{"app": "demo"})
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(collectionNode, externalCollection), currentCollection, currentExternal)
+	resources, err := controller.processNode(rcx, rcx.Runtime.Nodes()[0])
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "configs-0", resources[0].ID)
+
+	resources, err = controller.processNode(rcx, rcx.Runtime.Nodes()[1])
+	require.NoError(t, err)
+	assert.Nil(t, resources)
+	assert.Equal(t, NodeStateSynced, rcx.StateManager.NodeStates["external-configs"].State)
+}
+
+func TestCollectionAndExternalCollectionProcessing(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one", "two"}, "spec", "items")
+
+	collectionNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "configs",
+			Type:       graph.NodeTypeCollection,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": controllerTestCMGVK.GroupVersion().String(),
+				"kind":       controllerTestCMGVK.Kind,
+				"metadata": map[string]interface{}{
+					"name": "${item}",
+				},
+			},
+		},
+		Variables: []*variable.ResourceField{
+			standaloneField("metadata.name", mustCompileControllerExpr(t, "item", "item"), variable.ResourceVariableKindIteration),
+		},
+		ForEach: []graph.ForEachDimension{{
+			Name:       "item",
+			Expression: mustCompileControllerExpr(t, "schema.spec.items", "schema"),
+		}},
+	}
+
+	externalCollection := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "external-configs",
+			Type:       graph.NodeTypeExternalCollection,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": controllerTestCMGVK.GroupVersion().String(),
+				"kind":       controllerTestCMGVK.Kind,
+				"metadata": map[string]interface{}{
+					"selector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"app": "demo",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	current := newConfigMapObject("one", "default")
+	current.SetLabels(map[string]string{
+		metadata.InstanceIDLabel: string(instance.GetUID()),
+		metadata.NodeIDLabel:     "configs",
+		"app":                    "demo",
+	})
+	matchingExternal := newConfigMapObject("ext", "default")
+	matchingExternal.SetLabels(map[string]string{"app": "demo"})
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(collectionNode, externalCollection), current, matchingExternal)
+
+	collectionRuntimeNode := rcx.Runtime.Nodes()[0]
+	desired, err := collectionRuntimeNode.GetDesired()
+	require.NoError(t, err)
+	resources, err := controller.processCollectionNode(rcx, collectionRuntimeNode, rcx.StateManager.NewNodeState("configs"), desired)
+	require.NoError(t, err)
+	require.Len(t, resources, 2)
+	assert.Equal(t, "one", resources[0].Object.GetName())
+	assert.NotNil(t, resources[0].Current)
+	assert.Equal(t, "0", resources[0].Object.GetLabels()[metadata.CollectionIndexLabel])
+	assert.Equal(t, "2", resources[0].Object.GetLabels()[metadata.CollectionSizeLabel])
+
+	err = controller.processExternalCollectionNode(
+		rcx,
+		rcx.Runtime.Nodes()[1],
+		rcx.StateManager.NewNodeState("external-configs"),
+		[]*unstructured.Unstructured{externalCollection.Template.DeepCopy()},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, NodeStateSynced, rcx.StateManager.NodeStates["external-configs"].State)
+}
+
+func TestProcessExternalRefNodePaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		desired     []*unstructured.Unstructured
+		currentObjs []apimachineryruntime.Object
+		reactorErr  string
+		wantState   string
+		wantErr     string
+	}{
+		{
+			name:      "skips when the desired list is empty",
+			wantState: NodeStateSkipped,
+		},
+		{
+			name:       "marks error when get fails",
+			desired:    []*unstructured.Unstructured{newConfigMapObject("demo", "default")},
+			reactorErr: "get failed",
+			wantState:  NodeStateError,
+			wantErr:    "get failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			node := &graph.Node{
+				Meta: graph.NodeMeta{
+					ID:         "external",
+					Type:       graph.NodeTypeExternal,
+					GVR:        controllerTestCMGVR,
+					Namespaced: true,
+				},
+				Template: newConfigMapObject("demo", ""),
+			}
+
+			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(node), tt.currentObjs...)
+			if tt.reactorErr != "" {
+				raw.PrependReactor("get", "configmaps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+					return true, nil, errors.New(tt.reactorErr)
+				})
+			}
+
+			state := rcx.StateManager.NewNodeState(tt.name)
+			err := controller.processExternalRefNode(rcx, rcx.Runtime.Nodes()[0], state, tt.desired)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantState, state.State)
+		})
+	}
+}
+
+func TestProcessExternalRefNodeWaitsForReadiness(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	node := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "external",
+			Type:       graph.NodeTypeExternal,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: newConfigMapObject("demo", ""),
+		ReadyWhen: []*krocel.Expression{
+			mustCompileControllerExpr(t, "external.metadata.labels.ready == 'true'", "external"),
+		},
+	}
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(node), newConfigMapObject("demo", "default"))
+	state := rcx.StateManager.NewNodeState("external")
+	err := controller.processExternalRefNode(rcx, rcx.Runtime.Nodes()[0], state, []*unstructured.Unstructured{newConfigMapObject("demo", "default")})
+	require.NoError(t, err)
+	assert.Equal(t, NodeStateWaitingForReadiness, state.State)
+}
+
+func TestProcessExternalCollectionNodePaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		node        *graph.Node
+		desired     []*unstructured.Unstructured
+		currentObjs []apimachineryruntime.Object
+		reactorErr  string
+		wantState   string
+		wantErr     string
+	}{
+		{
+			name:      "skips when the desired list is empty",
+			node:      newExternalCollectionNodeForResources(t, nil),
+			wantState: NodeStateSkipped,
+		},
+		{
+			name:       "marks error when list fails",
+			node:       newExternalCollectionNodeForResources(t, nil),
+			desired:    []*unstructured.Unstructured{newConfigMapObject("demo", "default")},
+			reactorErr: "list failed",
+			wantState:  NodeStateError,
+			wantErr:    "list failed",
+		},
+		{
+			name: "marks error for invalid selectors",
+			node: newExternalCollectionNodeForResources(t, nil),
+			desired: []*unstructured.Unstructured{{
+				Object: map[string]interface{}{
+					"apiVersion": controllerTestCMGVK.GroupVersion().String(),
+					"kind":       controllerTestCMGVK.Kind,
+					"metadata": map[string]interface{}{
+						"selector": map[string]interface{}{
+							"matchExpressions": []interface{}{
+								map[string]interface{}{
+									"key":      "app",
+									"operator": "Bogus",
+								},
+							},
+						},
+					},
+				},
+			}},
+			wantState: NodeStateError,
+			wantErr:   "invalid label selector",
+		},
+		{
+			name: "waits for collection readiness",
+			node: newExternalCollectionNodeForResources(t, []*krocel.Expression{mustCompileControllerExpr(t, "each.metadata.labels.ready == 'true'", "each")}),
+			currentObjs: []apimachineryruntime.Object{func() *unstructured.Unstructured {
+				obj := newConfigMapObject("match", "default")
+				obj.SetLabels(map[string]string{"app": "demo"})
+				return obj
+			}()},
+			desired: []*unstructured.Unstructured{func() *unstructured.Unstructured {
+				obj := newConfigMapObject("demo", "default")
+				obj.Object["metadata"].(map[string]interface{})["selector"] = map[string]interface{}{
+					"matchLabels": map[string]interface{}{"app": "demo"},
+				}
+				return obj
+			}()},
+			wantState: NodeStateWaitingForReadiness,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(tt.node), tt.currentObjs...)
+			if tt.reactorErr != "" {
+				raw.PrependReactor("list", "configmaps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+					return true, nil, errors.New(tt.reactorErr)
+				})
+			}
+
+			state := rcx.StateManager.NewNodeState(tt.name)
+			err := controller.processExternalCollectionNode(rcx, rcx.Runtime.Nodes()[0], state, tt.desired)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantState, state.State)
+		})
+	}
+}
+
+func TestApplyDecoratorLabelsAndPatchMetadata(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
+
+	conflictingLabeler := metadata.GenericLabeler{
+		metadata.InstanceIDLabel: "conflict",
+	}
+	rcx.Labeler = conflictingLabeler
+
+	obj := newConfigMapObject("demo", "default")
+	obj.SetLabels(map[string]string{"keep": "yes"})
+	controller.applyDecoratorLabels(rcx, obj, "configs", &CollectionInfo{Index: 1, Size: 3})
+
+	assert.Equal(t, "yes", obj.GetLabels()["keep"])
+	assert.Equal(t, "configs", obj.GetLabels()[metadata.NodeIDLabel])
+	assert.Equal(t, "1", obj.GetLabels()[metadata.CollectionIndexLabel])
+	assert.Equal(t, string(instance.GetUID()), obj.GetLabels()[metadata.InstanceIDLabel])
+	assert.Empty(t, obj.GetLabels()[metadata.ManagedByLabelKey])
+
+	require.NoError(t, controller.patchInstanceWithApplySetMetadata(rcx, applyset.Metadata{
+		ID:                   "demo",
+		Tooling:              "tests",
+		GroupKinds:           sets.New[schema.GroupKind](controllerTestDeployGVK.GroupKind()),
+		AdditionalNamespaces: sets.New[string]("other"),
+	}))
+	stored := getStoredParentObject(t, raw)
+	assert.Equal(t, "demo", stored.GetLabels()[applyset.ApplySetParentIDLabel])
+}
+
+func TestPruneOrphansPaths(t *testing.T) {
+	tests := []struct {
+		name            string
+		reactorVerb     string
+		reactorResource string
+		reactorErr      error
+		batchMeta       applyset.Metadata
+		wantPruned      bool
+		wantRetry       bool
+		wantErr         string
+	}{
+		{
+			name:            "list errors are requeued",
+			reactorVerb:     "list",
+			reactorResource: "configmaps",
+			reactorErr:      errors.New("list failed"),
+			wantErr:         "prune failed",
+		},
+		{
+			name:            "uid conflicts request retry without error",
+			reactorVerb:     "delete",
+			reactorResource: "configmaps",
+			reactorErr:      apierrors.NewConflict(controllerTestCMGVR.GroupResource(), "orphan", errors.New("uid mismatch")),
+			wantPruned:      false,
+			wantRetry:       true,
+		},
+		{
+			name:            "shrink metadata patch failures are tolerated",
+			reactorVerb:     "patch",
+			reactorResource: "webapps",
+			reactorErr:      errors.New("patch failed"),
+			batchMeta: applyset.Metadata{
+				ID:                   "demo",
+				GroupKinds:           sets.New[schema.GroupKind](controllerTestCMGVK.GroupKind()),
+				AdditionalNamespaces: sets.New[string]("default"),
+			},
+			wantPruned: true,
+			wantRetry:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			orphan := newApplysetManagedConfigMap(instance, "orphan", "default")
+			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(), orphan)
+			raw.PrependReactor(tt.reactorVerb, tt.reactorResource, func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+				return true, nil, tt.reactorErr
+			})
+
+			applier := controller.createApplySet(rcx)
+			pruned, retry, err := controller.pruneOrphans(rcx, applier, &applyset.ApplyResult{}, applyset.Metadata{
+				GroupKinds: sets.New[schema.GroupKind](controllerTestCMGVK.GroupKind()),
+			}, tt.batchMeta)
+
+			if tt.wantErr != "" {
+				var retryAfter *requeue.RequeueNeededAfter
+				require.ErrorAs(t, err, &retryAfter)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPruned, pruned)
+			assert.Equal(t, tt.wantRetry, retry)
+		})
+	}
+}
+
+func TestProcessApplyResultsAndReadiness(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
+
+	resourceNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+		ReadyWhen: []*krocel.Expression{
+			mustCompileControllerExpr(t, "deploy.metadata.labels.ready == 'true'", "deploy"),
+		},
+	}
+	collectionNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "configs",
+			Type:       graph.NodeTypeCollection,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": controllerTestCMGVK.GroupVersion().String(),
+				"kind":       controllerTestCMGVK.Kind,
+				"metadata": map[string]interface{}{
+					"name": "${item}",
+				},
+			},
+		},
+		Variables: []*variable.ResourceField{
+			standaloneField("metadata.name", mustCompileControllerExpr(t, "item", "item"), variable.ResourceVariableKindIteration),
+		},
+		ForEach: []graph.ForEachDimension{{
+			Name:       "item",
+			Expression: mustCompileControllerExpr(t, "schema.spec.items", "schema"),
+		}},
+	}
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(resourceNode, collectionNode))
+	_, err := rcx.Runtime.Nodes()[1].GetDesired()
+	require.NoError(t, err)
+
+	rcx.StateManager.NewNodeState("deploy")
+	rcx.StateManager.NewNodeState("configs")
+
+	err = controller.processApplyResults(rcx, &applyset.ApplyResult{
+		Applied: []applyset.ApplyResultItem{
+			{
+				ID:       "deploy",
+				Observed: newDeploymentObject("demo", "default"),
+			},
+			{
+				ID:    "configs-0",
+				Error: errors.New("collection failed"),
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.Equal(t, NodeStateWaitingForReadiness, rcx.StateManager.NodeStates["deploy"].State)
+	assert.Equal(t, NodeStateError, rcx.StateManager.NodeStates["configs"].State)
+
+	waiting := &NodeState{}
+	setStateFromReadiness(rcx.Runtime.Nodes()[0], waiting)
+	assert.Equal(t, NodeStateWaitingForReadiness, waiting.State)
+
+	errorNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "bad",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("bad", ""),
+		ReadyWhen: []*krocel.Expression{
+			mustCompileControllerExpr(t, "1"),
+		},
+	}
+	errState := &NodeState{}
+	controller, rcx, _ = newControllerAndContext(t, instance, newTestGraph(errorNode))
+	rcx.Runtime.Nodes()[0].SetObserved([]*unstructured.Unstructured{newDeploymentObject("bad", "default")})
+	setStateFromReadiness(rcx.Runtime.Nodes()[0], errState)
+	assert.Equal(t, NodeStateError, errState.State)
+
+	controller, rcx, _ = newControllerAndContext(t, instance, newTestGraph(resourceNode))
+	rcx.StateManager.NewNodeState("deploy")
+	err = controller.processApplyResults(rcx, &applyset.ApplyResult{
+		Applied: []applyset.ApplyResultItem{{
+			ID:    "deploy",
+			Error: errors.New("apply failed"),
+		}},
+	})
+	require.Error(t, err)
+	assert.Equal(t, NodeStateError, rcx.StateManager.NodeStates["deploy"].State)
+}
+
+func TestUpdateCollectionFromApplyResultsPaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		items     []interface{}
+		results   map[string]applyset.ApplyResultItem
+		wantState string
+	}{
+		{
+			name:      "handles empty collections as ready",
+			items:     []interface{}{},
+			results:   map[string]applyset.ApplyResultItem{},
+			wantState: NodeStateSynced,
+		},
+		{
+			name:  "sets ready when observed items are present",
+			items: []interface{}{"one"},
+			results: map[string]applyset.ApplyResultItem{
+				"configs-0": {Observed: newConfigMapObject("one", "default")},
+			},
+			wantState: NodeStateSynced,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			_ = unstructured.SetNestedSlice(instance.Object, tt.items, "spec", "items")
+
+			collection := newCollectionNodeForResources(t, "configs")
+			controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(collection))
+			node := rcx.Runtime.Nodes()[0]
+			_, err := node.GetDesired()
+			require.NoError(t, err)
+
+			state := rcx.StateManager.NewNodeState("configs")
+			require.NoError(t, controller.updateCollectionFromApplyResults(rcx, node, state, tt.results))
+			assert.Equal(t, tt.wantState, state.State)
+		})
+	}
+}
+
+func TestUpdateCollectionFromApplyResultsErrorAndPendingPaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		node      *graph.Node
+		items     []interface{}
+		wantState string
+		wantErr   string
+	}{
+		{
+			name:      "returns nil while collection desired data is still pending",
+			node:      newCollectionNodeForResources(t, "configs"),
+			wantState: NodeStateInProgress,
+		},
+		{
+			name: "marks error when collection desired resolution fails",
+			node: &graph.Node{
+				Meta: graph.NodeMeta{
+					ID:         "configs",
+					Type:       graph.NodeTypeCollection,
+					GVR:        controllerTestCMGVR,
+					Namespaced: true,
+				},
+				Template: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": controllerTestCMGVK.GroupVersion().String(),
+						"kind":       controllerTestCMGVK.Kind,
+						"metadata": map[string]interface{}{
+							"name": "${1 / 0}",
+						},
+					},
+				},
+				Variables: []*variable.ResourceField{
+					standaloneField("metadata.name", mustCompileControllerExpr(t, "1 / 0"), variable.ResourceVariableKindIteration),
+				},
+				ForEach: []graph.ForEachDimension{{
+					Name:       "item",
+					Expression: mustCompileControllerExpr(t, "schema.spec.items", "schema"),
+				}},
+			},
+			items:     []interface{}{"one"},
+			wantState: NodeStateError,
+			wantErr:   "division by zero",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			if tt.items != nil {
+				_ = unstructured.SetNestedSlice(instance.Object, tt.items, "spec", "items")
+			}
+
+			controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(tt.node))
+			state := rcx.StateManager.NewNodeState("configs")
+			err := controller.updateCollectionFromApplyResults(rcx, rcx.Runtime.Nodes()[0], state, map[string]applyset.ApplyResultItem{})
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantState, state.State)
+		})
+	}
+}
+
+func TestWatchAndResourceHelpers(t *testing.T) {
+	rcx := &ReconcileContext{
+		Log:     zap.New(zap.UseDevMode(true)),
+		Watcher: erroringWatcher{},
+	}
+
+	requestWatch(rcx, "deploy", controllerTestDeployGVR, "demo", "default")
+	requestCollectionWatch(rcx, "configs", controllerTestCMGVR, "default", labels.Everything())
+
+	instance := newInstanceObject("demo", "default")
+	_, helperRCX, _ := newControllerAndContext(t, instance, newTestGraph())
+	client := resourceClientFor(helperRCX, graph.NodeMeta{
+		GVR:        controllerTestCMGVR,
+		Namespaced: false,
+	}, "ignored")
+	assert.NotNil(t, client)
+}
+
+func TestReconcileNodesRetryBranches(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	resourceNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(resourceNode))
+	raw.PrependReactor("patch", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		return true, nil, errors.New("apply failed")
+	})
+	err := controller.reconcileNodes(rcx)
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, err, &retryAfter)
+	assert.Contains(t, err.Error(), "apply failed")
+
+	instance = newInstanceObject("demo", "default")
+	instance.SetAnnotations(map[string]string{
+		applyset.ApplySetGKsAnnotation: "ConfigMap",
+	})
+	orphan := newApplysetManagedConfigMap(instance, "orphan", "default")
+	controller, rcx, raw = newControllerAndContext(t, instance, newTestGraph(), orphan)
+	raw.PrependReactor("delete", "configmaps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		return true, nil, apierrors.NewConflict(controllerTestCMGVR.GroupResource(), "orphan", errors.New("uid mismatch"))
+	})
+	err = controller.reconcileNodes(rcx)
+	require.ErrorAs(t, err, &retryAfter)
+	assert.Contains(t, err.Error(), "UID conflicts")
+}
+
+func newCollectionNodeForResources(t *testing.T, id string) *graph.Node {
+	t.Helper()
+
+	return &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         id,
+			Type:       graph.NodeTypeCollection,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": controllerTestCMGVK.GroupVersion().String(),
+				"kind":       controllerTestCMGVK.Kind,
+				"metadata": map[string]interface{}{
+					"name": "${item}",
+				},
+			},
+		},
+		Variables: []*variable.ResourceField{
+			standaloneField("metadata.name", mustCompileControllerExpr(t, "item", "item"), variable.ResourceVariableKindIteration),
+		},
+		ForEach: []graph.ForEachDimension{{
+			Name:       "item",
+			Expression: mustCompileControllerExpr(t, "schema.spec.items", "schema"),
+		}},
+	}
+}
+
+func newExternalCollectionNodeForResources(t *testing.T, readyWhen []*krocel.Expression) *graph.Node {
+	t.Helper()
+
+	return &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "external-configs",
+			Type:       graph.NodeTypeExternalCollection,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": controllerTestCMGVK.GroupVersion().String(),
+				"kind":       controllerTestCMGVK.Kind,
+				"metadata": map[string]interface{}{
+					"selector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"app": "demo",
+						},
+					},
+				},
+			},
+		},
+		ReadyWhen: readyWhen,
+	}
+}

--- a/pkg/controller/instance/status_test.go
+++ b/pkg/controller/instance/status_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/graph"
+	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
+)
+
+func TestConditionsMarkerAndInitialStatus(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	wrapper := &unstructuredWrapper{instance}
+
+	wrapper.SetConditions([]v1alpha1.Condition{{
+		Type:   v1alpha1.ConditionType(Ready),
+		Status: metav1.ConditionTrue,
+	}})
+	conditions := wrapper.GetConditions()
+	require.Len(t, conditions, 1)
+	assert.Equal(t, v1alpha1.ConditionType(Ready), conditions[0].Type)
+
+	marker := NewConditionsMarkerFor(instance)
+	marker.InstanceManaged()
+	marker.GraphResolved()
+	marker.ReconciliationActive()
+	marker.ResourcesReady()
+
+	rcx := &ReconcileContext{
+		Instance:     instance,
+		StateManager: &StateManager{State: InstanceStateInProgress},
+	}
+	status := rcx.initialStatus()
+	assert.Equal(t, InstanceStateActive, status["state"])
+
+	marker.ResourcesNotReady("not yet")
+	marker.ReconciliationSuspended("paused")
+	marker.ResourcesUnderDeletion("cleanup")
+	marker.InstanceNotManaged("nope")
+	marker.GraphResolutionFailed("bad graph")
+
+	rcx.StateManager.State = InstanceStateDeleting
+	status = rcx.initialStatus()
+	assert.Equal(t, InstanceStateDeleting, status["state"])
+
+	assert.Equal(t, metav1.ConditionFalse, conditionByType(t, instance, InstanceManaged).Status)
+	assert.Equal(t, metav1.ConditionFalse, conditionByType(t, instance, GraphResolved).Status)
+	assert.Equal(t, metav1.ConditionUnknown, conditionByType(t, instance, ResourcesReady).Status)
+	assert.Equal(t, metav1.ConditionTrue, conditionByType(t, instance, ReconciliationSuspended).Status)
+}
+
+func TestUpdateStatusPaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		badExpr   bool
+		wantURL   string
+		wantState string
+		wantErr   string
+	}{
+		{
+			name:      "copies resolved status fields but preserves reserved keys",
+			wantURL:   "https://demo",
+			wantState: string(InstanceStateDeleting),
+		},
+		{
+			name:    "returns instance desired resolution error",
+			badExpr: true,
+			wantErr: "division by zero",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+
+			instanceNode := &graph.Node{
+				Meta: graph.NodeMeta{
+					ID:         graph.InstanceNodeID,
+					Type:       graph.NodeTypeInstance,
+					GVR:        controllerTestParentGVR,
+					Namespaced: true,
+				},
+			}
+			if tt.badExpr {
+				instanceNode.Template = &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"status": map[string]interface{}{
+							"bad": "${1 / 0}",
+						},
+					},
+				}
+				instanceNode.Variables = []*variable.ResourceField{
+					standaloneField("status.bad", mustCompileControllerExpr(t, "1 / 0"), variable.ResourceVariableKindStatic),
+				}
+			} else {
+				instanceNode.Template = &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"status": map[string]interface{}{
+							"url":        "${'https://demo'}",
+							"state":      "${'OVERRIDE'}",
+							"conditions": "${['bad']}",
+						},
+					},
+				}
+				instanceNode.Variables = []*variable.ResourceField{
+					standaloneField("status.url", mustCompileControllerExpr(t, "'https://demo'"), variable.ResourceVariableKindStatic),
+					standaloneField("status.state", mustCompileControllerExpr(t, "'OVERRIDE'"), variable.ResourceVariableKindStatic),
+					standaloneField("status.conditions", mustCompileControllerExpr(t, "['bad']"), variable.ResourceVariableKindStatic),
+				}
+			}
+
+			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraphWithInstance(instanceNode))
+			rcx.StateManager.State = InstanceStateDeleting
+
+			err := controller.updateStatus(rcx)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			stored := getStoredParentObject(t, raw)
+
+			url, found, err := unstructured.NestedString(stored.Object, "status", "url")
+			require.NoError(t, err)
+			require.True(t, found)
+			assert.Equal(t, tt.wantURL, url)
+
+			state, found, err := unstructured.NestedString(stored.Object, "status", "state")
+			require.NoError(t, err)
+			require.True(t, found)
+			assert.Equal(t, tt.wantState, state)
+
+			conditions, found, err := unstructured.NestedSlice(stored.Object, "status", "conditions")
+			require.NoError(t, err)
+			require.True(t, found)
+			assert.NotEqual(t, []interface{}{"bad"}, conditions)
+		})
+	}
+}

--- a/pkg/controller/instance/test_helpers_test.go
+++ b/pkg/controller/instance/test_helpers_test.go
@@ -1,0 +1,408 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	metadatafake "k8s.io/client-go/metadata/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
+	clientfake "github.com/kubernetes-sigs/kro/pkg/client/fake"
+	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
+	"github.com/kubernetes-sigs/kro/pkg/dynamiccontroller"
+	"github.com/kubernetes-sigs/kro/pkg/graph"
+	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
+	krt "github.com/kubernetes-sigs/kro/pkg/runtime"
+)
+
+var (
+	controllerTestParentGVR = schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
+	controllerTestParentGVK = schema.GroupVersionKind{Group: "kro.run", Version: "v1alpha1", Kind: "WebApp"}
+	controllerTestDeployGVR = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	controllerTestDeployGVK = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	controllerTestCMGVR     = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	controllerTestCMGVK     = schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
+)
+
+var controllerTestEnv = func() *cel.Env {
+	env, err := krocel.DefaultEnvironment(krocel.WithResourceIDs([]string{
+		"schema", "deploy", "external", "each", "item", "configs",
+	}))
+	if err != nil {
+		panic(err)
+	}
+	return env
+}()
+
+func mustCompileControllerExpr(t *testing.T, expr string, refs ...string) *krocel.Expression {
+	t.Helper()
+
+	ast, issues := controllerTestEnv.Compile(expr)
+	if issues != nil && issues.Err() != nil {
+		t.Fatalf("compile %q: %v", expr, issues.Err())
+	}
+	program, err := controllerTestEnv.Program(ast)
+	require.NoError(t, err)
+
+	return &krocel.Expression{
+		Original:   expr,
+		References: refs,
+		Program:    program,
+	}
+}
+
+func buildControllerTestRESTMapper() meta.RESTMapper {
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+		{Group: "", Version: "v1"},
+		{Group: "apps", Version: "v1"},
+		{Group: "kro.run", Version: "v1alpha1"},
+	})
+	mapper.Add(controllerTestCMGVK, meta.RESTScopeNamespace)
+	mapper.Add(controllerTestDeployGVK, meta.RESTScopeNamespace)
+	mapper.Add(controllerTestParentGVK, meta.RESTScopeNamespace)
+	return mapper
+}
+
+func newControllerTestDynamicClient(t *testing.T, objs ...apimachineryruntime.Object) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+
+	scheme := apimachineryruntime.NewScheme()
+
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			controllerTestParentGVR: "WebAppList",
+			controllerTestDeployGVR: "DeploymentList",
+			controllerTestCMGVR:     "ConfigMapList",
+		},
+		objs...,
+	)
+	addApplyReactor(client)
+	return client
+}
+
+func addApplyReactor(client *dynamicfake.FakeDynamicClient) {
+	var rvCounter int64
+
+	client.PrependReactor("patch", "*", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		patchAction, ok := action.(k8stesting.PatchAction)
+		if !ok || patchAction.GetPatchType() != types.ApplyPatchType {
+			return false, nil, nil
+		}
+
+		obj := &unstructured.Unstructured{}
+		if err := obj.UnmarshalJSON(patchAction.GetPatch()); err != nil {
+			return true, nil, err
+		}
+
+		gvr := action.GetResource()
+		namespace := action.GetNamespace()
+		var (
+			current *unstructured.Unstructured
+			create  bool
+		)
+		stored, err := client.Tracker().Get(gvr, namespace, patchAction.GetName())
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return true, nil, err
+			}
+			current = &unstructured.Unstructured{Object: map[string]interface{}{}}
+			create = true
+		} else {
+			existing, ok := stored.(*unstructured.Unstructured)
+			if !ok {
+				return true, nil, fmt.Errorf("unexpected object type %T", stored)
+			}
+			current = existing.DeepCopy()
+		}
+
+		mergeMaps(current.Object, obj.Object)
+		current.SetGroupVersionKind(obj.GroupVersionKind())
+		if current.GetName() == "" {
+			current.SetName(patchAction.GetName())
+		}
+		if current.GetNamespace() == "" {
+			current.SetNamespace(namespace)
+		}
+		if current.GetUID() == "" {
+			current.SetUID(types.UID("uid-" + current.GetName()))
+		}
+		current.SetResourceVersion(strconv.FormatInt(atomic.AddInt64(&rvCounter, 1), 10))
+
+		if create {
+			if err := client.Tracker().Create(gvr, current, namespace); err != nil {
+				return true, nil, err
+			}
+		} else if err := client.Tracker().Update(gvr, current, namespace); err != nil {
+			return true, nil, err
+		}
+
+		return true, current.DeepCopy(), nil
+	})
+}
+
+func mergeMaps(dst, src map[string]interface{}) {
+	for key, value := range src {
+		srcMap, srcIsMap := value.(map[string]interface{})
+		dstMap, dstIsMap := dst[key].(map[string]interface{})
+		if srcIsMap && dstIsMap {
+			mergeMaps(dstMap, srcMap)
+			continue
+		}
+		dst[key] = value
+	}
+}
+
+func newControllerTestCoordinator(t *testing.T) *dynamiccontroller.WatchCoordinator {
+	t.Helper()
+
+	scheme := apimachineryruntime.NewScheme()
+	require.NoError(t, metav1.AddMetaToScheme(scheme))
+
+	log := zap.New(zap.UseDevMode(true))
+	metadataClient := metadatafake.NewSimpleMetadataClient(scheme)
+
+	var coord *dynamiccontroller.WatchCoordinator
+	watches := dynamiccontroller.NewWatchManager(metadataClient, time.Hour, func(event dynamiccontroller.Event) {
+		if coord != nil {
+			coord.RouteEvent(event)
+		}
+	}, log)
+
+	coord = dynamiccontroller.NewWatchCoordinator(watches, func(schema.GroupVersionResource, types.NamespacedName) {}, log)
+	return coord
+}
+
+func newControllerUnderTest(t *testing.T, raw *dynamicfake.FakeDynamicClient, g *graph.Graph) (*Controller, *clientfake.FakeSet) {
+	t.Helper()
+
+	clientSet := clientfake.NewFakeSet(raw)
+	clientSet.SetRESTMapper(buildControllerTestRESTMapper())
+
+	controller := NewController(
+		zap.New(zap.UseDevMode(true)),
+		ReconcileConfig{
+			DefaultRequeueDuration: 2 * time.Second,
+			RGDConfig: graph.RGDConfig{
+				MaxCollectionSize:          10,
+				MaxCollectionDimensionSize: 10,
+			},
+		},
+		controllerTestParentGVR,
+		g,
+		clientSet,
+		metadata.NewKROMetaLabeler(),
+		metadata.NewKROMetaLabeler(),
+		newControllerTestCoordinator(t),
+	)
+
+	return controller, clientSet
+}
+
+func newControllerAndContext(
+	t *testing.T,
+	instance *unstructured.Unstructured,
+	g *graph.Graph,
+	extraObjs ...apimachineryruntime.Object,
+) (*Controller, *ReconcileContext, *dynamicfake.FakeDynamicClient) {
+	t.Helper()
+
+	objs := append([]apimachineryruntime.Object{instance.DeepCopy()}, extraObjs...)
+	raw := newControllerTestDynamicClient(t, objs...)
+	controller, clientSet := newControllerUnderTest(t, raw, g)
+
+	rt, err := krt.FromGraph(g, instance.DeepCopy(), controller.reconcileConfig.RGDConfig)
+	require.NoError(t, err)
+
+	rcx := NewReconcileContext(
+		context.Background(),
+		controller.log,
+		controllerTestParentGVR,
+		clientSet.Dynamic(),
+		clientSet.RESTMapper(),
+		controller.childResourceLabeler,
+		rt,
+		controller.reconcileConfig,
+		instance.DeepCopy(),
+	)
+	rcx.Watcher = dynamiccontroller.NoopInstanceWatcher{}
+
+	return controller, rcx, raw
+}
+
+func newInstanceObject(name, namespace string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": controllerTestParentGVK.GroupVersion().String(),
+			"kind":       controllerTestParentGVK.Kind,
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{},
+		},
+	}
+	obj.SetGroupVersionKind(controllerTestParentGVK)
+	obj.SetUID(types.UID(name + "-uid"))
+	obj.SetResourceVersion("1")
+	return obj
+}
+
+func newClusterScopedInstanceObject(name string) *unstructured.Unstructured {
+	obj := newInstanceObject(name, "")
+	unstructured.RemoveNestedField(obj.Object, "metadata", "namespace")
+	obj.SetNamespace("")
+	return obj
+}
+
+func newDeploymentObject(name, namespace string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": controllerTestDeployGVK.GroupVersion().String(),
+			"kind":       controllerTestDeployGVK.Kind,
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+	obj.SetGroupVersionKind(controllerTestDeployGVK)
+	return obj
+}
+
+func newConfigMapObject(name, namespace string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": controllerTestCMGVK.GroupVersion().String(),
+			"kind":       controllerTestCMGVK.Kind,
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"data": map[string]interface{}{
+				"value": "x",
+			},
+		},
+	}
+	obj.SetGroupVersionKind(controllerTestCMGVK)
+	return obj
+}
+
+func newApplysetManagedConfigMap(instance *unstructured.Unstructured, name, namespace string) *unstructured.Unstructured {
+	obj := newConfigMapObject(name, namespace)
+	obj.SetUID(types.UID(name + "-uid"))
+	obj.SetLabels(map[string]string{
+		applyset.ApplysetPartOfLabel: applyset.ID(instance),
+	})
+	return obj
+}
+
+func newTestGraph(nodes ...*graph.Node) *graph.Graph {
+	instanceNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         graph.InstanceNodeID,
+			Type:       graph.NodeTypeInstance,
+			GVR:        controllerTestParentGVR,
+			Namespaced: true,
+		},
+		Template: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"status": map[string]interface{}{},
+			},
+		},
+	}
+	return newTestGraphWithInstance(instanceNode, nodes...)
+}
+
+func newTestGraphWithInstance(instanceNode *graph.Node, nodes ...*graph.Node) *graph.Graph {
+	nodeMap := make(map[string]*graph.Node, len(nodes))
+	resourceSchemas := map[string]*spec.Schema{
+		graph.InstanceNodeID: nil,
+	}
+	order := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		nodeMap[node.Meta.ID] = node
+		resourceSchemas[node.Meta.ID] = nil
+		order = append(order, node.Meta.ID)
+	}
+
+	return &graph.Graph{
+		Instance:         instanceNode,
+		Nodes:            nodeMap,
+		Resources:        nodeMap,
+		TopologicalOrder: order,
+		ResourceSchemas:  resourceSchemas,
+	}
+}
+
+func standaloneField(path string, expr *krocel.Expression, kind variable.ResourceVariableKind) *variable.ResourceField {
+	return &variable.ResourceField{
+		FieldDescriptor: variable.FieldDescriptor{
+			Path:                 path,
+			Expressions:          []*krocel.Expression{expr},
+			StandaloneExpression: true,
+		},
+		Kind: kind,
+	}
+}
+
+func conditionByType(t *testing.T, obj *unstructured.Unstructured, condType string) v1alpha1.Condition {
+	t.Helper()
+
+	conditions := (&unstructuredWrapper{obj}).GetConditions()
+	for _, condition := range conditions {
+		if condition.Type == v1alpha1.ConditionType(condType) {
+			return condition
+		}
+	}
+	t.Fatalf("condition %q not found", condType)
+	return v1alpha1.Condition{}
+}
+
+func getStoredParentObject(t *testing.T, client *dynamicfake.FakeDynamicClient) *unstructured.Unstructured {
+	t.Helper()
+
+	resource := client.Resource(controllerTestParentGVR)
+	obj, err := resource.Namespace("default").Get(context.Background(), "demo", metav1.GetOptions{})
+	require.NoError(t, err)
+	return obj
+}
+
+type erroringWatcher struct{}
+
+func (erroringWatcher) Watch(dynamiccontroller.WatchRequest) error { return errors.New("watch failed") }
+func (erroringWatcher) Done()                                      {}


### PR DESCRIPTION
Add broad unit coverage for reconcile success, requeue, suspend, deletion,
collection, external reference, apply-result, and status/state branches.

```
go test -cover ./pkg/controller/instance -count=1               
ok      github.com/kubernetes-sigs/kro/pkg/controller/instance  0.597s  coverage: 88.1% of statements
```