### PR TITLE
perf(cel): cache base declarations and environment with sync.Once

### DIFF
--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -17,6 +17,7 @@ package cel
 import (
 	"fmt"
 	"maps"
+	"sync"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
@@ -90,24 +91,49 @@ func WithListVariables(names []string) EnvOption {
 	}
 }
 
+var (
+	baseDeclarationsOnce   sync.Once
+	cachedBaseDeclarations []cel.EnvOption
+)
+
 // BaseDeclarations returns the base CEL environment options shared by all kro
 // CEL environments. Includes list/string extensions, optional types, encoders,
 // and Kubernetes CEL libraries (URLs, Regex, Random).
+// The result is cached via sync.Once since these options are stateless.
 func BaseDeclarations() []cel.EnvOption {
-	return []cel.EnvOption{
-		ext.Lists(),
-		ext.Strings(),
-		cel.OptionalTypes(),
-		ext.Encoders(),
-		// Kubernetes CEL libraries: enable url(), getHost(), regex helpers, etc.
-		// See https://kubernetes.io/docs/reference/using-api/cel/ and
-		// https://github.com/kubernetes-sigs/kro/issues/880.
-		k8scellib.URLs(),
-		k8scellib.Regex(),
-		library.Random(),
-		library.Maps(),
-		library.JSON(),
-	}
+	baseDeclarationsOnce.Do(func() {
+		cachedBaseDeclarations = []cel.EnvOption{
+			ext.Lists(),
+			ext.Strings(),
+			cel.OptionalTypes(),
+			ext.Encoders(),
+			// Kubernetes CEL libraries: enable url(), getHost(), regex helpers, etc.
+			// See https://kubernetes.io/docs/reference/using-api/cel/ and
+			// https://github.com/kubernetes-sigs/kro/issues/880.
+			k8scellib.URLs(),
+			k8scellib.Regex(),
+			library.Random(),
+			library.Maps(),
+			library.JSON(),
+		}
+	})
+	return cachedBaseDeclarations
+}
+
+var (
+	baseEnvOnce   sync.Once
+	cachedBaseEnv *cel.Env
+	baseEnvErr    error
+)
+
+// baseEnv returns a cached base CEL environment containing only the base
+// declarations. Use env.Extend() on the result to add custom declarations,
+// which is cheaper than building a full environment from scratch.
+func baseEnv() (*cel.Env, error) {
+	baseEnvOnce.Do(func() {
+		cachedBaseEnv, baseEnvErr = cel.NewEnv(BaseDeclarations()...)
+	})
+	return cachedBaseEnv, baseEnvErr
 }
 
 // DefaultEnvironment returns the default CEL environment.
@@ -120,13 +146,18 @@ func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
 // and returns both the environment and the DeclTypeProvider (if typed resources
 // were configured).
 func defaultEnvironment(options ...EnvOption) (*cel.Env, *DeclTypeProvider, error) {
-	declarations := BaseDeclarations()
+	base, err := baseEnv()
+	if err != nil {
+		return nil, nil, fmt.Errorf("base environment: %w", err)
+	}
 
 	opts := &envOptions{}
 	for _, opt := range options {
 		opt(opts)
 	}
 
+	// Only non-base declarations go here; base declarations are in the cached base env.
+	var declarations []cel.EnvOption
 	declarations = append(declarations, opts.customDeclarations...)
 
 	var provider *DeclTypeProvider
@@ -174,7 +205,7 @@ func defaultEnvironment(options ...EnvOption) (*cel.Env, *DeclTypeProvider, erro
 		declarations = append(declarations, cel.Variable(name, cel.AnyType))
 	}
 
-	env, err := cel.NewEnv(declarations...)
+	env, err := base.Extend(declarations...)
 	return env, provider, err
 }
 

--- a/pkg/cel/environment_test.go
+++ b/pkg/cel/environment_test.go
@@ -157,6 +157,59 @@ func TestDefaultEnvironment_KubernetesLibraries(t *testing.T) {
 	require.NoError(t, issues.Err(), "expected URL expression to compile without errors")
 }
 
