### PR TITLE
feat(instance): block graph propagation on terminating managed resources

### DIFF
--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -16,6 +16,7 @@ package instance
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -194,6 +195,12 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 	if !ok || !strings.EqualFold(reconcileState, "disabled") {
 		rcx.Mark.ReconciliationActive()
 		if err := c.reconcileNodes(rcx); err != nil {
+			var deletingErr *resourceDeletingError
+			if errors.As(err, &deletingErr) {
+				rcx.Mark.ResourcesDeleting("%v", deletingErr)
+				_ = c.updateStatus(rcx)
+				return rcx.delayedRequeue(deletingErr)
+			}
 			rcx.Mark.ResourcesNotReady("resource reconciliation failed: %v", err)
 			_ = c.updateStatus(rcx)
 			return err

--- a/pkg/controller/instance/controller_test.go
+++ b/pkg/controller/instance/controller_test.go
@@ -231,6 +231,87 @@ func TestReconcileResourceMutationRequestsRequeue(t *testing.T) {
 	assert.Equal(t, metav1.ConditionFalse, conditionByType(t, stored, ResourcesReady).Status)
 }
 
+func TestReconcileTerminatingManagedResourcesSetDeletingStatus(t *testing.T) {
+	tests := []struct {
+		name              string
+		configureInstance func(*unstructured.Unstructured)
+		graph             *graph.Graph
+		buildCurrent      func(*unstructured.Unstructured) []apimachineryruntime.Object
+		wantMessage       string
+	}{
+		{
+			name: "single resource",
+			graph: newTestGraph(&graph.Node{
+				Meta: graph.NodeMeta{
+					ID:         "deploy",
+					Type:       graph.NodeTypeResource,
+					GVR:        controllerTestDeployGVR,
+					Namespaced: true,
+				},
+				Template: newDeploymentObject("demo", ""),
+			}),
+			buildCurrent: func(_ *unstructured.Unstructured) []apimachineryruntime.Object {
+				current := newDeploymentObject("demo", "default")
+				now := metav1.Now()
+				current.SetDeletionTimestamp(&now)
+				return []apimachineryruntime.Object{current}
+			},
+			wantMessage: `resource "default/demo" for node "deploy" is currently being deleted`,
+		},
+		{
+			name: "collection resource",
+			configureInstance: func(instance *unstructured.Unstructured) {
+				_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
+			},
+			graph: newTestGraph(newCollectionNodeForResources(t)),
+			buildCurrent: func(instance *unstructured.Unstructured) []apimachineryruntime.Object {
+				current := newConfigMapObject("one", "default")
+				current.SetLabels(map[string]string{
+					metadata.InstanceIDLabel: string(instance.GetUID()),
+					metadata.NodeIDLabel:     "configs",
+				})
+				now := metav1.Now()
+				current.SetDeletionTimestamp(&now)
+				return []apimachineryruntime.Object{current}
+			},
+			wantMessage: `resource "default/one" for node "configs" is currently being deleted`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			if tt.configureInstance != nil {
+				tt.configureInstance(instance)
+			}
+
+			objs := tt.buildCurrent(instance)
+			args := append([]apimachineryruntime.Object{instance.DeepCopy()}, objs...)
+			raw := newControllerTestDynamicClient(t, args...)
+			controller, _ := newControllerUnderTest(t, raw, tt.graph)
+
+			err := controller.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()},
+			})
+			var retryAfter *requeue.RequeueNeededAfter
+			require.ErrorAs(t, err, &retryAfter)
+
+			stored := getStoredParentObject(t, raw)
+			state, found, err := unstructured.NestedString(stored.Object, "status", "state")
+			require.NoError(t, err)
+			require.True(t, found)
+			assert.Equal(t, string(InstanceStateInProgress), state)
+
+			cond := conditionByType(t, stored, ResourcesReady)
+			assert.Equal(t, metav1.ConditionFalse, cond.Status)
+			require.NotNil(t, cond.Reason)
+			assert.Equal(t, "ResourceDeleting", *cond.Reason)
+			require.NotNil(t, cond.Message)
+			assert.Contains(t, *cond.Message, tt.wantMessage)
+		})
+	}
+}
+
 func TestReconcileManagedStateFailureMarksStatus(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 	raw := newControllerTestDynamicClient(t, instance.DeepCopy())

--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -32,6 +32,33 @@ import (
 	"github.com/kubernetes-sigs/kro/pkg/runtime"
 )
 
+type resourceDeletingError struct {
+	NodeID      string
+	ResourceRef string
+}
+
+func (e *resourceDeletingError) Error() string {
+	return fmt.Sprintf(
+		"resource %q for node %q is currently being deleted; waiting for deletion to complete before continuing reconciliation",
+		e.ResourceRef,
+		e.NodeID,
+	)
+}
+
+func newResourceDeletingError(nodeID string, obj *unstructured.Unstructured) *resourceDeletingError {
+	return &resourceDeletingError{
+		NodeID:      nodeID,
+		ResourceRef: resourceRef(obj),
+	}
+}
+
+func resourceRef(obj *unstructured.Unstructured) string {
+	if obj.GetNamespace() == "" {
+		return obj.GetName()
+	}
+	return obj.GetNamespace() + "/" + obj.GetName()
+}
+
 // reconcileNodes orchestrates node processing, apply, prune, and state updates.
 func (c *Controller) reconcileNodes(rcx *ReconcileContext) error {
 	rcx.Log.V(2).Info("Reconciling resources")
@@ -297,6 +324,16 @@ func (c *Controller) processRegularNode(
 		return nil, state.Err
 	}
 
+	if current != nil && current.GetDeletionTimestamp() != nil {
+		state.SetDeleting()
+		rcx.Log.V(1).Info("Resource is terminating; waiting for deletion to complete",
+			"id", id,
+			"namespace", current.GetNamespace(),
+			"name", current.GetName(),
+		)
+		return nil, newResourceDeletingError(id, current)
+	}
+
 	if current != nil {
 		node.SetObserved([]*unstructured.Unstructured{current})
 	}
@@ -334,12 +371,9 @@ func (c *Controller) processCollectionNode(
 		return nil, state.Err
 	}
 
-	// Pass unordered observed items to runtime; it will align them to desired
-	// order by identity.
-	node.SetObserved(existingItems)
-
 	// Empty collection: observed is set (possibly with orphans to prune), mark ready.
 	if collectionSize == 0 {
+		node.SetObserved(existingItems)
 		state.SetReady()
 		return nil, nil
 	}
@@ -351,12 +385,31 @@ func (c *Controller) processCollectionNode(
 		existingByKey[key] = current
 	}
 
+	for _, expandedResource := range expandedResources {
+		requestWatch(rcx, id, gvr, expandedResource.GetName(), expandedResource.GetNamespace())
+	}
+
+	for _, expandedResource := range expandedResources {
+		key := expandedResource.GetNamespace() + "/" + expandedResource.GetName()
+		current := existingByKey[key]
+		if current != nil && current.GetDeletionTimestamp() != nil {
+			state.SetDeleting()
+			rcx.Log.V(1).Info("Collection resource is terminating; waiting for deletion to complete",
+				"id", id,
+				"namespace", current.GetNamespace(),
+				"name", current.GetName(),
+			)
+			return nil, newResourceDeletingError(id, current)
+		}
+	}
+
+	// Pass unordered observed items to runtime; it will align them to desired
+	// order by identity.
+	node.SetObserved(existingItems)
+
 	// Build resources list for apply
 	resources := make([]applyset.Resource, 0, collectionSize)
 	for i, expandedResource := range expandedResources {
-		// Register watch for each collection item.
-		requestWatch(rcx, id, gvr, expandedResource.GetName(), expandedResource.GetNamespace())
-
 		// Apply decorator labels with collection info
 		collectionInfo := &CollectionInfo{Index: i, Size: collectionSize}
 		c.applyDecoratorLabels(rcx, expandedResource, id, collectionInfo)

--- a/pkg/controller/instance/resources_test.go
+++ b/pkg/controller/instance/resources_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
@@ -152,17 +153,18 @@ func TestReconcileNodesPaths(t *testing.T) {
 func TestProcessNodePaths(t *testing.T) {
 	disabled := false
 	tests := []struct {
-		name            string
-		specEnabled     *bool
-		node            *graph.Node
-		currentObjs     []apimachineryruntime.Object
-		reactorVerb     string
-		reactorResource string
-		reactorErr      string
-		wantResources   int
-		wantSkipApply   bool
-		wantState       string
-		wantErr         string
+		name              string
+		specEnabled       *bool
+		configureInstance func(*unstructured.Unstructured)
+		node              *graph.Node
+		currentObjs       []apimachineryruntime.Object
+		reactorVerb       string
+		reactorResource   string
+		reactorErr        string
+		wantResources     int
+		wantSkipApply     bool
+		wantState         string
+		wantErr           string
 	}{
 		{
 			name:        "ignored node becomes skip apply",
@@ -252,6 +254,45 @@ func TestProcessNodePaths(t *testing.T) {
 			wantState: NodeStateError,
 			wantErr:   "division by zero",
 		},
+		{
+			name: "terminating managed resource marks deleting",
+			node: &graph.Node{
+				Meta: graph.NodeMeta{
+					ID:         "deploy",
+					Type:       graph.NodeTypeResource,
+					GVR:        controllerTestDeployGVR,
+					Namespaced: true,
+				},
+				Template: newDeploymentObject("demo", ""),
+			},
+			currentObjs: []apimachineryruntime.Object{func() *unstructured.Unstructured {
+				obj := newDeploymentObject("demo", "default")
+				now := metav1.Now()
+				obj.SetDeletionTimestamp(&now)
+				return obj
+			}()},
+			wantState: NodeStateDeleting,
+			wantErr:   "currently being deleted",
+		},
+		{
+			name: "terminating managed collection resource marks deleting",
+			configureInstance: func(instance *unstructured.Unstructured) {
+				_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
+			},
+			node: newCollectionNodeForResources(t),
+			currentObjs: []apimachineryruntime.Object{func() *unstructured.Unstructured {
+				obj := newConfigMapObject("one", "default")
+				obj.SetLabels(map[string]string{
+					metadata.InstanceIDLabel: "demo-uid",
+					metadata.NodeIDLabel:     "configs",
+				})
+				now := metav1.Now()
+				obj.SetDeletionTimestamp(&now)
+				return obj
+			}()},
+			wantState: NodeStateDeleting,
+			wantErr:   "currently being deleted",
+		},
 	}
 
 	for _, tt := range tests {
@@ -259,6 +300,9 @@ func TestProcessNodePaths(t *testing.T) {
 			instance := newInstanceObject("demo", "default")
 			if tt.specEnabled != nil {
 				_ = unstructured.SetNestedField(instance.Object, *tt.specEnabled, "spec", "enabled")
+			}
+			if tt.configureInstance != nil {
+				tt.configureInstance(instance)
 			}
 
 			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(tt.node), tt.currentObjs...)
@@ -290,7 +334,7 @@ func TestProcessNodeCollectionTypes(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 	_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
 
-	collectionNode := newCollectionNodeForResources(t, "configs")
+	collectionNode := newCollectionNodeForResources(t)
 	externalCollection := newExternalCollectionNodeForResources(t, nil)
 
 	currentCollection := newConfigMapObject("one", "default")
@@ -416,6 +460,17 @@ func TestProcessExternalRefNodePaths(t *testing.T) {
 			wantState:  NodeStateError,
 			wantErr:    "get failed",
 		},
+		{
+			name:    "terminating external ref does not use deleting shortcut",
+			desired: []*unstructured.Unstructured{newConfigMapObject("demo", "default")},
+			currentObjs: []apimachineryruntime.Object{func() *unstructured.Unstructured {
+				obj := newConfigMapObject("demo", "default")
+				now := metav1.Now()
+				obj.SetDeletionTimestamp(&now)
+				return obj
+			}()},
+			wantState: NodeStateSynced,
+		},
 	}
 
 	for _, tt := range tests {
@@ -534,6 +589,25 @@ func TestProcessExternalCollectionNodePaths(t *testing.T) {
 				return obj
 			}()},
 			wantState: NodeStateWaitingForReadiness,
+		},
+		{
+			name: "terminating external collection item does not use deleting shortcut",
+			node: newExternalCollectionNodeForResources(t, nil),
+			currentObjs: []apimachineryruntime.Object{func() *unstructured.Unstructured {
+				obj := newConfigMapObject("match", "default")
+				obj.SetLabels(map[string]string{"app": "demo"})
+				now := metav1.Now()
+				obj.SetDeletionTimestamp(&now)
+				return obj
+			}()},
+			desired: []*unstructured.Unstructured{func() *unstructured.Unstructured {
+				obj := newConfigMapObject("demo", "default")
+				obj.Object["metadata"].(map[string]interface{})["selector"] = map[string]interface{}{
+					"matchLabels": map[string]interface{}{"app": "demo"},
+				}
+				return obj
+			}()},
+			wantState: NodeStateSynced,
 		},
 	}
 
@@ -784,7 +858,7 @@ func TestUpdateCollectionFromApplyResultsPaths(t *testing.T) {
 			instance := newInstanceObject("demo", "default")
 			_ = unstructured.SetNestedSlice(instance.Object, tt.items, "spec", "items")
 
-			collection := newCollectionNodeForResources(t, "configs")
+			collection := newCollectionNodeForResources(t)
 			controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(collection))
 			node := rcx.Runtime.Nodes()[0]
 			_, err := node.GetDesired()
@@ -807,7 +881,7 @@ func TestUpdateCollectionFromApplyResultsErrorAndPendingPaths(t *testing.T) {
 	}{
 		{
 			name:      "returns nil while collection desired data is still pending",
-			node:      newCollectionNodeForResources(t, "configs"),
+			node:      newCollectionNodeForResources(t),
 			wantState: NodeStateInProgress,
 		},
 		{
@@ -917,12 +991,110 @@ func TestReconcileNodesRetryBranches(t *testing.T) {
 	assert.Contains(t, err.Error(), "UID conflicts")
 }
 
-func newCollectionNodeForResources(t *testing.T, id string) *graph.Node {
+func TestReconcileNodesBlocksDependentsWhenManagedResourcesAreTerminating(t *testing.T) {
+	tests := []struct {
+		name              string
+		configureInstance func(*unstructured.Unstructured)
+		nodes             []*graph.Node
+		currentObjs       func(*unstructured.Unstructured) []apimachineryruntime.Object
+		dependentName     string
+	}{
+		{
+			name: "regular resource blocks dependent apply",
+			nodes: []*graph.Node{
+				{
+					Meta: graph.NodeMeta{
+						ID:           "config",
+						Type:         graph.NodeTypeResource,
+						GVR:          controllerTestCMGVR,
+						Namespaced:   true,
+						Dependencies: nil,
+					},
+					Template: newConfigMapObject("demo-config", ""),
+				},
+				{
+					Meta: graph.NodeMeta{
+						ID:           "deploy",
+						Type:         graph.NodeTypeResource,
+						GVR:          controllerTestDeployGVR,
+						Namespaced:   true,
+						Dependencies: []string{"config"},
+					},
+					Template: newDeploymentObject("demo", ""),
+				},
+			},
+			currentObjs: func(_ *unstructured.Unstructured) []apimachineryruntime.Object {
+				obj := newConfigMapObject("demo-config", "default")
+				now := metav1.Now()
+				obj.SetDeletionTimestamp(&now)
+				return []apimachineryruntime.Object{obj}
+			},
+			dependentName: "demo",
+		},
+		{
+			name: "collection blocks dependent apply",
+			configureInstance: func(instance *unstructured.Unstructured) {
+				_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
+			},
+			nodes: []*graph.Node{
+				func() *graph.Node {
+					node := newCollectionNodeForResources(t)
+					node.Meta.Dependencies = nil
+					return node
+				}(),
+				{
+					Meta: graph.NodeMeta{
+						ID:           "deploy",
+						Type:         graph.NodeTypeResource,
+						GVR:          controllerTestDeployGVR,
+						Namespaced:   true,
+						Dependencies: []string{"configs"},
+					},
+					Template: newDeploymentObject("demo", ""),
+				},
+			},
+			currentObjs: func(instance *unstructured.Unstructured) []apimachineryruntime.Object {
+				obj := newConfigMapObject("one", "default")
+				obj.SetLabels(map[string]string{
+					metadata.InstanceIDLabel: string(instance.GetUID()),
+					metadata.NodeIDLabel:     "configs",
+				})
+				now := metav1.Now()
+				obj.SetDeletionTimestamp(&now)
+				return []apimachineryruntime.Object{obj}
+			},
+			dependentName: "demo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			if tt.configureInstance != nil {
+				tt.configureInstance(instance)
+			}
+
+			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(tt.nodes...), tt.currentObjs(instance)...)
+			err := controller.reconcileNodes(rcx)
+
+			var deletingErr *resourceDeletingError
+			require.ErrorAs(t, err, &deletingErr)
+			assert.Contains(t, err.Error(), "currently being deleted")
+
+			deployClient := raw.Resource(controllerTestDeployGVR).Namespace("default")
+			_, getErr := deployClient.Get(t.Context(), tt.dependentName, metav1.GetOptions{})
+			require.Error(t, getErr)
+			assert.True(t, apierrors.IsNotFound(getErr), "dependent resource should not be created while dependency is terminating")
+		})
+	}
+}
+
+func newCollectionNodeForResources(t *testing.T) *graph.Node {
 	t.Helper()
 
 	return &graph.Node{
 		Meta: graph.NodeMeta{
-			ID:         id,
+			ID:         "configs",
 			Type:       graph.NodeTypeCollection,
 			GVR:        controllerTestCMGVR,
 			Namespaced: true,

--- a/pkg/controller/instance/status.go
+++ b/pkg/controller/instance/status.go
@@ -115,6 +115,11 @@ func (m *ConditionsMarker) ResourcesNotReady(msg string, args ...any) {
 	m.cs.SetFalse(ResourcesReady, "NotReady", fmt.Sprintf(msg, args...))
 }
 
+// ResourcesDeleting signals there are managed resources currently terminating.
+func (m *ConditionsMarker) ResourcesDeleting(msg string, args ...any) {
+	m.cs.SetFalse(ResourcesReady, "ResourceDeleting", fmt.Sprintf(msg, args...))
+}
+
 // ReconciliationSuspended signals that reconciliation is suspended
 func (m *ConditionsMarker) ReconciliationSuspended(msg string, args ...any) {
 	m.cs.SetTrueWithReason(ReconciliationSuspended, "Suspended", fmt.Sprintf(msg, args...))

--- a/test/integration/suites/core/terminating_managed_resource_test.go
+++ b/test/integration/suites/core/terminating_managed_resource_test.go
@@ -1,0 +1,283 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	ctrlinstance "github.com/kubernetes-sigs/kro/pkg/controller/instance"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+var _ = Describe("Terminating Managed Resources", func() {
+	var namespace string
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})).To(Succeed())
+	})
+
+	It("should not create downstream resources while a managed resource is terminating", func(ctx SpecContext) {
+		const (
+			rgdName           = "test-terminating-managed-resource"
+			instanceName      = "test-terminating"
+			blockingFinalizer = "tests.kro.run/block-delete"
+		)
+
+		rgd := generator.NewResourceGraphDefinition(rgdName,
+			generator.WithSchema(
+				"TerminatingManagedResource", "v1alpha1",
+				map[string]interface{}{
+					"name":             "string",
+					"createDeployment": "boolean",
+				},
+				nil,
+			),
+			generator.WithResource("config", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-config",
+				},
+				"data": map[string]interface{}{
+					"value": "active",
+				},
+			}, nil, nil),
+			// The Deployment depends on config data, but it is only desired after createDeployment flips to true.
+			generator.WithResource("deployment", map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}",
+				},
+				"spec": map[string]interface{}{
+					"replicas": 1,
+					"selector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"app": "${schema.spec.name}",
+						},
+					},
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"app": "${schema.spec.name}",
+							},
+						},
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx",
+									"env": []interface{}{
+										map[string]interface{}{
+											"name":  "CONFIG_VALUE",
+											"value": "${config.data.value}",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}, nil, []string{"${schema.spec.createDeployment}"}),
+		)
+
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			_ = env.Client.Delete(ctx, rgd)
+		})
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		instance := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+				"kind":       "TerminatingManagedResource",
+				"metadata": map[string]interface{}{
+					"name":      instanceName,
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"name":             instanceName,
+					"createDeployment": false,
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			_ = env.Client.Delete(ctx, instance)
+		})
+
+		configMapName := instanceName + "-config"
+		configMapKey := types.NamespacedName{Name: configMapName, Namespace: namespace}
+		deploymentKey := types.NamespacedName{Name: instanceName, Namespace: namespace}
+
+		// Start with only the upstream managed resource desired.
+		configMap := &corev1.ConfigMap{}
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, configMapKey, configMap)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(configMap.Data["value"]).To(Equal("active"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, deploymentKey, &appsv1.Deployment{})
+			g.Expect(err).To(MatchError(errors.IsNotFound, "deployment should not be created before it becomes desired"))
+		}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: namespace}, instance)
+			g.Expect(err).ToNot(HaveOccurred())
+			state, found, err := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(state).To(Equal("ACTIVE"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// Hold the ConfigMap in a terminating state so reconcile sees a live object with deletionTimestamp set.
+		DeferCleanup(func(ctx SpecContext) {
+			current := &corev1.ConfigMap{}
+			if err := env.Client.Get(ctx, configMapKey, current); err != nil {
+				return
+			}
+			current.Finalizers = nil
+			_ = env.Client.Update(ctx, current)
+		})
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, configMapKey, configMap)
+			g.Expect(err).ToNot(HaveOccurred())
+			configMap.Finalizers = append(configMap.Finalizers, blockingFinalizer)
+			g.Expect(env.Client.Update(ctx, configMap)).To(Succeed())
+		}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		Expect(env.Client.Delete(ctx, configMap)).To(Succeed())
+		Eventually(func(g Gomega, ctx SpecContext) {
+			current := &corev1.ConfigMap{}
+			err := env.Client.Get(ctx, configMapKey, current)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(current.GetDeletionTimestamp()).ToNot(BeNil())
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// Make the downstream Deployment newly desired while the upstream ConfigMap is still terminating.
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: namespace}, instance)
+			g.Expect(err).ToNot(HaveOccurred())
+			spec, found, err := unstructured.NestedMap(instance.Object, "spec")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			spec["createDeployment"] = true
+			g.Expect(unstructured.SetNestedMap(instance.Object, spec, "spec")).To(Succeed())
+			g.Expect(env.Client.Update(ctx, instance)).To(Succeed())
+		}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: namespace}, instance)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			state, found, err := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(state).To(Equal("IN_PROGRESS"))
+
+			statusConditions, found, err := unstructured.NestedSlice(instance.Object, "status", "conditions")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+
+			var resourcesReadyCondition map[string]interface{}
+			for _, condInterface := range statusConditions {
+				if cond, ok := condInterface.(map[string]interface{}); ok && cond["type"] == ctrlinstance.ResourcesReady {
+					resourcesReadyCondition = cond
+					break
+				}
+			}
+
+			g.Expect(resourcesReadyCondition).ToNot(BeNil())
+			g.Expect(resourcesReadyCondition["status"]).To(Equal("False"))
+			g.Expect(resourcesReadyCondition["reason"]).To(Equal("ResourceDeleting"))
+			msg, _ := resourcesReadyCondition["message"].(string)
+			g.Expect(msg).To(ContainSubstring(fmt.Sprintf(`resource "%s/%s"`, namespace, configMapName)))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		Consistently(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, deploymentKey, &appsv1.Deployment{})
+			g.Expect(err).To(MatchError(errors.IsNotFound, "deployment should not be created while configmap is terminating"))
+		}, 8*time.Second, 500*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		// Once deletion completes, the controller should recreate the ConfigMap and then continue with the Deployment.
+		Expect(env.Client.Get(ctx, configMapKey, configMap)).To(Succeed())
+		configMap.Finalizers = nil
+		Expect(env.Client.Update(ctx, configMap)).To(Succeed())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, configMapKey, &corev1.ConfigMap{})
+			g.Expect(err).To(MatchError(errors.IsNotFound, "terminating configmap should be deleted after finalizer removal"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			current := &corev1.ConfigMap{}
+			err := env.Client.Get(ctx, configMapKey, current)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(current.GetDeletionTimestamp()).To(BeNil())
+			g.Expect(current.Data["value"]).To(Equal("active"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			current := &appsv1.Deployment{}
+			err := env.Client.Get(ctx, deploymentKey, current)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(current.Spec.Template.Spec.Containers).ToNot(BeEmpty())
+			g.Expect(current.Spec.Template.Spec.Containers[0].Env).ToNot(BeEmpty())
+			g.Expect(current.Spec.Template.Spec.Containers[0].Env[0].Value).To(Equal("active"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: namespace}, instance)
+			g.Expect(err).ToNot(HaveOccurred())
+			state, found, err := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(state).To(Equal("ACTIVE"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+})


### PR DESCRIPTION
When a managed resource is manually deleted, Kubernetes can keep the
object visible during finalization with a `deletionTimestamp` set. In
that window, kro was still treating the resource as present and could
continue reconciliation as if nothing was wrong.

That makes the behavior misleading for users and unsafe for dependency
ordering. A terminating managed resource cannot be recreated yet, and
downstream resources should not keep progressing while one of their
managed inputs is actively being deleted.

Detect terminating managed single resources and managed collection
items during normal reconcile, mark the instance as
`ResourcesReady=False` with reason `ResourceDeleting`, and requeue until
deletion completes instead of continuing apply/prune work.