### PR TITLE
perf(graph): eliminate duplicate CEL type building during RGD construction

### DIFF
--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -112,6 +112,14 @@ func BaseDeclarations() []cel.EnvOption {
 
 // DefaultEnvironment returns the default CEL environment.
 func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
+	env, _, err := defaultEnvironment(options...)
+	return env, err
+}
+
+// defaultEnvironment is the shared implementation that builds the CEL environment
+// and returns both the environment and the DeclTypeProvider (if typed resources
+// were configured).
+func defaultEnvironment(options ...EnvOption) (*cel.Env, *DeclTypeProvider, error) {
 	declarations := BaseDeclarations()
 
 	opts := &envOptions{}
@@ -120,6 +128,8 @@ func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
 	}
 
 	declarations = append(declarations, opts.customDeclarations...)
+
+	var provider *DeclTypeProvider
 
 	if len(opts.typedResources) > 0 {
 		// We need both a TypeProvider (for field resolution) and variable declarations.
@@ -146,14 +156,14 @@ func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
 		}
 
 		if len(declTypes) > 0 {
-			baseProvider := NewDeclTypeProvider(declTypes...)
+			provider = NewDeclTypeProvider(declTypes...)
 			// Enable recognition of CEL reserved keywords as field names
-			baseProvider.SetRecognizeKeywordAsFieldName(true)
+			provider.SetRecognizeKeywordAsFieldName(true)
 
 			registry := types.NewEmptyRegistry()
-			wrappedProvider, err := baseProvider.WithTypeProvider(registry)
+			wrappedProvider, err := provider.WithTypeProvider(registry)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 
 			declarations = append(declarations, cel.CustomTypeProvider(wrappedProvider))
@@ -164,7 +174,8 @@ func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
 		declarations = append(declarations, cel.Variable(name, cel.AnyType))
 	}
 
-	return cel.NewEnv(declarations...)
+	env, err := cel.NewEnv(declarations...)
+	return env, provider, err
 }
 
 // TypedEnvironment creates a CEL environment with type checking enabled.
@@ -173,6 +184,13 @@ func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
 // CEL expressions against OpenAPI schemas.
 func TypedEnvironment(schemas map[string]*spec.Schema) (*cel.Env, error) {
 	return DefaultEnvironment(WithTypedResources(schemas))
+}
+
+// TypedEnvironmentWithProvider creates a typed CEL environment and also returns
+// the DeclTypeProvider that was created internally. This avoids the need to
+// create a separate provider via CreateDeclTypeProvider for the same schemas.
+func TypedEnvironmentWithProvider(schemas map[string]*spec.Schema) (*cel.Env, *DeclTypeProvider, error) {
+	return defaultEnvironment(WithTypedResources(schemas))
 }
 
 // UntypedEnvironment creates a CEL environment without type declarations.

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -252,13 +252,12 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 	celSchemas[SchemaVarName] = schemaWithoutStatus
 
 	// Create a single typed CEL environment with all schemas for compilation.
-	// Following Kubernetes best practice: create one env, extend once at init,
-	// compile all expressions against it. AST inspection handles scope validation.
-	typedEnv, err := krocel.TypedEnvironment(celSchemas)
+	// TypedEnvironmentWithProvider returns both the env and the DeclTypeProvider it
+	// creates internally, avoiding duplicate schema-to-DeclType conversions.
+	typedEnv, typeProvider, err := krocel.TypedEnvironmentWithProvider(celSchemas)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create typed CEL environment: %w", err)
 	}
-	typeProvider := krocel.CreateDeclTypeProvider(celSchemas)
 
 	// Validate and compile all resource CEL expressions.
 	for id, node := range nodes {
@@ -965,7 +964,7 @@ func resolveSchemaAndTypeName(segments []fieldpath.Segment, rootSchema *spec.Sch
 // getExpectedTypeForField computes the expected CEL type for a field descriptor.
 // For standalone expressions, the type is derived from the OpenAPI schema at the path.
 // For string templates, the expected type is always string.
-func getExpectedTypeForField(descriptor *variable.FieldDescriptor, rootSchema *spec.Schema, resourceID string) *cel.Type {
+func getExpectedTypeForField(descriptor *variable.FieldDescriptor, rootSchema *spec.Schema, resourceID string, typeProvider *krocel.DeclTypeProvider) *cel.Type {
 	if !descriptor.StandaloneExpression {
 		return cel.StringType
 	}
@@ -980,20 +979,27 @@ func getExpectedTypeForField(descriptor *variable.FieldDescriptor, rootSchema *s
 		return cel.DynType
 	}
 
-	return getCelTypeFromSchema(schema, typeName)
+	return getCelTypeFromSchema(schema, typeName, typeProvider)
 }
 
-// getCelTypeFromSchema converts an OpenAPI schema to a CEL type with the given type name
-func getCelTypeFromSchema(schema *spec.Schema, typeName string) *cel.Type {
+// getCelTypeFromSchema looks up a pre-registered CEL type by name from the
+// provider (O(1) hash lookup). Falls back to converting the schema directly
+// for nested types that aren't registered at the top level.
+func getCelTypeFromSchema(schema *spec.Schema, typeName string, typeProvider *krocel.DeclTypeProvider) *cel.Type {
+	if typeProvider != nil {
+		if declType, found := typeProvider.FindDeclType(typeName); found {
+			return declType.CelType()
+		}
+	}
+
+	// Fallback: convert schema directly for nested/leaf types not in the provider
 	if schema == nil {
 		return cel.DynType
 	}
-
 	declType := krocel.SchemaDeclTypeWithMetadata(&openapi.Schema{Schema: schema}, false)
 	if declType == nil {
 		return cel.DynType
 	}
-
 	declType = declType.MaybeAssignTypeName(typeName)
 	return declType.CelType()
 }
@@ -1124,7 +1130,7 @@ func validateAndCompileTemplates(
 
 	for _, templateVariable := range node.Variables {
 		// Compute expected type for this field
-		expectedType := getExpectedTypeForField(&templateVariable.FieldDescriptor, nodeSchema, node.Meta.ID)
+		expectedType := getExpectedTypeForField(&templateVariable.FieldDescriptor, nodeSchema, node.Meta.ID, typeProvider)
 
 		for _, expression := range templateVariable.Expressions {
 			// Parse, type-check, and compile


### PR DESCRIPTION
Three targeted optimizations to avoid redundant SchemaDeclTypeWithMetadata calls:

1. Add TypedEnvironmentWithProvider() that returns the DeclTypeProvider already created internally by DefaultEnvironment, replacing separate CreateDeclTypeProvider + TypedEnvironment call pairs.

2. Change getCelTypeFromSchema to use O(1) provider.FindDeclType lookup instead of re-converting schemas per field descriptor.

3. Reuse templatesEnv for readyWhen validation instead of creating a per-resource TypedEnvironment.