### PR TITLE
dynamiccontroller: rollback provisional watches on failed reconciles

### DIFF
--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -119,9 +119,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 	// Get per-instance watcher from the coordinator.
 	watcher := c.coordinator.ForInstance(c.gvr, req.NamespacedName)
 	defer func() {
-		if err == nil {
-			watcher.Done()
-		}
+		watcher.Done(err == nil)
 	}()
 
 	//--------------------------------------------------------------

--- a/pkg/controller/instance/test_helpers_test.go
+++ b/pkg/controller/instance/test_helpers_test.go
@@ -405,4 +405,4 @@ func getStoredParentObject(t *testing.T, client *dynamicfake.FakeDynamicClient) 
 type erroringWatcher struct{}
 
 func (erroringWatcher) Watch(dynamiccontroller.WatchRequest) error { return errors.New("watch failed") }
-func (erroringWatcher) Done()                                      {}
+func (erroringWatcher) Done(bool)                                  {}

--- a/pkg/controller/instance/watch_test.go
+++ b/pkg/controller/instance/watch_test.go
@@ -40,7 +40,7 @@ func (m *mockWatcher) Watch(req dynamiccontroller.WatchRequest) error {
 	return nil
 }
 
-func (m *mockWatcher) Done() {}
+func (m *mockWatcher) Done(bool) {}
 
 func (m *mockWatcher) getRequests() []dynamiccontroller.WatchRequest {
 	m.mu.Lock()

--- a/pkg/dynamiccontroller/coordinator.go
+++ b/pkg/dynamiccontroller/coordinator.go
@@ -39,10 +39,10 @@ type InstanceWatcher interface {
 
 	// Done signals that all Watch() calls for this reconciliation cycle
 	// are complete. Any watch requests from the previous cycle that were
-	// NOT re-requested are automatically cleaned up.
-	//
-	// If reconciliation fails before Done(), previous requests stay active.
-	Done()
+	// NOT re-requested are automatically cleaned up. If commit is false, the
+	// current cycle is discarded and the previously committed watch set stays
+	// active.
+	Done(commit bool)
 }
 
 // WatchRequest describes a resource the instance reconciler wants to watch.
@@ -85,6 +85,12 @@ type instanceState struct {
 	previous map[string]*WatchRequest // from last Done() cycle
 }
 
+// scalarEntry is a single scalar watch in the reverse index.
+type scalarEntry struct {
+	nodeID string
+	key    instanceKey
+}
+
 // collectionEntry is a single collection watch in the reverse index.
 type collectionEntry struct {
 	nodeID    string // enables identity-based matching for dedup and removal
@@ -107,8 +113,8 @@ type WatchCoordinator struct {
 	instances map[instanceKey]*instanceState
 
 	// Reverse indexes for event routing.
-	// GVR -> namespace/name -> set of instanceKeys
-	scalarIndex map[schema.GroupVersionResource]map[types.NamespacedName]map[instanceKey]struct{}
+	// GVR -> namespace/name -> list of node-owned scalar watch entries.
+	scalarIndex map[schema.GroupVersionResource]map[types.NamespacedName][]scalarEntry
 
 	// GVR -> list of collection watchers.
 	collectionIndex map[schema.GroupVersionResource][]collectionEntry
@@ -121,7 +127,7 @@ func NewWatchCoordinator(watches *WatchManager, enqueue EnqueueFunc, log logr.Lo
 		enqueue:         enqueue,
 		log:             log.WithName("watch-coordinator"),
 		instances:       make(map[instanceKey]*instanceState),
-		scalarIndex:     make(map[schema.GroupVersionResource]map[types.NamespacedName]map[instanceKey]struct{}),
+		scalarIndex:     make(map[schema.GroupVersionResource]map[types.NamespacedName][]scalarEntry),
 		collectionIndex: make(map[schema.GroupVersionResource][]collectionEntry),
 	}
 }
@@ -152,23 +158,24 @@ func (c *WatchCoordinator) addWatch(key instanceKey, req WatchRequest) error {
 	// Fix reverse index orphaning on nodeID reuse: if an existing entry
 	// for this nodeID has a different target, remove it from indexes first.
 	if old, exists := state.current[req.NodeID]; exists {
-		changed := old.GVR != req.GVR || old.Name != req.Name || old.Namespace != req.Namespace
-		if !changed && old.isCollection() && req.isCollection() {
-			changed = old.Selector.String() != req.Selector.String()
-		}
-		if changed {
-			c.removeRequestFromIndexesLocked(key, old)
+		if !sameWatchTarget(old, &req) {
+			if prev, shared := state.previous[req.NodeID]; !shared || !sameWatchTarget(prev, old) {
+				c.removeRequestFromIndexesLocked(key, old)
+			}
 		}
 	}
 
 	// Add to current cycle.
 	state.current[req.NodeID] = &req
 
-	// Add to reverse index.
-	if req.isCollection() {
-		c.addCollectionIndexLocked(key, req)
-	} else {
-		c.addScalarIndexLocked(key, req)
+	// Add to reverse index only when this request is not already covered by
+	// the previously committed watch set for the same node.
+	if prev, shared := state.previous[req.NodeID]; !shared || !sameWatchTarget(prev, &req) {
+		if req.isCollection() {
+			c.addCollectionIndexLocked(key, req)
+		} else {
+			c.addScalarIndexLocked(key, req)
+		}
 	}
 
 	gvr := req.GVR
@@ -182,6 +189,33 @@ func (c *WatchCoordinator) addWatch(key instanceKey, req WatchRequest) error {
 	}
 
 	return nil
+}
+
+// abortInstance discards the current reconciliation cycle for an instance.
+func (c *WatchCoordinator) abortInstance(key instanceKey) {
+	c.mu.Lock()
+
+	state, ok := c.instances[key]
+	if !ok {
+		c.mu.Unlock()
+		return
+	}
+
+	var affectedGVRs []schema.GroupVersionResource
+	for nodeID, req := range state.current {
+		if prev, shared := state.previous[nodeID]; shared && sameWatchTarget(prev, req) {
+			continue
+		}
+		c.removeRequestFromIndexesLocked(key, req)
+		affectedGVRs = append(affectedGVRs, req.GVR)
+	}
+
+	state.current = make(map[string]*WatchRequest)
+
+	orphanedGVRs := c.findOrphanedGVRsLocked(affectedGVRs)
+	c.mu.Unlock()
+
+	c.stopWatches(orphanedGVRs)
 }
 
 // doneInstance finalizes the reconciliation cycle for an instance.
@@ -199,13 +233,8 @@ func (c *WatchCoordinator) doneInstance(key instanceKey) {
 	// Collect affected GVRs for orphan cleanup.
 	var affectedGVRs []schema.GroupVersionResource
 	for nodeID, oldReq := range state.previous {
-		if newReq, stillActive := state.current[nodeID]; stillActive {
-			if newReq.GVR == oldReq.GVR && newReq.Name == oldReq.Name && newReq.Namespace == oldReq.Namespace {
-				// Same target (selector changes are handled by addCollectionIndexLocked
-				// which replaces the entry by key+nodeID).
-				continue
-			}
-			// Target changed — remove old index entry.
+		if newReq, stillActive := state.current[nodeID]; stillActive && sameWatchTarget(newReq, oldReq) {
+			continue
 		}
 		c.removeRequestFromIndexesLocked(key, oldReq)
 		affectedGVRs = append(affectedGVRs, oldReq.GVR)
@@ -301,8 +330,8 @@ func (c *WatchCoordinator) RouteEvent(event Event) {
 	// Scalar matches (O(1) per GVR+name).
 	if byName, ok := c.scalarIndex[event.GVR]; ok {
 		key := types.NamespacedName{Name: event.Name, Namespace: event.Namespace}
-		for instKey := range byName[key] {
-			matched[instKey] = struct{}{}
+		for _, entry := range byName[key] {
+			matched[entry.key] = struct{}{}
 		}
 	}
 
@@ -342,8 +371,8 @@ func (c *WatchCoordinator) WatchRequestCount() (scalar, collection int) {
 	defer c.mu.RUnlock()
 
 	for _, byName := range c.scalarIndex {
-		for _, instSet := range byName {
-			scalar += len(instSet)
+		for _, entries := range byName {
+			scalar += len(entries)
 		}
 	}
 	for _, entries := range c.collectionIndex {
@@ -365,24 +394,29 @@ func (c *WatchCoordinator) HasRequestsForGVR(gvr schema.GroupVersionResource) bo
 func (c *WatchCoordinator) addScalarIndexLocked(key instanceKey, req WatchRequest) {
 	byName, ok := c.scalarIndex[req.GVR]
 	if !ok {
-		byName = make(map[types.NamespacedName]map[instanceKey]struct{})
+		byName = make(map[types.NamespacedName][]scalarEntry)
 		c.scalarIndex[req.GVR] = byName
 	}
 	nn := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	if _, ok := byName[nn]; !ok {
-		byName[nn] = make(map[instanceKey]struct{})
+	for _, entry := range byName[nn] {
+		if entry.key == key && entry.nodeID == req.NodeID {
+			return
+		}
 	}
-	byName[nn][key] = struct{}{}
+	byName[nn] = append(byName[nn], scalarEntry{
+		nodeID: req.NodeID,
+		key:    key,
+	})
 }
 
 func (c *WatchCoordinator) addCollectionIndexLocked(key instanceKey, req WatchRequest) {
-	// Remove any existing entry for the same (key, nodeID) to avoid duplicates
-	// on re-registration (e.g. selector changed between reconciliation cycles).
 	entries := c.collectionIndex[req.GVR]
-	for i, e := range entries {
-		if e.key == key && e.nodeID == req.NodeID {
-			entries = append(entries[:i], entries[i+1:]...)
-			break
+	for _, e := range entries {
+		if e.key == key &&
+			e.nodeID == req.NodeID &&
+			e.namespace == req.Namespace &&
+			e.selector.String() == req.Selector.String() {
+			return
 		}
 	}
 	c.collectionIndex[req.GVR] = append(entries, collectionEntry{
@@ -407,13 +441,21 @@ func (c *WatchCoordinator) removeScalarIndexLocked(key instanceKey, req *WatchRe
 		return
 	}
 	nn := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	instSet, ok := byName[nn]
+	entries, ok := byName[nn]
 	if !ok {
 		return
 	}
-	delete(instSet, key)
-	if len(instSet) == 0 {
+	filtered := entries[:0]
+	for _, entry := range entries {
+		if entry.key == key && entry.nodeID == req.NodeID {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	if len(filtered) == 0 {
 		delete(byName, nn)
+	} else {
+		byName[nn] = filtered
 	}
 	if len(byName) == 0 {
 		delete(c.scalarIndex, req.GVR)
@@ -446,7 +488,10 @@ func (c *WatchCoordinator) removeCollectionIndexLocked(key instanceKey, req *Wat
 	entries := c.collectionIndex[req.GVR]
 	filtered := entries[:0]
 	for _, e := range entries {
-		if e.key == key && e.nodeID == req.NodeID {
+		if e.key == key &&
+			e.nodeID == req.NodeID &&
+			e.namespace == req.Namespace &&
+			e.selector.String() == req.Selector.String() {
 			continue
 		}
 		filtered = append(filtered, e)
@@ -463,7 +508,7 @@ func (c *WatchCoordinator) removeCollectionIndexLocked(key instanceKey, req *Wat
 type NoopInstanceWatcher struct{}
 
 func (NoopInstanceWatcher) Watch(_ WatchRequest) error { return nil }
-func (NoopInstanceWatcher) Done()                      {}
+func (NoopInstanceWatcher) Done(bool)                  {}
 
 // instanceWatcher is the concrete implementation of InstanceWatcher.
 type instanceWatcher struct {
@@ -480,10 +525,32 @@ func (w *instanceWatcher) Watch(req WatchRequest) error {
 	}, req)
 }
 
-// Done finalizes the current reconciliation cycle, cleaning up stale requests.
-func (w *instanceWatcher) Done() {
-	w.coordinator.doneInstance(instanceKey{
+// Done finalizes the current reconciliation cycle. If commit is false, the
+// provisional watch set is discarded and the previous one stays active.
+func (w *instanceWatcher) Done(commit bool) {
+	key := instanceKey{
 		parentGVR: w.parentGVR,
 		instance:  w.instance,
-	})
+	}
+	if !commit {
+		w.coordinator.abortInstance(key)
+		return
+	}
+	w.coordinator.doneInstance(key)
+}
+
+func sameWatchTarget(a, b *WatchRequest) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.GVR != b.GVR || a.Name != b.Name || a.Namespace != b.Namespace {
+		return false
+	}
+	if a.isCollection() != b.isCollection() {
+		return false
+	}
+	if !a.isCollection() {
+		return true
+	}
+	return a.Selector.String() == b.Selector.String()
 }

--- a/pkg/dynamiccontroller/coordinator_test.go
+++ b/pkg/dynamiccontroller/coordinator_test.go
@@ -139,7 +139,7 @@ func TestWatchAndDone_ScalarWatch(t *testing.T) {
 	})
 	assert.Equal(t, 1, recorder.count())
 
-	watcher.Done()
+	watcher.Done(true)
 }
 
 func TestWatchAndDone_CleanupStaleRequests(t *testing.T) {
@@ -150,7 +150,7 @@ func TestWatchAndDone_CleanupStaleRequests(t *testing.T) {
 	w1 := coord.ForInstance(testParentGVR, instance)
 	require.NoError(t, w1.Watch(WatchRequest{NodeID: "deployment", GVR: testDeployGVR, Name: "d1", Namespace: "default"}))
 	require.NoError(t, w1.Watch(WatchRequest{NodeID: "service", GVR: testServiceGVR, Name: "s1", Namespace: "default"}))
-	w1.Done()
+	w1.Done(true)
 
 	// Verify both match.
 	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
@@ -161,7 +161,7 @@ func TestWatchAndDone_CleanupStaleRequests(t *testing.T) {
 	// Cycle 2: only watch deployment (service removed).
 	w2 := coord.ForInstance(testParentGVR, instance)
 	require.NoError(t, w2.Watch(WatchRequest{NodeID: "deployment", GVR: testDeployGVR, Name: "d1", Namespace: "default"}))
-	w2.Done()
+	w2.Done(true)
 
 	// Deployment still matches, service no longer does.
 	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
@@ -184,7 +184,7 @@ func TestCollectionWatch(t *testing.T) {
 		Namespace: "default",
 		Selector:  selector,
 	}))
-	watcher.Done()
+	watcher.Done(true)
 
 	// Matching labels.
 	coord.RouteEvent(Event{
@@ -223,7 +223,7 @@ func TestRemoveInstance(t *testing.T) {
 
 	watcher := coord.ForInstance(testParentGVR, instance)
 	require.NoError(t, watcher.Watch(WatchRequest{NodeID: "deployment", GVR: testDeployGVR, Name: "d1", Namespace: "default"}))
-	watcher.Done()
+	watcher.Done(true)
 
 	// Verify match.
 	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
@@ -247,11 +247,11 @@ func TestRemoveParentGVR(t *testing.T) {
 	// Two instances watching deployments.
 	w1 := coord.ForInstance(testParentGVR, inst1)
 	require.NoError(t, w1.Watch(WatchRequest{NodeID: "deployment", GVR: testDeployGVR, Name: "d1", Namespace: "default"}))
-	w1.Done()
+	w1.Done(true)
 
 	w2 := coord.ForInstance(testParentGVR, inst2)
 	require.NoError(t, w2.Watch(WatchRequest{NodeID: "deployment", GVR: testDeployGVR, Name: "d2", Namespace: "default"}))
-	w2.Done()
+	w2.Done(true)
 
 	assert.Equal(t, 2, coord.InstanceWatchCount())
 
@@ -273,11 +273,11 @@ func TestSharedWatchAcrossInstances(t *testing.T) {
 	// Both instances watch the same shared configmap.
 	w1 := coord.ForInstance(testParentGVR, inst1)
 	require.NoError(t, w1.Watch(WatchRequest{NodeID: "config", GVR: testCmGVR, Name: "shared-cm", Namespace: "default"}))
-	w1.Done()
+	w1.Done(true)
 
 	w2 := coord.ForInstance(testParentGVR, inst2)
 	require.NoError(t, w2.Watch(WatchRequest{NodeID: "config", GVR: testCmGVR, Name: "shared-cm", Namespace: "default"}))
-	w2.Done()
+	w2.Done(true)
 
 	// One event should trigger BOTH instances.
 	coord.RouteEvent(Event{Type: EventUpdate, GVR: testCmGVR, Name: "shared-cm", Namespace: "default"})
@@ -290,7 +290,7 @@ func TestStopOrphanedWatch_RemoveInstance(t *testing.T) {
 
 	watcher := coord.ForInstance(testParentGVR, instance)
 	require.NoError(t, watcher.Watch(WatchRequest{NodeID: "deployment", GVR: testDeployGVR, Name: "d1", Namespace: "default"}))
-	watcher.Done()
+	watcher.Done(true)
 
 	// Informer should be running.
 	assert.Equal(t, 1, coord.watches.ActiveWatchCount(), "expected 1 active watch for deployment GVR")
@@ -312,14 +312,14 @@ func TestStopOrphanedWatch_DoneCleanup(t *testing.T) {
 	w1 := coord.ForInstance(testParentGVR, instance)
 	require.NoError(t, w1.Watch(WatchRequest{NodeID: "deployment", GVR: testDeployGVR, Name: "d1", Namespace: "default"}))
 	require.NoError(t, w1.Watch(WatchRequest{NodeID: "service", GVR: testServiceGVR, Name: "s1", Namespace: "default"}))
-	w1.Done()
+	w1.Done(true)
 
 	assert.Equal(t, 2, coord.watches.ActiveWatchCount(), "expected 2 active watches after cycle 1")
 
 	// Cycle 2: only watch deployment — service should be cleaned up.
 	w2 := coord.ForInstance(testParentGVR, instance)
 	require.NoError(t, w2.Watch(WatchRequest{NodeID: "deployment", GVR: testDeployGVR, Name: "d1", Namespace: "default"}))
-	w2.Done()
+	w2.Done(true)
 
 	assert.Equal(t, 1, coord.watches.ActiveWatchCount(), "expected service watch to be stopped after cycle 2")
 
@@ -335,11 +335,11 @@ func TestStopOrphanedWatch_RemoveParentGVR(t *testing.T) {
 
 	w1 := coord.ForInstance(testParentGVR, inst1)
 	require.NoError(t, w1.Watch(WatchRequest{NodeID: "deployment", GVR: testDeployGVR, Name: "d1", Namespace: "default"}))
-	w1.Done()
+	w1.Done(true)
 
 	w2 := coord.ForInstance(testParentGVR, inst2)
 	require.NoError(t, w2.Watch(WatchRequest{NodeID: "deployment", GVR: testDeployGVR, Name: "d2", Namespace: "default"}))
-	w2.Done()
+	w2.Done(true)
 
 	assert.Equal(t, 1, coord.watches.ActiveWatchCount(), "expected 1 active watch (shared deployment GVR)")
 
@@ -357,12 +357,12 @@ func TestStopOrphanedWatch_SharedGVRNotStopped(t *testing.T) {
 	// Instance 1 (parent1) watches deployments.
 	w1 := coord.ForInstance(testParentGVR, inst1)
 	require.NoError(t, w1.Watch(WatchRequest{NodeID: "deployment", GVR: testDeployGVR, Name: "d1", Namespace: "default"}))
-	w1.Done()
+	w1.Done(true)
 
 	// Instance 2 (parent2) also watches deployments.
 	w2 := coord.ForInstance(parentGVR2, inst2)
 	require.NoError(t, w2.Watch(WatchRequest{NodeID: "deployment", GVR: testDeployGVR, Name: "d2", Namespace: "default"}))
-	w2.Done()
+	w2.Done(true)
 
 	assert.Equal(t, 1, coord.watches.ActiveWatchCount(), "expected 1 shared deployment watch")
 
@@ -387,7 +387,7 @@ func TestStopOrphanedWatch_CollectionWatch(t *testing.T) {
 		Namespace: "default",
 		Selector:  selector,
 	}))
-	watcher.Done()
+	watcher.Done(true)
 
 	assert.Equal(t, 1, coord.watches.ActiveWatchCount(), "expected 1 active watch for collection GVR")
 
@@ -415,7 +415,7 @@ func TestCollectionWatch_DoneCleanup(t *testing.T) {
 		Name:      "d1",
 		Namespace: "default",
 	}))
-	w1.Done()
+	w1.Done(true)
 
 	assert.Equal(t, 2, coord.watches.ActiveWatchCount(), "expected 2 active watches after cycle 1")
 
@@ -427,7 +427,7 @@ func TestCollectionWatch_DoneCleanup(t *testing.T) {
 		Name:      "d1",
 		Namespace: "default",
 	}))
-	w2.Done()
+	w2.Done(true)
 
 	assert.Nil(t, coord.watches.GetInformer(testCmGVR), "collection configmap informer should have been stopped")
 	assert.NotNil(t, coord.watches.GetInformer(testDeployGVR), "deployment informer should still be running")
@@ -445,7 +445,7 @@ func TestNodeIDReuse_ChangesTargetGVR(t *testing.T) {
 		Name:      "d1",
 		Namespace: "default",
 	}))
-	w1.Done()
+	w1.Done(true)
 
 	assert.NotNil(t, coord.watches.GetInformer(testDeployGVR), "deployment informer should be running after cycle 1")
 
@@ -457,7 +457,7 @@ func TestNodeIDReuse_ChangesTargetGVR(t *testing.T) {
 		Name:      "s1",
 		Namespace: "default",
 	}))
-	w2.Done()
+	w2.Done(true)
 
 	assert.Nil(t, coord.watches.GetInformer(testDeployGVR), "old deployment informer should be stopped after nodeID reuse")
 	assert.NotNil(t, coord.watches.GetInformer(testServiceGVR), "new service informer should be running")
@@ -476,7 +476,7 @@ func TestMixedScalarAndCollection_RemoveParentGVR(t *testing.T) {
 		Name:      "d1",
 		Namespace: "default",
 	}))
-	w1.Done()
+	w1.Done(true)
 
 	// Instance 2: collection watch on configmaps.
 	w2 := coord.ForInstance(testParentGVR, inst2)
@@ -487,7 +487,7 @@ func TestMixedScalarAndCollection_RemoveParentGVR(t *testing.T) {
 		Namespace: "default",
 		Selector:  selector,
 	}))
-	w2.Done()
+	w2.Done(true)
 
 	assert.Equal(t, 2, coord.watches.ActiveWatchCount(), "expected 2 active watches (deployment + configmap)")
 
@@ -516,7 +516,7 @@ func TestDuplicateCollectionRegistration_Idempotent(t *testing.T) {
 		Namespace: "default",
 		Selector:  selector,
 	}))
-	watcher.Done()
+	watcher.Done(true)
 
 	// Should only have 1 collection entry, not 2.
 	_, collection := coord.WatchRequestCount()
@@ -553,7 +553,7 @@ func TestScalarAndCollectionDedup(t *testing.T) {
 		Namespace: "default",
 		Selector:  selector,
 	}))
-	watcher.Done()
+	watcher.Done(true)
 
 	// An event matching both scalar and collection should enqueue only once.
 	coord.RouteEvent(Event{
@@ -579,7 +579,7 @@ func TestCollectionWatch_SelectorChange(t *testing.T) {
 		Namespace: "default",
 		Selector:  selectorV1,
 	}))
-	w1.Done()
+	w1.Done(true)
 
 	// Cycle 2: same nodeID, different selector (app=v2).
 	w2 := coord.ForInstance(testParentGVR, instance)
@@ -590,7 +590,7 @@ func TestCollectionWatch_SelectorChange(t *testing.T) {
 		Namespace: "default",
 		Selector:  selectorV2,
 	}))
-	w2.Done()
+	w2.Done(true)
 
 	// Old selector should not match.
 	coord.RouteEvent(Event{
@@ -629,7 +629,7 @@ func TestRouteEvent_OldLabelsMatch(t *testing.T) {
 		Namespace: "default",
 		Selector:  selector,
 	}))
-	watcher.Done()
+	watcher.Done(true)
 
 	// Update event: new labels no longer match, but old labels did.
 	// Should still trigger re-reconciliation (label-loss detection).
@@ -652,7 +652,7 @@ func TestWatchRequestCount(t *testing.T) {
 	require.NoError(t, watcher.Watch(WatchRequest{NodeID: "deploy", GVR: testDeployGVR, Name: "d1", Namespace: "default"}))
 	selector, _ := labels.Parse("app=test")
 	require.NoError(t, watcher.Watch(WatchRequest{NodeID: "configs", GVR: testCmGVR, Namespace: "default", Selector: selector}))
-	watcher.Done()
+	watcher.Done(true)
 
 	scalar, collection := coord.WatchRequestCount()
 	assert.Equal(t, 1, scalar)
@@ -672,7 +672,8 @@ func TestNoopInstanceWatcher(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Done should not panic.
-	noop.Done()
+	noop.Done(true)
+	noop.Done(false)
 }
 
 func TestRemoveInstance_NonExistent(t *testing.T) {
@@ -688,8 +689,158 @@ func TestDoneInstance_NoState(t *testing.T) {
 
 	// Calling Done on a watcher that never called Watch should not panic.
 	watcher := coord.ForInstance(testParentGVR, types.NamespacedName{Name: "empty", Namespace: "default"})
-	watcher.Done()
+	watcher.Done(true)
 	assert.Equal(t, 0, coord.InstanceWatchCount())
+}
+
+func TestAbortInstance_RollsBackFailedCycleTargetChange(t *testing.T) {
+	coord, recorder := newTestCoordinator(t)
+	instance := types.NamespacedName{Name: "my-app", Namespace: "default"}
+
+	w1 := coord.ForInstance(testParentGVR, instance)
+	require.NoError(t, w1.Watch(WatchRequest{
+		NodeID:    "dependency",
+		GVR:       testDeployGVR,
+		Name:      "d1",
+		Namespace: "default",
+	}))
+	w1.Done(true)
+
+	w2 := coord.ForInstance(testParentGVR, instance)
+	require.NoError(t, w2.Watch(WatchRequest{
+		NodeID:    "dependency",
+		GVR:       testServiceGVR,
+		Name:      "s1",
+		Namespace: "default",
+	}))
+	w2.Done(false)
+
+	coord.RouteEvent(Event{Type: EventUpdate, GVR: testServiceGVR, Name: "s1", Namespace: "default"})
+	assert.Equal(t, 0, recorder.count(), "aborted target change should not stay active")
+
+	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
+	assert.Equal(t, 1, recorder.count(), "previous committed watch should remain active after abort")
+
+	assert.NotNil(t, coord.watches.GetInformer(testDeployGVR), "previous informer should stay running")
+	assert.Nil(t, coord.watches.GetInformer(testServiceGVR), "orphaned failed-cycle informer should be stopped")
+
+	scalar, collection := coord.WatchRequestCount()
+	assert.Equal(t, 1, scalar)
+	assert.Equal(t, 0, collection)
+}
+
+func TestAbortInstance_SameTargetKeepsPreviousWatch(t *testing.T) {
+	coord, recorder := newTestCoordinator(t)
+	instance := types.NamespacedName{Name: "my-app", Namespace: "default"}
+
+	w1 := coord.ForInstance(testParentGVR, instance)
+	require.NoError(t, w1.Watch(WatchRequest{
+		NodeID:    "dependency",
+		GVR:       testDeployGVR,
+		Name:      "d1",
+		Namespace: "default",
+	}))
+	w1.Done(true)
+
+	w2 := coord.ForInstance(testParentGVR, instance)
+	require.NoError(t, w2.Watch(WatchRequest{
+		NodeID:    "dependency",
+		GVR:       testDeployGVR,
+		Name:      "d1",
+		Namespace: "default",
+	}))
+	w2.Done(false)
+
+	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
+	assert.Equal(t, 1, recorder.count(), "aborting an unchanged request must not drop the previous watch")
+
+	scalar, collection := coord.WatchRequestCount()
+	assert.Equal(t, 1, scalar)
+	assert.Equal(t, 0, collection)
+}
+
+func TestAbortInstance_DoesNotPromoteFailedCurrentOnLaterSuccess(t *testing.T) {
+	coord, recorder := newTestCoordinator(t)
+	instance := types.NamespacedName{Name: "my-app", Namespace: "default"}
+
+	w1 := coord.ForInstance(testParentGVR, instance)
+	require.NoError(t, w1.Watch(WatchRequest{
+		NodeID:    "dependency",
+		GVR:       testDeployGVR,
+		Name:      "d1",
+		Namespace: "default",
+	}))
+	w1.Done(true)
+
+	w2 := coord.ForInstance(testParentGVR, instance)
+	require.NoError(t, w2.Watch(WatchRequest{
+		NodeID:    "dependency",
+		GVR:       testServiceGVR,
+		Name:      "s1",
+		Namespace: "default",
+	}))
+	w2.Done(false)
+
+	w3 := coord.ForInstance(testParentGVR, instance)
+	require.NoError(t, w3.Watch(WatchRequest{
+		NodeID:    "dependency",
+		GVR:       testDeployGVR,
+		Name:      "d1",
+		Namespace: "default",
+	}))
+	w3.Done(true)
+
+	coord.RouteEvent(Event{Type: EventUpdate, GVR: testServiceGVR, Name: "s1", Namespace: "default"})
+	assert.Equal(t, 0, recorder.count(), "aborted requests must not be committed by a later successful Done")
+
+	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
+	assert.Equal(t, 1, recorder.count(), "successful cycle should keep only the committed watch")
+}
+
+func TestAbortInstance_RollsBackCollectionSelectorChange(t *testing.T) {
+	coord, recorder := newTestCoordinator(t)
+	instance := types.NamespacedName{Name: "my-app", Namespace: "default"}
+
+	selectorV1, err := labels.Parse("app=v1")
+	require.NoError(t, err)
+	selectorV2, err := labels.Parse("app=v2")
+	require.NoError(t, err)
+
+	w1 := coord.ForInstance(testParentGVR, instance)
+	require.NoError(t, w1.Watch(WatchRequest{
+		NodeID:    "configs",
+		GVR:       testCmGVR,
+		Namespace: "default",
+		Selector:  selectorV1,
+	}))
+	w1.Done(true)
+
+	w2 := coord.ForInstance(testParentGVR, instance)
+	require.NoError(t, w2.Watch(WatchRequest{
+		NodeID:    "configs",
+		GVR:       testCmGVR,
+		Namespace: "default",
+		Selector:  selectorV2,
+	}))
+	w2.Done(false)
+
+	coord.RouteEvent(Event{
+		Type:      EventUpdate,
+		GVR:       testCmGVR,
+		Name:      "cm-v2",
+		Namespace: "default",
+		Labels:    map[string]string{"app": "v2"},
+	})
+	assert.Equal(t, 0, recorder.count(), "aborted selector change should not stay active")
+
+	coord.RouteEvent(Event{
+		Type:      EventUpdate,
+		GVR:       testCmGVR,
+		Name:      "cm-v1",
+		Namespace: "default",
+		Labels:    map[string]string{"app": "v1"},
+	})
+	assert.Equal(t, 1, recorder.count(), "previous committed selector should remain active after abort")
 }
 
 func TestAddWatch_EnsureWatchSyncError(t *testing.T) {

--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -212,7 +212,7 @@ func TestChildCleanup_DoesNotStopParentInformer(t *testing.T) {
 		Name:      "target",
 		Namespace: "default",
 	}))
-	watcher.Done()
+	watcher.Done(true)
 
 	dc.coordinator.RemoveInstance(consumerParentGVR, instance)
 	assert.NotNil(t, dc.watches.GetInformer(parentGVR), "child cleanup must not stop a registered parent informer")
@@ -246,7 +246,7 @@ func TestDeregister_KeepsInformerWhileChildWatchRemains(t *testing.T) {
 		Name:      "target",
 		Namespace: "default",
 	}))
-	watcher.Done()
+	watcher.Done(true)
 
 	require.NoError(t, dc.Deregister(ctx, parentGVR))
 	assert.NotNil(t, dc.watches.GetInformer(parentGVR), "child watch should keep informer alive after parent deregister")


### PR DESCRIPTION
note reviewers: review after https://github.com/kubernetes-sigs/kro/pull/1105

The watch coordinator activates watch requests before reconciliation
finishes so instance controllers do not miss events between dependency
discovery and completion. In that model, a failed reconcile could leave
provisional requests in the routing indexes and a later successful cycle
could promote those stale requests into the committed watch set.

Make completion explicit by changing `InstanceWatcher.Done` to take a
commit flag. Successful reconciles now commit the current watch set,
while failed reconciles discard the provisional requests and keep the
previously committed watches active.

To make rollback safe, change "scalar" watch indexing to track node level
ownership in addition to the instance key. This matches the identity
already used for collection watches and lets the coordinator remove only
the provisional entries from a failed cycle without tearing down still
valid committed watches for the same instance.

This keeps the existing watch-before read behavior while preventing
failed cycle watch requests from remaining routable, being committed by
a later reconcile, or keeping orphan informers alive.

For example, if one reconcile has already committed a watch on external
resource A, and the next reconcile starts switching that node to watch
resource B but exits with a requeue before finishing, updates to B should
not enqueue the instance and the later successful reconcile should not
accidentally commit B from that failed cycle. Only the previously
committed watch on A should remain active until a successful reconcile
commits the switch.