### PR TITLE
dynamiccontroller: retain parent informers for shared GVR watches

### DIFF
--- a/pkg/dynamiccontroller/coordinator.go
+++ b/pkg/dynamiccontroller/coordinator.go
@@ -352,6 +352,14 @@ func (c *WatchCoordinator) WatchRequestCount() (scalar, collection int) {
 	return
 }
 
+// HasRequestsForGVR reports whether any child or external watch requests still
+// exist for the given GVR.
+func (c *WatchCoordinator) HasRequestsForGVR(gvr schema.GroupVersionResource) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.scalarIndex[gvr]) > 0 || len(c.collectionIndex[gvr]) > 0
+}
+
 // --- internal helpers ---
 
 func (c *WatchCoordinator) addScalarIndexLocked(key instanceKey, req WatchRequest) {

--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -354,14 +354,18 @@ func (dc *DynamicController) Register(
 
 	// Create parent watch if it doesn't exist.
 	if _, exists := dc.parentWatches[parent]; !exists {
-		// Ensure informer is running and wait for cache sync.
-		if err := dc.watches.EnsureWatch(parent); err != nil {
+		// Retain the shared informer for the parent and wait for cache sync.
+		if err := dc.watches.EnsureParentWatch(parent); err != nil {
 			dc.handlers.Delete(parent)
 			return fmt.Errorf("add parent handler %s: %w", parent, err)
 		}
 
 		inf := dc.watches.GetInformer(parent)
 		if inf == nil {
+			dc.watches.ReleaseParentWatch(parent)
+			if !dc.coordinator.HasRequestsForGVR(parent) {
+				dc.watches.StopWatch(parent)
+			}
 			dc.handlers.Delete(parent)
 			return fmt.Errorf("add parent handler %s: informer not found after EnsureWatch", parent)
 		}
@@ -380,8 +384,11 @@ func (dc *DynamicController) Register(
 		}
 		reg, err := inf.AddEventHandler(parentHandler)
 		if err != nil {
+			dc.watches.ReleaseParentWatch(parent)
+			if !dc.coordinator.HasRequestsForGVR(parent) {
+				dc.watches.StopWatch(parent)
+			}
 			dc.handlers.Delete(parent)
-			dc.watches.StopWatch(parent)
 			return fmt.Errorf("add parent handler %s: %w", parent, err)
 		}
 		dc.parentWatches[parent] = reg
@@ -447,8 +454,12 @@ func (dc *DynamicController) Deregister(_ context.Context, parent schema.GroupVe
 		}
 		delete(dc.parentWatches, parent)
 
-		// Stop the parent informer — it's no longer needed.
-		dc.watches.StopWatch(parent)
+		// Release the parent retention and stop the shared informer only if
+		// no child/external watches still depend on it.
+		dc.watches.ReleaseParentWatch(parent)
+		if !dc.coordinator.HasRequestsForGVR(parent) {
+			dc.watches.StopWatch(parent)
+		}
 
 		gvrCount.Dec()
 		handlerDetachTotal.WithLabelValues("parent").Inc()

--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -186,6 +186,75 @@ func TestEnqueueObject(t *testing.T) {
 	assert.Equal(t, 1, dc.queue.Len())
 }
 
+func TestChildCleanup_DoesNotStopParentInformer(t *testing.T) {
+	logger := noopLogger()
+	client, mapper := setupFakeClient(t)
+
+	dc := NewDynamicController(logger, testConfig(), client, mapper)
+	ctx := t.Context()
+	dc.ctx.Store(&ctx)
+
+	parentGVR := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
+	consumerParentGVR := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "consumers"}
+
+	handlerFunc := Handler(func(ctx context.Context, req controllerruntime.Request) error {
+		return nil
+	})
+
+	require.NoError(t, dc.Register(ctx, parentGVR, handlerFunc))
+	assert.NotNil(t, dc.watches.GetInformer(parentGVR), "parent informer should be running after register")
+
+	instance := types.NamespacedName{Name: "consumer", Namespace: "default"}
+	watcher := dc.coordinator.ForInstance(consumerParentGVR, instance)
+	require.NoError(t, watcher.Watch(WatchRequest{
+		NodeID:    "external",
+		GVR:       parentGVR,
+		Name:      "target",
+		Namespace: "default",
+	}))
+	watcher.Done()
+
+	dc.coordinator.RemoveInstance(consumerParentGVR, instance)
+	assert.NotNil(t, dc.watches.GetInformer(parentGVR), "child cleanup must not stop a registered parent informer")
+
+	require.NoError(t, dc.Deregister(ctx, parentGVR))
+	assert.Nil(t, dc.watches.GetInformer(parentGVR), "informer should stop once both parent and child users are gone")
+}
+
+func TestDeregister_KeepsInformerWhileChildWatchRemains(t *testing.T) {
+	logger := noopLogger()
+	client, mapper := setupFakeClient(t)
+
+	dc := NewDynamicController(logger, testConfig(), client, mapper)
+	ctx := t.Context()
+	dc.ctx.Store(&ctx)
+
+	parentGVR := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
+	consumerParentGVR := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "consumers"}
+
+	handlerFunc := Handler(func(ctx context.Context, req controllerruntime.Request) error {
+		return nil
+	})
+
+	require.NoError(t, dc.Register(ctx, parentGVR, handlerFunc))
+
+	instance := types.NamespacedName{Name: "consumer", Namespace: "default"}
+	watcher := dc.coordinator.ForInstance(consumerParentGVR, instance)
+	require.NoError(t, watcher.Watch(WatchRequest{
+		NodeID:    "external",
+		GVR:       parentGVR,
+		Name:      "target",
+		Namespace: "default",
+	}))
+	watcher.Done()
+
+	require.NoError(t, dc.Deregister(ctx, parentGVR))
+	assert.NotNil(t, dc.watches.GetInformer(parentGVR), "child watch should keep informer alive after parent deregister")
+
+	dc.coordinator.RemoveInstance(consumerParentGVR, instance)
+	assert.Nil(t, dc.watches.GetInformer(parentGVR), "informer should stop after the remaining child watch is removed")
+}
+
 func TestInstanceUpdatePolicy(t *testing.T) {
 	logger := noopLogger()
 

--- a/pkg/dynamiccontroller/watch.go
+++ b/pkg/dynamiccontroller/watch.go
@@ -36,9 +36,15 @@ import (
 type WatchManager struct {
 	mu      sync.Mutex
 	watches map[schema.GroupVersionResource]*gvrWatch
-	client  metadata.Interface
-	resync  time.Duration
-	log     logr.Logger
+	// parentRefs keeps parent informers alive while a registered parent GVR
+	// still depends on the shared watch.
+	// TODO: If watch ownership gets more complex, replace the split
+	// parent-retention + coordinator-index model with a unified owner set in
+	// WatchManager so informer lifetime is derived from one source of truth.
+	parentRefs map[schema.GroupVersionResource]int
+	client     metadata.Interface
+	resync     time.Duration
+	log        logr.Logger
 
 	// onEvent is the single callback invoked for every informer event.
 	// Set at construction time; never nil.
@@ -66,14 +72,43 @@ type gvrWatch struct {
 // for every informer event across all GVRs.
 func NewWatchManager(client metadata.Interface, resync time.Duration, onEvent EventHandler, log logr.Logger) *WatchManager {
 	wm := &WatchManager{
-		watches: make(map[schema.GroupVersionResource]*gvrWatch),
-		client:  client,
-		resync:  resync,
-		onEvent: onEvent,
-		log:     log.WithName("watch-manager"),
+		watches:    make(map[schema.GroupVersionResource]*gvrWatch),
+		parentRefs: make(map[schema.GroupVersionResource]int),
+		client:     client,
+		resync:     resync,
+		onEvent:    onEvent,
+		log:        log.WithName("watch-manager"),
 	}
 	wm.createInformer = wm.defaultCreateInformer
 	return wm
+}
+
+// EnsureParentWatch retains the watch for a registered parent GVR and ensures
+// the underlying informer is running.
+func (m *WatchManager) EnsureParentWatch(gvr schema.GroupVersionResource) error {
+	m.mu.Lock()
+	m.parentRefs[gvr]++
+	m.mu.Unlock()
+
+	if err := m.EnsureWatch(gvr); err != nil {
+		m.ReleaseParentWatch(gvr)
+		return err
+	}
+	return nil
+}
+
+// ReleaseParentWatch drops one parent retention for the given GVR.
+func (m *WatchManager) ReleaseParentWatch(gvr schema.GroupVersionResource) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	refs := m.parentRefs[gvr]
+	switch {
+	case refs <= 1:
+		delete(m.parentRefs, gvr)
+	default:
+		m.parentRefs[gvr] = refs - 1
+	}
 }
 
 // EnsureWatch idempotently ensures an informer is running for the given GVR.
@@ -105,7 +140,7 @@ func (m *WatchManager) EnsureWatch(gvr schema.GroupVersionResource) error {
 		// Stop and remove the broken watch so a future EnsureWatch can retry
 		// with a fresh informer instead of returning early for a registered
 		// but non-functional watch.
-		m.StopWatch(gvr)
+		m.forceStopWatch(gvr)
 		return fmt.Errorf("cache sync timeout for %s", gvr)
 	}
 	return nil
@@ -117,13 +152,7 @@ func (m *WatchManager) EnsureWatch(gvr schema.GroupVersionResource) error {
 func (m *WatchManager) StopWatch(gvr schema.GroupVersionResource) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	w, ok := m.watches[gvr]
-	if !ok {
-		return
-	}
-	close(w.stopCh)
-	delete(m.watches, gvr)
-	m.log.V(1).Info("Watch stopped", "gvr", gvr)
+	m.stopWatchLocked(gvr, false)
 }
 
 // GetInformer returns the SharedIndexInformer for the given GVR, or nil
@@ -154,6 +183,7 @@ func (m *WatchManager) Shutdown() {
 		close(w.stopCh)
 	}
 	m.watches = make(map[schema.GroupVersionResource]*gvrWatch)
+	m.parentRefs = make(map[schema.GroupVersionResource]int)
 }
 
 const defaultSyncTimeout = 30 * time.Second
@@ -194,6 +224,28 @@ func (m *WatchManager) newWatch(gvr schema.GroupVersionResource) *gvrWatch {
 	}
 
 	return w
+}
+
+func (m *WatchManager) forceStopWatch(gvr schema.GroupVersionResource) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopWatchLocked(gvr, true)
+}
+
+func (m *WatchManager) stopWatchLocked(gvr schema.GroupVersionResource, force bool) {
+	w, ok := m.watches[gvr]
+	if !ok {
+		return
+	}
+	if !force {
+		if refs := m.parentRefs[gvr]; refs > 0 {
+			m.log.V(1).Info("Watch retained by registered parent", "gvr", gvr, "parentRefs", refs)
+			return
+		}
+	}
+	close(w.stopCh)
+	delete(m.watches, gvr)
+	m.log.V(1).Info("Watch stopped", "gvr", gvr)
 }
 
 // eventHandlerFuncs returns cache.ResourceEventHandlerFuncs that convert

--- a/pkg/dynamiccontroller/watch_test.go
+++ b/pkg/dynamiccontroller/watch_test.go
@@ -74,6 +74,22 @@ func TestStopWatch_ThenEnsureWatch_CreatesFresh(t *testing.T) {
 	assert.NotSame(t, inf1, inf2, "expected fresh informer after StopWatch + EnsureWatch")
 }
 
+func TestStopWatch_RetainedByParent(t *testing.T) {
+	wm := newTestWatchManager(t)
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+	assert.NoError(t, wm.EnsureParentWatch(gvr))
+	assert.NotNil(t, wm.GetInformer(gvr))
+
+	// Child/orphan cleanup should not stop a parent-retained watch.
+	wm.StopWatch(gvr)
+	assert.NotNil(t, wm.GetInformer(gvr), "parent-retained informer should stay running")
+
+	wm.ReleaseParentWatch(gvr)
+	wm.StopWatch(gvr)
+	assert.Nil(t, wm.GetInformer(gvr), "watch should stop after the parent releases it")
+}
+
 func TestDeleteFunc_Tombstone(t *testing.T) {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 

--- a/test/integration/suites/core/externalref_watch_test.go
+++ b/test/integration/suites/core/externalref_watch_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -466,4 +467,177 @@ var _ = Describe("ExternalRef Watch", func() {
 			g.Expect(sortedNames).To(Equal("cm-charlie,cm-alpha,cm-bravo"))
 		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 	})
+
+	It("external ref to a chained RGD keeps the producer instance reconciling after consumer deletion",
+		func(ctx SpecContext) {
+			By("creating the producer RGD that owns the watched custom resource kind")
+			producerRGD := generator.NewResourceGraphDefinition("test-chained-producer",
+				generator.WithSchema(
+					"WatchedDatabase", "v1alpha1",
+					map[string]interface{}{
+						"value": "string",
+					},
+					nil,
+				),
+				generator.WithResource("managed", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "watched-database-config",
+					},
+					"data": map[string]interface{}{
+						"value": "${schema.spec.value}",
+					},
+				}, nil, nil),
+			)
+			Expect(env.Client.Create(ctx, producerRGD)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				Expect(env.Client.Delete(ctx, producerRGD)).To(Succeed())
+			})
+
+			By("waiting for the producer RGD to become active")
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: producerRGD.Name}, producerRGD)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(producerRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			By("creating a producer instance and waiting for its managed ConfigMap")
+			producerInstance := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "kro.run/v1alpha1",
+					"kind":       "WatchedDatabase",
+					"metadata": map[string]interface{}{
+						"name":      "watched-db",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"value": "one",
+					},
+				},
+			}
+			Expect(env.Client.Create(ctx, producerInstance)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				err := env.Client.Delete(ctx, producerInstance)
+				if err != nil && !apierrors.IsNotFound(err) {
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
+
+			producerCM := &corev1.ConfigMap{}
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      producerInstance.GetName(),
+					Namespace: namespace,
+				}, producerInstance)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(producerInstance.Object).To(HaveKey("status"))
+				g.Expect(producerInstance.Object["status"]).To(HaveKeyWithValue("state", "ACTIVE"))
+
+				err = env.Client.Get(ctx, types.NamespacedName{
+					Name:      "watched-database-config",
+					Namespace: namespace,
+				}, producerCM)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(producerCM.Data).To(HaveKeyWithValue("value", "one"))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			By("creating a consumer RGD that externalRefs the producer custom resource kind")
+			consumerRGD := generator.NewResourceGraphDefinition("test-chained-consumer",
+				generator.WithSchema(
+					"DatabaseObserver", "v1alpha1",
+					map[string]interface{}{},
+					nil,
+				),
+				generator.WithExternalRef("database", &krov1alpha1.ExternalRef{
+					APIVersion: "kro.run/v1alpha1",
+					Kind:       "WatchedDatabase",
+					Metadata: krov1alpha1.ExternalRefMetadata{
+						Name: "watched-db",
+					},
+				}, nil, nil),
+				generator.WithResource("managed", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "database-observer-config",
+					},
+					"data": map[string]interface{}{
+						"value": "${database.spec.value}",
+					},
+				}, nil, nil),
+			)
+			Expect(env.Client.Create(ctx, consumerRGD)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				Expect(env.Client.Delete(ctx, consumerRGD)).To(Succeed())
+			})
+
+			By("waiting for the consumer RGD to become active")
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: consumerRGD.Name}, consumerRGD)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(consumerRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			By("creating the consumer instance so it registers an externalRef watch on the producer kind")
+			consumerInstance := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "kro.run/v1alpha1",
+					"kind":       "DatabaseObserver",
+					"metadata": map[string]interface{}{
+						"name":      "db-observer",
+						"namespace": namespace,
+					},
+				},
+			}
+			Expect(env.Client.Create(ctx, consumerInstance)).To(Succeed())
+
+			consumerCM := &corev1.ConfigMap{}
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      consumerInstance.GetName(),
+					Namespace: namespace,
+				}, consumerInstance)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(consumerInstance.Object).To(HaveKey("status"))
+				g.Expect(consumerInstance.Object["status"]).To(HaveKeyWithValue("state", "ACTIVE"))
+
+				err = env.Client.Get(ctx, types.NamespacedName{
+					Name:      "database-observer-config",
+					Namespace: namespace,
+				}, consumerCM)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(consumerCM.Data).To(HaveKeyWithValue("value", "one"))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			By("deleting the consumer instance so its externalRef watch is cleaned up")
+			Expect(env.Client.Delete(ctx, consumerInstance)).To(Succeed())
+			Eventually(func() bool {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      consumerInstance.GetName(),
+					Namespace: namespace,
+				}, consumerInstance)
+				return apierrors.IsNotFound(err)
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(BeTrue())
+
+			By("updating the producer instance after consumer deletion")
+			Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      producerInstance.GetName(),
+				Namespace: namespace,
+			}, producerInstance)).To(Succeed())
+			Expect(unstructured.SetNestedField(producerInstance.Object, "two", "spec", "value")).To(Succeed())
+			Expect(env.Client.Update(ctx, producerInstance)).To(Succeed())
+
+			By("asserting the producer instance still reconciles via its parent watch")
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      "watched-database-config",
+					Namespace: namespace,
+				}, producerCM)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(producerCM.Data).To(HaveKeyWithValue("value", "two"))
+			}, 5*time.Second, 500*time.Millisecond).WithContext(ctx).Should(Succeed(),
+				"producer managed resource should still update after the consumer externalRef instance is deleted",
+			)
+		})
 })


### PR DESCRIPTION
Parent watches and instance level child/externalRef watches share a single
`WatchManager` informer per `GVR`. The watch coordinator tears down orphaned
child watches by GVR when the last instance request disappears. In the
chained RGD case, that allowed externalRef watch cleanup to stop an
informer that was still serving a registered parent GVR, leaving the
parent controller without a live watch.

Introduce explicit parent retention in `WatchManager` and make parent
registration/deregistration acquire and release that retention. Normal
`StopWatch` calls now refuse to stop a retained informer, while informer
shutdown still happens once the final remaining user is gone: either after
the last parent deregisters, or after the last child/external watch request
is removed.

Also add regression coverage for the shared-GVR lifecycle:
- unit coverage for parent-retained watches in WatchManager
- dynamic-controller tests for parent/child informer coexistence
- an integration test covering RGD chaining with externalRef watches