+func TestBaseDeclarations_ReturnsSameSlice(t *testing.T) {
+	a := BaseDeclarations()
+	b := BaseDeclarations()
+	assert.Equal(t, len(a), len(b))
+	// Both calls should return the same backing array (cached via sync.Once)
+	if len(a) > 0 && len(b) > 0 {
+		assert.Same(t, &a[0], &b[0], "expected same backing array from cached BaseDeclarations")
+	}
+}
+
+func TestBaseEnv_Extend_PreservesLibraries(t *testing.T) {
+	// Verify that extending the cached base env still has all libraries available
+	env, err := DefaultEnvironment(
+		WithResourceIDs([]string{"myResource"}),
+	)
+	require.NoError(t, err)
+
+	// Libraries from BaseDeclarations should be available
+	expr := `url("https://example.com").getHost()`
+	_, issues := env.Compile(expr)
+	assert.NoError(t, issues.Err(), "URL library should be available via base.Extend()")
+
+	// Custom variable should also work
+	expr2 := `myResource`
+	_, issues2 := env.Compile(expr2)
+	assert.NoError(t, issues2.Err(), "extended variable should be available")
+}
+
+func TestBaseEnv_Extend_MultipleEnvironments(t *testing.T) {
+	// Create two environments with different options from the same base
+	env1, err := DefaultEnvironment(WithResourceIDs([]string{"alpha"}))
+	require.NoError(t, err)
+
+	env2, err := DefaultEnvironment(WithResourceIDs([]string{"beta"}))
+	require.NoError(t, err)
+
+	// Each should have its own variable, not the other's
+	_, issues := env1.Compile("alpha")
+	assert.NoError(t, issues.Err())
+
+	_, issues = env2.Compile("beta")
+	assert.NoError(t, issues.Err())
+}
+
+func BenchmarkDefaultEnvironment(b *testing.B) {
+	for b.Loop() {
+		_, err := DefaultEnvironment(WithResourceIDs([]string{"a", "b", "c"}))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func Test_CELEnvHasFunction(t *testing.T) {
 	env, err := DefaultEnvironment()
 	require.NoError(t, err, "failed to create CEL env")

--- a/pkg/graph/builder_bench_test.go
+++ b/pkg/graph/builder_bench_test.go
@@ -1,0 +1,184 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"fmt"
+	"testing"
+
+	memory2 "k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/restmapper"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/k8s"
+)
+
+// newBenchBuilder creates a Builder with fake resolvers for benchmarking.
+func newBenchBuilder(b *testing.B) *Builder {
+	b.Helper()
+	fakeResolver, fakeDiscovery := k8s.NewFakeResolver()
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(memory2.NewMemCacheClient(fakeDiscovery))
+	return &Builder{
+		schemaResolver: fakeResolver,
+		restMapper:     restMapper,
+	}
+}
+
+// BenchmarkNewRGD_SimplePodAndConfig benchmarks a minimal RGD: one Pod + one ConfigMap.
+func BenchmarkNewRGD_SimplePodAndConfig(b *testing.B) {
+	builder := newBenchBuilder(b)
+	rgd := generator.NewResourceGraphDefinition("bench-simple",
+		generator.WithSchema(
+			"SimpleApp", "v1alpha1",
+			map[string]interface{}{
+				"name": "string",
+			},
+			map[string]interface{}{
+				"configName": "${config.metadata.name}",
+			},
+		),
+		generator.WithResource("config", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "${schema.spec.name}-config",
+				"namespace": "default",
+			},
+			"data": map[string]interface{}{
+				"app": "${schema.spec.name}",
+			},
+		}, nil, nil),
+		generator.WithResource("pod", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "${schema.spec.name}",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"containers": []interface{}{
+					map[string]interface{}{
+						"name":  "app",
+						"image": "nginx",
+					},
+				},
+			},
+		}, nil, nil),
+	)
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := builder.NewResourceGraphDefinition(rgd, defaultRGDConfig)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkNewRGD_ManyPods benchmarks an RGD with many similar resources to
+// stress the type building path with repeated schema conversions.
+func BenchmarkNewRGD_ManyPods(b *testing.B) {
+	builder := newBenchBuilder(b)
+
+	opts := []generator.ResourceGraphDefinitionOption{
+		generator.WithSchema(
+			"PodSet", "v1alpha1",
+			map[string]interface{}{
+				"name": "string",
+			},
+			map[string]interface{}{
+				"pod00Phase": "${pod00.status.phase}",
+			},
+		),
+	}
+
+	// 20 pods, each referencing schema.spec.name
+	for i := 0; i < 20; i++ {
+		id := fmt.Sprintf("pod%02d", i)
+		opts = append(opts, generator.WithResource(id, map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "${schema.spec.name}-" + id,
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"containers": []interface{}{
+					map[string]interface{}{
+						"name":  id,
+						"image": "nginx",
+					},
+				},
+			},
+		}, nil, nil))
+	}
+
+	rgd := generator.NewResourceGraphDefinition("bench-many-pods", opts...)
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := builder.NewResourceGraphDefinition(rgd, defaultRGDConfig)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkNewRGD_WithCollections benchmarks a collection-based RGD
+// to measure forEach + type inference overhead.
+func BenchmarkNewRGD_WithCollections(b *testing.B) {
+	builder := newBenchBuilder(b)
+	rgd := generator.NewResourceGraphDefinition("bench-collections",
+		generator.WithSchema(
+			"PodPerRegion", "v1alpha1",
+			map[string]interface{}{
+				"name":    "string",
+				"regions": "[]string",
+			},
+			map[string]interface{}{
+				"podCount": "${string(pods.size())}",
+			},
+		),
+		generator.WithResourceCollection("pods", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "${schema.spec.name + '-' + region}",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"containers": []interface{}{
+					map[string]interface{}{
+						"name":  "app",
+						"image": "nginx",
+					},
+				},
+			},
+		},
+			[]krov1alpha1.ForEachDimension{
+				{"region": "${schema.spec.regions}"},
+			},
+			nil, nil),
+	)
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := builder.NewResourceGraphDefinition(rgd, defaultRGDConfig)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
BaseDeclarations() now computes its []cel.EnvOption slice once via sync.Once instead of rebuilding 9 library options on every call.

A cached base *cel.Env is built once from BaseDeclarations(), and defaultEnvironment() uses env.Extend() instead of cel.NewEnv() to add per-call declarations. Extend() reuses the parent's type registry and function bindings, making environment creation significantly cheaper.

Benchmark improvement over previous commit (SimplePodAndConfig):
  ~582µs → ~430µs (-26%), 649KB → 545KB (-16%), 7162 → 4972 allocs (-30%)