### PR TITLE
fix(graph/resolver): expose schema resolver metrics on controller-runtime registry

### DIFF
--- a/pkg/graph/schema/resolver/metrics.go
+++ b/pkg/graph/schema/resolver/metrics.go
@@ -16,6 +16,7 @@ package resolver
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 var (
@@ -73,5 +74,5 @@ func MustRegister(registry prometheus.Registerer) {
 // TODO(a-hilaly): rework all kro custom metrics to use a custom registry, and
 // register them all somewhere central.
 func init() {
-	MustRegister(prometheus.DefaultRegisterer)
+	MustRegister(metrics.Registry)
 }


### PR DESCRIPTION
Register `schema_resolver_*` on controller-runtime's metrics registry.

They were using the default Prometheus registry, so they did not show up
on kro's served `/metrics` endpoint.