### PR TITLE
feat(cel): add deterministic seeded integer generation function

### DIFF
--- a/pkg/cel/library/random.go
+++ b/pkg/cel/library/random.go
@@ -27,23 +27,24 @@ const (
 	alphanumericChars = "0123456789abcdefghijklmnopqrstuvwxyz"
 )
 
-// Random returns a CEL library that provides functions to generate random text
+// Random returns a CEL library that provides deterministic random generation
+// functions.
 //
 // Library functions:
 //
-// random.seededString() returns a CEL function that generates deterministic random
-// strings based on a seed.
+// random.seededString(length: int, seed: string) → string
 //
-// The function takes two arguments:
-// - length: an integer specifying the length of the random string to generate
-// - seed: a string used as the seed for the random string generation
-//
-// Example usage:
+// Generates a deterministic random alphanumeric string of the given length
+// using the seed. Same length and seed always produce the same string.
 //
 //	random.seededString(10, schema.metadata.uid)
 //
-// This will generate a random string of length 10 using the seed schema.metadata.uid.
-// The same length and seed will always produce the same random string.
+// random.seededInt(min: int, max: int, seed: string) → int
+//
+// Generates a deterministic random integer in [min, max) using the seed.
+// Same min, max, and seed always produce the same integer.
+//
+//	random.seededInt(30000, 32768, schema.metadata.uid)
 func Random() cel.EnvOption {
 	return cel.Lib(&randomLibrary{})
 }
@@ -63,11 +64,53 @@ func (l *randomLibrary) CompileOptions() []cel.EnvOption {
 				cel.BinaryBinding(generateDeterministicString),
 			),
 		),
+		cel.Function("random.seededInt",
+			cel.Overload("random.seededInt_int_int_string",
+				[]*cel.Type{cel.IntType, cel.IntType, cel.StringType},
+				cel.IntType,
+				cel.FunctionBinding(generateDeterministicInt),
+			),
+		),
 	}
 }
 
 func (l *randomLibrary) ProgramOptions() []cel.ProgramOption {
 	return nil
+}
+
+func generateDeterministicInt(args ...ref.Val) ref.Val {
+	if len(args) != 3 {
+		return types.NewErr("random.seededInt requires exactly 3 arguments")
+	}
+	minVal, maxVal, seed := args[0], args[1], args[2]
+
+	if minVal.Type() != types.IntType {
+		return types.NewErr("random.seededInt min must be an integer")
+	}
+	if maxVal.Type() != types.IntType {
+		return types.NewErr("random.seededInt max must be an integer")
+	}
+	if seed.Type() != types.StringType {
+		return types.NewErr("random.seededInt seed must be a string")
+	}
+
+	minInt := minVal.(types.Int).Value().(int64)
+	maxInt := maxVal.(types.Int).Value().(int64)
+	if minInt >= maxInt {
+		return types.NewErr("random.seededInt min must be less than max")
+	}
+
+	seedStr := seed.(types.String).Value().(string)
+	hash := sha256.Sum256([]byte(seedStr))
+
+	// Read first 8 bytes as uint64 for better distribution
+	v := uint64(hash[0])<<56 | uint64(hash[1])<<48 | uint64(hash[2])<<40 | uint64(hash[3])<<32 |
+		uint64(hash[4])<<24 | uint64(hash[5])<<16 | uint64(hash[6])<<8 | uint64(hash[7])
+
+	rangeSize := uint64(maxInt - minInt)
+	result := minInt + int64(v%rangeSize)
+
+	return types.Int(result)
 }
 
 func generateDeterministicString(length ref.Val, seed ref.Val) ref.Val {

--- a/pkg/cel/library/random_test.go
+++ b/pkg/cel/library/random_test.go
@@ -139,6 +139,135 @@ func TestRandomString(t *testing.T) {
 	}
 }
 
