### PR TITLE
KREP-021: CEL write-back — stateful transitions in ResourceGraphDefinitions

### DIFF
--- a/docs/design/proposals/cel-writeback/proposal.md
+++ b/docs/design/proposals/cel-writeback/proposal.md
@@ -1,4 +1,4 @@
-# CEL Write-Back: Stateful Transitions in ResourceGraphDefinitions
+# KREP-021: CEL Write-Back — Stateful Transitions in ResourceGraphDefinitions
 
 **Author:** Rafael Panazzo (https://github.com/pnz1990)
 **Status:** Draft / Open Question (see §Design Details and §Other Solutions Considered)


### PR DESCRIPTION
## Summary

kro's CEL expressions are read-only today: they evaluate against a snapshot of the parent instance CR and produce derived values in `status` fields and child resource templates, but cannot persist a computed value back into the CR across reconcile cycles.

This blocks stateful transition patterns (certificate rotation timestamps, progressive delivery phase advancement, retry counters, autoscaling cooldown enforcement, quota accumulation) that today each require a bespoke external controller — the exact reconcile-patch loop kro already performs internally.

## What this proposal adds

A new virtual resource type in the RGD `resources` list — a **write-back node** — that evaluates CEL expressions and persists the results back into the instance CR rather than creating a Kubernetes resource.

Two alternatives are presented, differing only in where the result is written:

- **Alt A: `specPatch`** — writes to instance `spec` using a dedicated SSA field manager (`kro.run/specpatch`). Simpler implementation; requires `ignoreDifferences` or SSA mode in GitOps tooling.
- **Alt B: `stateWrite`** — writes to a new `status.state` sub-object. GitOps-compatible by construction (GitOps tools never touch `status`); slightly more implementation complexity (must relax `withStatusOmitted` for the `status.state` sub-path).

Both integrate with the existing DAG, `includeWhen`, and idempotency machinery. Both are ~300 lines of Go across 4 files.

The proposal explicitly enumerates what write-back nodes **cannot** do (per-request entropy, array element mutation by index, time-triggered transitions, cross-instance mutations) and does not overclaim.

## Origin

This proposal emerged from building [Krombat](https://github.com/pnz1990/krombat), a Kubernetes-native turn-based RPG using kro RGDs as the game state machine. The external-controller workaround is operational there today; this proposal aims to eliminate the need for it in the simple cases.

## Questions for maintainers

1. Which alternative aligns better with kro's long-term API philosophy?
2. Is the `withStatusOmitted` restriction in `buildContext` intentional as a general rule?
3. Should write-back nodes use a `type:` discriminator on resource entries, or a top-level `transitions:` stanza?

Happy to revise based on feedback or implement a proof-of-concept for whichever alternative the maintainers prefer.