### PR TITLE
dynamiccontroller: replace EnsureWatch/StopWatch with keyed ownership

### DIFF
--- a/pkg/dynamiccontroller/coordinator.go
+++ b/pkg/dynamiccontroller/coordinator.go
@@ -114,6 +114,10 @@ type WatchCoordinator struct {
 	collectionIndex map[schema.GroupVersionResource][]collectionEntry
 }
 
+// coordinatorWatchKey is the ownership key the coordinator uses when
+// calling Acquire/Release on the WatchManager.
+const coordinatorWatchKey = "coordinator"
+
 // NewWatchCoordinator creates a new WatchCoordinator.
 func NewWatchCoordinator(watches *WatchManager, enqueue EnqueueFunc, log logr.Logger) *WatchCoordinator {
 	return &WatchCoordinator{
@@ -174,11 +178,10 @@ func (c *WatchCoordinator) addWatch(key instanceKey, req WatchRequest) error {
 	gvr := req.GVR
 	c.mu.Unlock()
 
-	// Ensure an informer is running for this GVR.
-	// Called outside the coordinator lock to avoid holding it while
-	// the WatchManager acquires its own lock.
-	if err := c.watches.EnsureWatch(gvr); err != nil {
-		c.log.Error(err, "Failed to ensure watch", "gvr", gvr)
+	// Acquire is idempotent per key — safe to call without checking
+	// whether the coordinator already holds this GVR.
+	if _, err := c.watches.Acquire(gvr, coordinatorWatchKey); err != nil {
+		c.log.Error(err, "Failed to acquire watch", "gvr", gvr)
 	}
 
 	return nil
@@ -424,13 +427,23 @@ func (c *WatchCoordinator) findOrphanedGVRsLocked(gvrs []schema.GroupVersionReso
 	return orphaned
 }
 
-// stopWatches stops informers for the given GVRs. Must be called without
-// c.mu held to avoid holding the coordinator lock while the WatchManager
-// acquires its own lock.
+// stopWatches releases the coordinator's references for the given GVRs.
+// Re-validates orphan status under the lock to prevent races where a
+// concurrent addWatch re-populates the index between orphan detection
+// and this call.
 func (c *WatchCoordinator) stopWatches(gvrs []schema.GroupVersionResource) {
+	c.mu.Lock()
+	var confirmed []schema.GroupVersionResource
 	for _, gvr := range gvrs {
-		c.watches.StopWatch(gvr)
-		c.log.V(1).Info("Stopped orphaned child watch", "gvr", gvr)
+		if len(c.scalarIndex[gvr]) == 0 && len(c.collectionIndex[gvr]) == 0 {
+			confirmed = append(confirmed, gvr)
+		}
+	}
+	c.mu.Unlock()
+
+	for _, gvr := range confirmed {
+		c.watches.Release(gvr, coordinatorWatchKey)
+		c.log.V(1).Info("Released orphaned child watch", "gvr", gvr)
 	}
 }
 

--- a/pkg/dynamiccontroller/coordinator_test.go
+++ b/pkg/dynamiccontroller/coordinator_test.go
@@ -299,9 +299,10 @@ func TestStopOrphanedWatch_RemoveInstance(t *testing.T) {
 	coord.RemoveInstance(testParentGVR, instance)
 	assert.Equal(t, 0, coord.watches.ActiveWatchCount(), "expected 0 active watches after removing last requestor")
 
-	// EnsureWatch can re-create it.
-	assert.NoError(t, coord.watches.EnsureWatch(testDeployGVR))
-	assert.Equal(t, 1, coord.watches.ActiveWatchCount(), "expected watch to be re-created after EnsureWatch")
+	// Acquire can re-create it.
+	_, err := coord.watches.Acquire(testDeployGVR, "test")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, coord.watches.ActiveWatchCount(), "expected watch to be re-created after Acquire")
 }
 
 func TestStopOrphanedWatch_DoneCleanup(t *testing.T) {
@@ -692,7 +693,7 @@ func TestDoneInstance_NoState(t *testing.T) {
 	assert.Equal(t, 0, coord.InstanceWatchCount())
 }
 
-func TestAddWatch_EnsureWatchSyncError(t *testing.T) {
+func TestAddWatch_AcquireSyncError(t *testing.T) {
 	log := zap.New(zap.UseDevMode(true))
 
 	scheme := runtime.NewScheme()
@@ -712,14 +713,14 @@ func TestAddWatch_EnsureWatchSyncError(t *testing.T) {
 
 	watcher := coord.ForInstance(testParentGVR, instance)
 
-	// EnsureWatch will fail sync but addWatch logs and returns nil.
+	// Acquire will fail sync but addWatch logs and returns nil.
 	err := watcher.Watch(WatchRequest{
 		NodeID:    "deploy",
 		GVR:       testDeployGVR,
 		Name:      "d1",
 		Namespace: "default",
 	})
-	assert.NoError(t, err) // addWatch does not propagate EnsureWatch errors
+	assert.NoError(t, err) // addWatch does not propagate Acquire errors
 
 	wm.Shutdown()
 }
@@ -738,6 +739,59 @@ func TestRemoveInstance_ScalarIndexCleanup(t *testing.T) {
 	scalar, collection := coord.WatchRequestCount()
 	assert.Equal(t, 0, scalar)
 	assert.Equal(t, 0, collection)
+}
+
+func TestConcurrentAddWatch_SameGVR(t *testing.T) {
+	log := zap.New(zap.UseDevMode(true))
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1.AddMetaToScheme(scheme))
+	client := fake.NewSimpleMetadataClient(scheme)
+
+	recorder := &enqueueRecorder{}
+	var coord *WatchCoordinator
+	wm := NewWatchManager(client, 1*time.Hour, func(event Event) {
+		if coord != nil {
+			coord.RouteEvent(event)
+		}
+	}, log)
+
+	coord = NewWatchCoordinator(wm, recorder.enqueue, log)
+
+	// Launch N goroutines that each add a watch for the same GVR via
+	// different instances. Acquire is idempotent per key, so even though
+	// multiple goroutines call Acquire concurrently, the coordinator
+	// holds exactly one ownership entry per GVR.
+	const n = 10
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			inst := types.NamespacedName{
+				Name:      fmt.Sprintf("app-%d", idx),
+				Namespace: "default",
+			}
+			w := coord.ForInstance(testParentGVR, inst)
+			_ = w.Watch(WatchRequest{
+				NodeID:    "deployment",
+				GVR:       testDeployGVR,
+				Name:      fmt.Sprintf("d-%d", idx),
+				Namespace: "default",
+			})
+			w.Done()
+		}(i)
+	}
+	wg.Wait()
+
+	// Should have exactly 1 active watch (shared GVR).
+	assert.Equal(t, 1, wm.ActiveWatchCount(),
+		"expected exactly 1 active watch for the shared GVR")
+
+	// Remove all instances — watch should stop cleanly with no leaked refs.
+	coord.RemoveParentGVR(testParentGVR)
+	assert.Equal(t, 0, wm.ActiveWatchCount(),
+		"expected 0 active watches after removing all instances (no ref leak)")
 }
 
 func TestRemoveParentGVR_NonExistent(t *testing.T) {

--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -80,6 +80,10 @@ import (
 	"github.com/kubernetes-sigs/kro/pkg/requeue"
 )
 
+// parentWatchKey is the ownership key the DynamicController uses when
+// calling Acquire/Release on the WatchManager for parent GVR watches.
+const parentWatchKey = "parent"
+
 // Config holds the configuration for DynamicController
 type Config struct {
 	// Workers specifies the number of workers processing items from the queue
@@ -354,8 +358,8 @@ func (dc *DynamicController) Register(
 
 	// Create parent watch if it doesn't exist.
 	if _, exists := dc.parentWatches[parent]; !exists {
-		// Ensure informer is running and wait for cache sync.
-		if err := dc.watches.EnsureWatch(parent); err != nil {
+		// Acquire a reference on the informer and wait for cache sync.
+		if _, err := dc.watches.Acquire(parent, parentWatchKey); err != nil {
 			dc.handlers.Delete(parent)
 			return fmt.Errorf("add parent handler %s: %w", parent, err)
 		}
@@ -363,7 +367,8 @@ func (dc *DynamicController) Register(
 		inf := dc.watches.GetInformer(parent)
 		if inf == nil {
 			dc.handlers.Delete(parent)
-			return fmt.Errorf("add parent handler %s: informer not found after EnsureWatch", parent)
+			dc.watches.Release(parent, parentWatchKey)
+			return fmt.Errorf("add parent handler %s: informer not found after Acquire", parent)
 		}
 
 		// Register event handler directly on the parent informer.
@@ -381,7 +386,7 @@ func (dc *DynamicController) Register(
 		reg, err := inf.AddEventHandler(parentHandler)
 		if err != nil {
 			dc.handlers.Delete(parent)
-			dc.watches.StopWatch(parent)
+			dc.watches.Release(parent, parentWatchKey)
 			return fmt.Errorf("add parent handler %s: %w", parent, err)
 		}
 		dc.parentWatches[parent] = reg
@@ -447,8 +452,10 @@ func (dc *DynamicController) Deregister(_ context.Context, parent schema.GroupVe
 		}
 		delete(dc.parentWatches, parent)
 
-		// Stop the parent informer — it's no longer needed.
-		dc.watches.StopWatch(parent)
+		// Release the parent's reference. If the coordinator still holds
+		// a reference (e.g. a child watches the same GVR), the informer
+		// stays alive until all owners have released.
+		dc.watches.Release(parent, parentWatchKey)
 
 		gvrCount.Dec()
 		handlerDetachTotal.WithLabelValues("parent").Inc()

--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -495,7 +495,114 @@ func TestKeyFromGVR(t *testing.T) {
 	}
 }
 
-func TestRegister_EnsureWatchSyncError(t *testing.T) {
+// TestChildCleanup_DoesNotStopParentInformer verifies that when a child/externalRef
+// watch shares the same GVR as a parent watch, cleaning up the child's coordinator
+// reference does not stop the parent's informer. This is the core bug that keyed
+// ownership prevents: without separate ownership keys, releasing the coordinator's
+// reference would kill the parent informer.
+func TestChildCleanup_DoesNotStopParentInformer(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1.AddMetaToScheme(scheme))
+	client := fake.NewSimpleMetadataClient(scheme)
+	mapper := meta.NewDefaultRESTMapper(scheme.PreferredVersionAllGroups())
+
+	// Producer RGD's parent GVR — also used as an externalRef by the consumer.
+	producerGVR := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "producers"}
+	// Consumer RGD's parent GVR.
+	consumerGVR := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "consumers"}
+
+	dc := NewDynamicController(noopLogger(), testConfig(), client, mapper)
+	ctx := t.Context()
+	go func() { _ = dc.Start(ctx) }()
+	require.Eventually(t, func() bool { return dc.ctx.Load() != nil }, 2*time.Second, 10*time.Millisecond)
+
+	noopHandler := Handler(func(_ context.Context, _ controllerruntime.Request) error { return nil })
+
+	// Register producer as a parent — acquires informer with key "parent".
+	require.NoError(t, dc.Register(ctx, producerGVR, noopHandler))
+	assert.NotNil(t, dc.watches.GetInformer(producerGVR), "producer informer should be running")
+
+	// Register consumer as a parent.
+	require.NoError(t, dc.Register(ctx, consumerGVR, noopHandler))
+
+	// Simulate consumer's instance reconciler watching producerGVR as an externalRef.
+	// This goes through the coordinator, which acquires with key "coordinator".
+	consumerInstance := types.NamespacedName{Name: "my-consumer", Namespace: "default"}
+	watcher := dc.coordinator.ForInstance(consumerGVR, consumerInstance)
+	require.NoError(t, watcher.Watch(WatchRequest{
+		NodeID:    "producer-ref",
+		GVR:       producerGVR,
+		Name:      "my-producer",
+		Namespace: "default",
+	}))
+	watcher.Done()
+
+	// producerGVR now has two owners: "parent" and "coordinator".
+	assert.NotNil(t, dc.watches.GetInformer(producerGVR), "producer informer should still be running with two owners")
+
+	// Consumer instance is deleted — coordinator releases its reference.
+	dc.coordinator.RemoveInstance(consumerGVR, consumerInstance)
+
+	// The producer's parent informer MUST survive because the "parent" key still owns it.
+	assert.NotNil(t, dc.watches.GetInformer(producerGVR),
+		"producer informer must survive child cleanup — parent key still holds ownership")
+	// 2 active watches: producerGVR (parent) + consumerGVR (parent).
+	assert.Equal(t, 2, dc.watches.ActiveWatchCount(),
+		"expected both parent informers still active")
+}
+
+// TestDeregister_KeepsInformerWhileChildWatchRemains verifies the reverse scenario:
+// when a parent is deregistered but the coordinator still holds a reference to the
+// same GVR (because another RGD's instance watches it as an externalRef), the
+// informer stays alive until the coordinator also releases.
+func TestDeregister_KeepsInformerWhileChildWatchRemains(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1.AddMetaToScheme(scheme))
+	client := fake.NewSimpleMetadataClient(scheme)
+	mapper := meta.NewDefaultRESTMapper(scheme.PreferredVersionAllGroups())
+
+	// Shared GVR: acts as both a parent for producerRGD and an externalRef for consumerRGD.
+	sharedGVR := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "shared"}
+	consumerGVR := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "consumers"}
+
+	dc := NewDynamicController(noopLogger(), testConfig(), client, mapper)
+	ctx := t.Context()
+	go func() { _ = dc.Start(ctx) }()
+	require.Eventually(t, func() bool { return dc.ctx.Load() != nil }, 2*time.Second, 10*time.Millisecond)
+
+	noopHandler := Handler(func(_ context.Context, _ controllerruntime.Request) error { return nil })
+
+	// Register sharedGVR as a parent.
+	require.NoError(t, dc.Register(ctx, sharedGVR, noopHandler))
+
+	// Register consumer and have an instance watch sharedGVR via coordinator.
+	require.NoError(t, dc.Register(ctx, consumerGVR, noopHandler))
+	consumerInstance := types.NamespacedName{Name: "my-consumer", Namespace: "default"}
+	watcher := dc.coordinator.ForInstance(consumerGVR, consumerInstance)
+	require.NoError(t, watcher.Watch(WatchRequest{
+		NodeID:    "shared-ref",
+		GVR:       sharedGVR,
+		Name:      "my-shared",
+		Namespace: "default",
+	}))
+	watcher.Done()
+
+	// Deregister sharedGVR as parent — releases "parent" key.
+	require.NoError(t, dc.Deregister(ctx, sharedGVR))
+
+	// Informer MUST survive because coordinator still holds "coordinator" key.
+	assert.NotNil(t, dc.watches.GetInformer(sharedGVR),
+		"informer must survive parent deregister — coordinator still holds ownership")
+
+	// Now clean up the coordinator reference.
+	dc.coordinator.RemoveInstance(consumerGVR, consumerInstance)
+
+	// Now the informer should stop — no owners remain.
+	assert.Nil(t, dc.watches.GetInformer(sharedGVR),
+		"informer should stop after all owners release")
+}
+
+func TestRegister_AcquireSyncError(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, v1.AddMetaToScheme(scheme))
 

--- a/pkg/dynamiccontroller/watch.go
+++ b/pkg/dynamiccontroller/watch.go
@@ -30,9 +30,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// WatchManager manages informer lifecycle per GVR.
-// Informers start lazily on first use and stay alive until Shutdown().
-// This avoids all start/stop races and lock-while-blocking issues.
+// WatchManager manages informer lifecycle per GVR using keyed ownership.
+// Callers Acquire a GVR with a unique key to start (or reuse) an informer
+// and Release it when done. Acquire is idempotent per key — calling it
+// twice with the same key is a no-op. The informer stops when all owners
+// have Released it. Shutdown() force-stops all informers regardless of
+// outstanding owners.
 type WatchManager struct {
 	mu      sync.Mutex
 	watches map[schema.GroupVersionResource]*gvrWatch
@@ -44,7 +47,7 @@ type WatchManager struct {
 	// Set at construction time; never nil.
 	onEvent EventHandler
 
-	// SyncTimeout is the maximum time to wait for cache sync in EnsureWatch.
+	// SyncTimeout is the maximum time to wait for cache sync in Acquire.
 	// Zero means use the default (30s).
 	SyncTimeout time.Duration
 
@@ -54,11 +57,12 @@ type WatchManager struct {
 }
 
 // gvrWatch wraps a single SharedIndexInformer for one GVR.
-// Once started, the informer runs until Shutdown().
+// The informer runs until all owners have Released it or Shutdown() is called.
 type gvrWatch struct {
 	gvr      schema.GroupVersionResource
 	informer cache.SharedIndexInformer
 	stopCh   chan struct{}
+	owners   map[string]struct{} // keyed ownership set
 	log      logr.Logger
 }
 
@@ -76,19 +80,25 @@ func NewWatchManager(client metadata.Interface, resync time.Duration, onEvent Ev
 	return wm
 }
 
-// EnsureWatch idempotently ensures an informer is running for the given GVR.
-// If the informer is already running, this is a no-op. After starting the
-// informer it waits for the initial cache sync with a timeout and returns an
-// error if the sync does not complete.
-func (m *WatchManager) EnsureWatch(gvr schema.GroupVersionResource) error {
+// Acquire adds the given key to the ownership set for the GVR and ensures
+// the informer is running. Acquire is idempotent: calling it again with the
+// same key is a no-op and returns (false, nil). Returns (true, nil) when the
+// key was newly added. The informer stops only when all owners Release it.
+func (m *WatchManager) Acquire(gvr schema.GroupVersionResource, key string) (bool, error) {
 	m.mu.Lock()
 
-	if _, ok := m.watches[gvr]; ok {
+	if w, ok := m.watches[gvr]; ok {
+		if _, held := w.owners[key]; held {
+			m.mu.Unlock()
+			return false, nil
+		}
+		w.owners[key] = struct{}{}
 		m.mu.Unlock()
-		return nil
+		return true, nil
 	}
 
 	w := m.newWatch(gvr)
+	w.owners[key] = struct{}{}
 	m.watches[gvr] = w
 
 	go w.informer.Run(w.stopCh)
@@ -102,28 +112,37 @@ func (m *WatchManager) EnsureWatch(gvr schema.GroupVersionResource) error {
 	defer cancel()
 
 	if !cache.WaitForCacheSync(syncCtx.Done(), w.informer.HasSynced) {
-		// Stop and remove the broken watch so a future EnsureWatch can retry
-		// with a fresh informer instead of returning early for a registered
-		// but non-functional watch.
-		m.StopWatch(gvr)
-		return fmt.Errorf("cache sync timeout for %s", gvr)
+		// Remove our key rather than force-removing. A concurrent
+		// Acquire may have added another key while we were waiting for
+		// sync, so force-removing would kill their watch.
+		m.mu.Lock()
+		delete(w.owners, key)
+		if len(w.owners) == 0 {
+			close(w.stopCh)
+			delete(m.watches, gvr)
+		}
+		m.mu.Unlock()
+		return false, fmt.Errorf("cache sync timeout for %s", gvr)
 	}
-	return nil
+	return true, nil
 }
 
-// StopWatch stops the informer for the given GVR and removes it from the
-// watches map. It is non-blocking and idempotent. A subsequent EnsureWatch
-// for the same GVR will create a fresh informer.
-func (m *WatchManager) StopWatch(gvr schema.GroupVersionResource) {
+// Release removes the given key from the ownership set for the GVR.
+// If the key is not present, this is a no-op. When the ownership set
+// becomes empty, the informer is stopped and removed.
+func (m *WatchManager) Release(gvr schema.GroupVersionResource, key string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	w, ok := m.watches[gvr]
 	if !ok {
 		return
 	}
-	close(w.stopCh)
-	delete(m.watches, gvr)
-	m.log.V(1).Info("Watch stopped", "gvr", gvr)
+	delete(w.owners, key)
+	if len(w.owners) == 0 {
+		close(w.stopCh)
+		delete(m.watches, gvr)
+		m.log.V(1).Info("Watch stopped", "gvr", gvr)
+	}
 }
 
 // GetInformer returns the SharedIndexInformer for the given GVR, or nil
@@ -184,6 +203,7 @@ func (m *WatchManager) newWatch(gvr schema.GroupVersionResource) *gvrWatch {
 		gvr:      gvr,
 		informer: inf,
 		stopCh:   make(chan struct{}),
+		owners:   make(map[string]struct{}),
 		log:      m.log.WithValues("gvr", gvr.String()),
 	}
 

--- a/pkg/dynamiccontroller/watch_test.go
+++ b/pkg/dynamiccontroller/watch_test.go
@@ -40,38 +40,41 @@ func newTestWatchManager(t *testing.T) *WatchManager {
 	return NewWatchManager(client, 1*time.Hour, func(Event) {}, noopLogger())
 }
 
-func TestStopWatch_Idempotent(t *testing.T) {
+func TestRelease_Idempotent(t *testing.T) {
 	wm := newTestWatchManager(t)
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	assert.NoError(t, wm.EnsureWatch(gvr))
+	_, err := wm.Acquire(gvr, "test")
+	assert.NoError(t, err)
 	assert.Equal(t, 1, wm.ActiveWatchCount())
 
-	wm.StopWatch(gvr)
+	wm.Release(gvr, "test")
 	assert.Equal(t, 0, wm.ActiveWatchCount())
 
-	// Second StopWatch should not panic and count stays 0.
-	wm.StopWatch(gvr)
+	// Second Release should not panic and count stays 0.
+	wm.Release(gvr, "test")
 	assert.Equal(t, 0, wm.ActiveWatchCount())
 }
 
-func TestStopWatch_ThenEnsureWatch_CreatesFresh(t *testing.T) {
+func TestRelease_ThenAcquire_CreatesFresh(t *testing.T) {
 	wm := newTestWatchManager(t)
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	assert.NoError(t, wm.EnsureWatch(gvr))
+	_, err := wm.Acquire(gvr, "test")
+	assert.NoError(t, err)
 	inf1 := wm.GetInformer(gvr)
 	assert.NotNil(t, inf1)
 
-	wm.StopWatch(gvr)
+	wm.Release(gvr, "test")
 	assert.Nil(t, wm.GetInformer(gvr))
 
-	assert.NoError(t, wm.EnsureWatch(gvr))
+	_, err = wm.Acquire(gvr, "test")
+	assert.NoError(t, err)
 	inf2 := wm.GetInformer(gvr)
 	assert.NotNil(t, inf2)
 
 	// Must be a new informer instance, not the old one.
-	assert.NotSame(t, inf1, inf2, "expected fresh informer after StopWatch + EnsureWatch")
+	assert.NotSame(t, inf1, inf2, "expected fresh informer after Release + Acquire")
 }
 
 func TestDeleteFunc_Tombstone(t *testing.T) {
@@ -111,20 +114,53 @@ func TestDeleteFunc_Tombstone(t *testing.T) {
 	assert.Equal(t, map[string]string{"app": "test"}, received[0].Labels)
 }
 
-func TestEnsureWatch_Idempotent(t *testing.T) {
+func TestAcquire_MultipleOwners(t *testing.T) {
 	wm := newTestWatchManager(t)
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	assert.NoError(t, wm.EnsureWatch(gvr))
+	_, err := wm.Acquire(gvr, "owner-a")
+	assert.NoError(t, err)
 	inf1 := wm.GetInformer(gvr)
 	assert.NotNil(t, inf1)
 	assert.Equal(t, 1, wm.ActiveWatchCount())
 
-	// Second call is a no-op; same informer, same count.
-	assert.NoError(t, wm.EnsureWatch(gvr))
+	// Second Acquire with a different key returns the same informer.
+	_, err = wm.Acquire(gvr, "owner-b")
+	assert.NoError(t, err)
 	inf2 := wm.GetInformer(gvr)
 	assert.Same(t, inf1, inf2)
 	assert.Equal(t, 1, wm.ActiveWatchCount())
+
+	// Releasing one owner does not stop the informer.
+	wm.Release(gvr, "owner-a")
+	assert.Equal(t, 1, wm.ActiveWatchCount(), "informer should still be running with one owner remaining")
+	assert.NotNil(t, wm.GetInformer(gvr))
+
+	// Releasing last owner stops the informer.
+	wm.Release(gvr, "owner-b")
+	assert.Equal(t, 0, wm.ActiveWatchCount(), "informer should stop when all owners are released")
+	assert.Nil(t, wm.GetInformer(gvr))
+}
+
+func TestAcquire_Idempotent(t *testing.T) {
+	wm := newTestWatchManager(t)
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+	added, err := wm.Acquire(gvr, "test")
+	assert.NoError(t, err)
+	assert.True(t, added, "first Acquire should return true")
+
+	// Same key again — idempotent, returns false.
+	added, err = wm.Acquire(gvr, "test")
+	assert.NoError(t, err)
+	assert.False(t, added, "duplicate Acquire with same key should return false")
+
+	assert.Equal(t, 1, wm.ActiveWatchCount())
+
+	// Single Release is sufficient since the key was only counted once.
+	wm.Release(gvr, "test")
+	assert.Equal(t, 0, wm.ActiveWatchCount(), "informer should stop after single Release")
+	assert.Nil(t, wm.GetInformer(gvr))
 }
 
 func TestShutdown(t *testing.T) {
@@ -132,8 +168,8 @@ func TestShutdown(t *testing.T) {
 	gvr1 := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 	gvr2 := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
 
-	assert.NoError(t, wm.EnsureWatch(gvr1))
-	assert.NoError(t, wm.EnsureWatch(gvr2))
+	_, _ = wm.Acquire(gvr1, "test")
+	_, _ = wm.Acquire(gvr2, "test")
 	assert.Equal(t, 2, wm.ActiveWatchCount())
 
 	wm.Shutdown()
@@ -245,7 +281,7 @@ func TestNewWatch_WatchErrorHandler(t *testing.T) {
 
 	wm := NewWatchManager(failClient, 1*time.Hour, func(e Event) {}, noopLogger())
 	wm.SyncTimeout = 500 * time.Millisecond
-	_ = wm.EnsureWatch(gvr)
+	_, _ = wm.Acquire(gvr, "test")
 
 	// Give the informer goroutine time to hit the error handler.
 	time.Sleep(200 * time.Millisecond)
@@ -320,7 +356,7 @@ func TestUpdateFunc_OldLabels(t *testing.T) {
 	assert.Equal(t, map[string]string{"team": "alpha"}, received[0].OldLabels)
 }
 
-func TestEnsureWatch_SyncTimeout(t *testing.T) {
+func TestAcquire_SyncTimeout(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = v1.AddMetaToScheme(scheme)
 	client := fake.NewSimpleMetadataClient(scheme)
@@ -333,15 +369,15 @@ func TestEnsureWatch_SyncTimeout(t *testing.T) {
 	wm.SyncTimeout = 200 * time.Millisecond
 
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
-	err := wm.EnsureWatch(gvr)
+	_, err := wm.Acquire(gvr, "test")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cache sync timeout")
 
-	// Broken watch should be cleaned up so a future EnsureWatch can retry.
+	// Broken watch should be cleaned up so a future Acquire can retry.
 	assert.Equal(t, 0, wm.ActiveWatchCount())
 }
 
-func TestEnsureWatch_SyncTimeout_RetrySucceeds(t *testing.T) {
+func TestAcquire_SyncTimeout_RetrySucceeds(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = v1.AddMetaToScheme(scheme)
 	client := fake.NewSimpleMetadataClient(scheme)
@@ -361,40 +397,41 @@ func TestEnsureWatch_SyncTimeout_RetrySucceeds(t *testing.T) {
 
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	err := wm.EnsureWatch(gvr)
+	_, err := wm.Acquire(gvr, "test")
 	assert.Error(t, err)
 	assert.Equal(t, 0, wm.ActiveWatchCount(), "broken watch should be removed")
 
 	// Second call: lists succeed → should create fresh informer and sync.
 	failList.Store(false)
 	wm.SyncTimeout = 5 * time.Second
-	err = wm.EnsureWatch(gvr)
+	_, err = wm.Acquire(gvr, "test")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, wm.ActiveWatchCount(), "retry should succeed with fresh informer")
 	wm.Shutdown()
 }
 
-func TestEnsureWatch_SyncSuccess(t *testing.T) {
+func TestAcquire_SyncSuccess(t *testing.T) {
 	wm := newTestWatchManager(t)
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 	wm.SyncTimeout = 5 * time.Second
 
-	err := wm.EnsureWatch(gvr)
+	_, err := wm.Acquire(gvr, "test")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, wm.ActiveWatchCount())
 	wm.Shutdown()
 }
 
-func TestEnsureWatch_ConcurrentCalls(t *testing.T) {
+func TestAcquire_ConcurrentCalls(t *testing.T) {
 	wm := newTestWatchManager(t)
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	// Launch multiple concurrent EnsureWatch calls.
+	// Launch multiple concurrent Acquire calls with distinct keys.
 	errs := make(chan error, 10)
 	for i := 0; i < 10; i++ {
-		go func() {
-			errs <- wm.EnsureWatch(gvr)
-		}()
+		go func(idx int) {
+			_, err := wm.Acquire(gvr, fmt.Sprintf("caller-%d", idx))
+			errs <- err
+		}(i)
 	}
 	for i := 0; i < 10; i++ {
 		assert.NoError(t, <-errs)
@@ -405,24 +442,24 @@ func TestEnsureWatch_ConcurrentCalls(t *testing.T) {
 	wm.Shutdown()
 }
 
-func TestConcurrentEnsureWatch_StopWatch(t *testing.T) {
+func TestConcurrentAcquire_Release(t *testing.T) {
 	wm := newTestWatchManager(t)
 	wm.SyncTimeout = 500 * time.Millisecond
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	// Start and stop concurrently.
+	// Start and stop concurrently with key "a".
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		for i := 0; i < 20; i++ {
-			_ = wm.EnsureWatch(gvr)
-			wm.StopWatch(gvr)
+			_, _ = wm.Acquire(gvr, "a")
+			wm.Release(gvr, "a")
 		}
 	}()
 
-	// Concurrent EnsureWatch calls.
+	// Concurrent Acquire calls with key "b".
 	for i := 0; i < 20; i++ {
-		_ = wm.EnsureWatch(gvr)
+		_, _ = wm.Acquire(gvr, "b")
 	}
 	<-done
 
@@ -430,6 +467,61 @@ func TestConcurrentEnsureWatch_StopWatch(t *testing.T) {
 	count := wm.ActiveWatchCount()
 	assert.True(t, count == 0 || count == 1)
 	wm.Shutdown()
+}
+
+func TestAcquire_SyncTimeout_ConcurrentRef(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1.AddMetaToScheme(scheme)
+	client := fake.NewSimpleMetadataClient(scheme)
+
+	// Fail all list calls so the first Acquire's cache sync times out.
+	client.PrependReactor("list", "*", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("simulated list error")
+	})
+
+	wm := NewWatchManager(client, 1*time.Hour, func(Event) {}, noopLogger())
+	wm.SyncTimeout = 200 * time.Millisecond
+
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+	// G1: Acquire creates the watch (owner "g1") and starts waiting for sync.
+	// While G1 blocks, G2 Acquires the same GVR (owner "g2").
+	// When G1's sync timeout fires, it should remove only its own key
+	// instead of force-removing the watch, so G2's ownership stays valid.
+	var g2err error
+	g2done := make(chan struct{})
+
+	// Start G1.
+	g1done := make(chan struct{})
+	go func() {
+		defer close(g1done)
+		_, _ = wm.Acquire(gvr, "g1") // will timeout
+	}()
+
+	// Give G1 time to create the watch and start waiting for sync.
+	time.Sleep(50 * time.Millisecond)
+
+	// G2: Acquire same GVR with different key.
+	go func() {
+		defer close(g2done)
+		_, g2err = wm.Acquire(gvr, "g2")
+	}()
+	<-g2done
+
+	// G2 should succeed (it adds its key to the existing watch).
+	assert.NoError(t, g2err)
+
+	// Wait for G1 timeout.
+	<-g1done
+
+	// The watch should still exist because G2 holds ownership.
+	assert.Equal(t, 1, wm.ActiveWatchCount(),
+		"watch should survive G1's timeout because G2 still owns it")
+
+	// G2 releases — now the watch should stop.
+	wm.Release(gvr, "g2")
+	assert.Equal(t, 0, wm.ActiveWatchCount(),
+		"watch should stop after G2 releases")
 }
 
 func TestSyncTimeout_DefaultValue(t *testing.T) {

--- a/test/integration/suites/core/externalref_watch_test.go
+++ b/test/integration/suites/core/externalref_watch_test.go
@@ -21,14 +21,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
-
-	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
-	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
 )
 
 var _ = Describe("ExternalRef Watch", func() {
@@ -466,4 +466,177 @@ var _ = Describe("ExternalRef Watch", func() {
 			g.Expect(sortedNames).To(Equal("cm-charlie,cm-alpha,cm-bravo"))
 		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 	})
+
+	It("external ref to a chained RGD keeps the producer instance reconciling after consumer deletion",
+		func(ctx SpecContext) {
+			By("creating the producer RGD that owns the watched custom resource kind")
+			producerRGD := generator.NewResourceGraphDefinition("test-chained-producer",
+				generator.WithSchema(
+					"WatchedDatabase", "v1alpha1",
+					map[string]interface{}{
+						"value": "string",
+					},
+					nil,
+				),
+				generator.WithResource("managed", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "watched-database-config",
+					},
+					"data": map[string]interface{}{
+						"value": "${schema.spec.value}",
+					},
+				}, nil, nil),
+			)
+			Expect(env.Client.Create(ctx, producerRGD)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				Expect(env.Client.Delete(ctx, producerRGD)).To(Succeed())
+			})
+
+			By("waiting for the producer RGD to become active")
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: producerRGD.Name}, producerRGD)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(producerRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			By("creating a producer instance and waiting for its managed ConfigMap")
+			producerInstance := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "kro.run/v1alpha1",
+					"kind":       "WatchedDatabase",
+					"metadata": map[string]interface{}{
+						"name":      "watched-db",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"value": "one",
+					},
+				},
+			}
+			Expect(env.Client.Create(ctx, producerInstance)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				err := env.Client.Delete(ctx, producerInstance)
+				if err != nil && !apierrors.IsNotFound(err) {
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
+
+			producerCM := &corev1.ConfigMap{}
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      producerInstance.GetName(),
+					Namespace: namespace,
+				}, producerInstance)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(producerInstance.Object).To(HaveKey("status"))
+				g.Expect(producerInstance.Object["status"]).To(HaveKeyWithValue("state", "ACTIVE"))
+
+				err = env.Client.Get(ctx, types.NamespacedName{
+					Name:      "watched-database-config",
+					Namespace: namespace,
+				}, producerCM)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(producerCM.Data).To(HaveKeyWithValue("value", "one"))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			By("creating a consumer RGD that externalRefs the producer custom resource kind")
+			consumerRGD := generator.NewResourceGraphDefinition("test-chained-consumer",
+				generator.WithSchema(
+					"DatabaseObserver", "v1alpha1",
+					map[string]interface{}{},
+					nil,
+				),
+				generator.WithExternalRef("database", &krov1alpha1.ExternalRef{
+					APIVersion: "kro.run/v1alpha1",
+					Kind:       "WatchedDatabase",
+					Metadata: krov1alpha1.ExternalRefMetadata{
+						Name: "watched-db",
+					},
+				}, nil, nil),
+				generator.WithResource("managed", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "database-observer-config",
+					},
+					"data": map[string]interface{}{
+						"value": "${database.spec.value}",
+					},
+				}, nil, nil),
+			)
+			Expect(env.Client.Create(ctx, consumerRGD)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				Expect(env.Client.Delete(ctx, consumerRGD)).To(Succeed())
+			})
+
+			By("waiting for the consumer RGD to become active")
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: consumerRGD.Name}, consumerRGD)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(consumerRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			By("creating the consumer instance so it registers an externalRef watch on the producer kind")
+			consumerInstance := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "kro.run/v1alpha1",
+					"kind":       "DatabaseObserver",
+					"metadata": map[string]interface{}{
+						"name":      "db-observer",
+						"namespace": namespace,
+					},
+				},
+			}
+			Expect(env.Client.Create(ctx, consumerInstance)).To(Succeed())
+
+			consumerCM := &corev1.ConfigMap{}
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      consumerInstance.GetName(),
+					Namespace: namespace,
+				}, consumerInstance)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(consumerInstance.Object).To(HaveKey("status"))
+				g.Expect(consumerInstance.Object["status"]).To(HaveKeyWithValue("state", "ACTIVE"))
+
+				err = env.Client.Get(ctx, types.NamespacedName{
+					Name:      "database-observer-config",
+					Namespace: namespace,
+				}, consumerCM)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(consumerCM.Data).To(HaveKeyWithValue("value", "one"))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			By("deleting the consumer instance so its externalRef watch is cleaned up")
+			Expect(env.Client.Delete(ctx, consumerInstance)).To(Succeed())
+			Eventually(func() bool {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      consumerInstance.GetName(),
+					Namespace: namespace,
+				}, consumerInstance)
+				return apierrors.IsNotFound(err)
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(BeTrue())
+
+			By("updating the producer instance after consumer deletion")
+			Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      producerInstance.GetName(),
+				Namespace: namespace,
+			}, producerInstance)).To(Succeed())
+			Expect(unstructured.SetNestedField(producerInstance.Object, "two", "spec", "value")).To(Succeed())
+			Expect(env.Client.Update(ctx, producerInstance)).To(Succeed())
+
+			By("asserting the producer instance still reconciles via its parent watch")
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      "watched-database-config",
+					Namespace: namespace,
+				}, producerCM)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(producerCM.Data).To(HaveKeyWithValue("value", "two"))
+			}, 5*time.Second, 500*time.Millisecond).WithContext(ctx).Should(Succeed(),
+				"producer managed resource should still update after the consumer externalRef instance is deleted",
+			)
+		})
 })


### PR DESCRIPTION
Replace the LazyInformer-based EnsureWatch/StopWatch API with a layered
WatchManager + WatchCoordinator architecture using keyed ownership.

WatchManager.Acquire(gvr, key) / Release(gvr, key) tracks owners per
GVR via a map[string]struct{} instead of integer refcounting. Each
caller holds an independent, idempotent reference — the parent uses
key "parent" and the coordinator uses key "coordinator". The informer
stops only when all owners have released. This prevents the shared-GVR
bug where cleaning up one caller's reference kills the informer needed
by the other (the chained RGD scenario from https://github.com/kubernetes-sigs/kro/pull/1105).

WatchCoordinator aggregates watch requests from all instance
reconcilers, maintains scalar + collection reverse indexes for O(1)
event routing, and automatically cleans up stale requests across
reconciliation cycles.

DynamicController is simplified by delegating child watch lifecycle
entirely to the coordinator, removing inline informer management,
the heldGVRs map, and the double-check pattern.