+func TestRandomInt(t *testing.T) {
+	env, err := cel.NewEnv(Random())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		expr     string
+		wantErr  bool
+		errMsg   string
+		validate func(*testing.T, int64)
+	}{
+		{
+			name: "basic range",
+			expr: "random.seededInt(0, 100, 'test-seed')",
+			validate: func(t *testing.T, result int64) {
+				assert.GreaterOrEqual(t, result, int64(0))
+				assert.Less(t, result, int64(100))
+			},
+		},
+		{
+			name: "nodeport range",
+			expr: "random.seededInt(30000, 32768, 'my-service')",
+			validate: func(t *testing.T, result int64) {
+				assert.GreaterOrEqual(t, result, int64(30000))
+				assert.Less(t, result, int64(32768))
+			},
+		},
+		{
+			name: "range of 1",
+			expr: "random.seededInt(5, 6, 'seed')",
+			validate: func(t *testing.T, result int64) {
+				assert.Equal(t, int64(5), result)
+			},
+		},
+		{
+			name: "negative range",
+			expr: "random.seededInt(-100, -50, 'seed')",
+			validate: func(t *testing.T, result int64) {
+				assert.GreaterOrEqual(t, result, int64(-100))
+				assert.Less(t, result, int64(-50))
+			},
+		},
+		{
+			name:    "min equals max",
+			expr:    "random.seededInt(5, 5, 'seed')",
+			wantErr: true,
+			errMsg:  "random.seededInt min must be less than max",
+		},
+		{
+			name:    "min greater than max",
+			expr:    "random.seededInt(10, 5, 'seed')",
+			wantErr: true,
+			errMsg:  "random.seededInt min must be less than max",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expr)
+			require.NoError(t, issues.Err())
+
+			program, err := env.Program(ast)
+			require.NoError(t, err)
+
+			out, _, err := program.Eval(map[string]interface{}{})
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+			require.NoError(t, err)
+
+			result, ok := out.Value().(int64)
+			require.True(t, ok)
+			tt.validate(t, result)
+
+			// Test determinism
+			out2, _, err := program.Eval(map[string]interface{}{})
+			require.NoError(t, err)
+			result2, ok := out2.Value().(int64)
+			require.True(t, ok)
+			assert.Equal(t, result, result2, "seededInt should be deterministic")
+
+			// Different seeds tested separately in TestRandomIntDifferentSeeds
+		})
+	}
+}
+
+func TestRandomIntDifferentSeeds(t *testing.T) {
+	env, err := cel.NewEnv(Random())
+	require.NoError(t, err)
+
+	// Same range, different seeds should (almost certainly) produce different values
+	ast1, _ := env.Compile("random.seededInt(0, 1000000, 'seed-a')")
+	ast2, _ := env.Compile("random.seededInt(0, 1000000, 'seed-b')")
+
+	prog1, _ := env.Program(ast1)
+	prog2, _ := env.Program(ast2)
+
+	out1, _, _ := prog1.Eval(map[string]interface{}{})
+	out2, _, _ := prog2.Eval(map[string]interface{}{})
+
+	assert.NotEqual(t, out1.Value().(int64), out2.Value().(int64),
+		"different seeds should produce different integers")
+}
+
+func TestRandomIntTypeErrors(t *testing.T) {
+	env, err := cel.NewEnv(Random())
+	require.NoError(t, err)
+
+	// These should fail at compile time due to type mismatch
+	typeErrCases := []struct {
+		name string
+		expr string
+	}{
+		{"string min", "random.seededInt('a', 10, 'seed')"},
+		{"string max", "random.seededInt(0, 'b', 'seed')"},
+		{"int seed", "random.seededInt(0, 10, 123)"},
+		{"missing arg", "random.seededInt(0, 10)"},
+	}
+
+	for _, tc := range typeErrCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, issues := env.Compile(tc.expr)
+			assert.Error(t, issues.Err(), "expected compile error for %s", tc.expr)
+		})
+	}
+}
+
 func TestRandomStringErrors(t *testing.T) {
 	env, err := cel.NewEnv(Random())
 	require.NoError(t, err)


### PR DESCRIPTION
The random CEL library only supported generating deterministic strings
via `random.seededString`. This adds `random.seededInt(min, max, seed)`
which generates a deterministic integer in `[min, max)` from a SHA-256
hash of the seed string. This is useful for cases like generating stable
NodePort values from a resource UID.

The implementation reads the first 8 bytes of the hash as a uint64 and
maps it into the requested range. Input validation rejects cases where
min >= max. The doc comment on `Random()` is also updated to document
both library functions in a consistent format.