### PR TITLE
feat(cel): add support for `TwoVarComprehensions` in CEL environment 

### DIFF
--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -103,6 +103,7 @@ var (
 func BaseDeclarations() []cel.EnvOption {
 	baseDeclarationsOnce.Do(func() {
 		cachedBaseDeclarations = []cel.EnvOption{
+			ext.TwoVarComprehensions(),
 			ext.Lists(),
 			ext.Strings(),
 			cel.OptionalTypes(),

--- a/pkg/cel/environment_test.go
+++ b/pkg/cel/environment_test.go
@@ -15,6 +15,7 @@
 package cel
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/google/cel-go/cel"
@@ -155,6 +156,70 @@ func TestDefaultEnvironment_KubernetesLibraries(t *testing.T) {
 	expr := `url("https://example.com/foo").getHost()`
 	_, issues := env.Compile(expr)
 	require.NoError(t, issues.Err(), "expected URL expression to compile without errors")
+}
+
+// TestDefaultEnvironment_TwoVarComprehensions verifies that the two-variable
+// comprehension macros (transformMap, transformMapEntry, transformList) from
+// ext.TwoVarComprehensions() work through kro's CEL environment.
+func TestDefaultEnvironment_TwoVarComprehensions(t *testing.T) {
+	env, err := DefaultEnvironment()
+	require.NoError(t, err, "failed to create CEL env")
+
+	tests := []struct {
+		name string
+		expr string
+		want any
+	}{
+		{
+			name: "transformMap on list doubles values",
+			expr: `[10, 20, 30].transformMap(i, v, v * 2)`,
+			want: map[int64]int64{0: 20, 1: 40, 2: 60},
+		},
+		{
+			name: "transformMap on list with filter",
+			expr: `[10, 20, 30].transformMap(i, v, i > 0, v * 2)`,
+			want: map[int64]int64{1: 40, 2: 60},
+		},
+		{
+			name: "transformMap on map adds 10 to values",
+			expr: `{'a': 1, 'b': 2}.transformMap(k, v, v + 10)`,
+			want: map[string]int64{"a": 11, "b": 12},
+		},
+		{
+			name: "transformMapEntry on list swaps key/value",
+			expr: `['x','y'].transformMapEntry(i, v, {v: i})`,
+			want: map[string]int64{"x": 0, "y": 1},
+		},
+		{
+			name: "transformMapEntry on map doubles value",
+			expr: `{'a': 1}.transformMapEntry(k, v, {k: v * 2})`,
+			want: map[string]int64{"a": 2},
+		},
+		{
+			name: "transformList on map extracts keys",
+			expr: `{'a': 1, 'b': 2}.transformList(k, v, k)`,
+			want: []string{"a", "b"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ast, issues := env.Compile(tc.expr)
+			require.NoError(t, issues.Err(), "compile failed")
+
+			prog, err := env.Program(ast)
+			require.NoError(t, err, "program creation failed")
+
+			out, _, err := prog.Eval(cel.NoVars())
+			require.NoError(t, err, "eval failed")
+
+			// Convert CEL ref.Val result to a native Go value for comparison.
+			got, err := out.ConvertToNative(reflect.TypeOf(tc.want))
+			require.NoError(t, err, "native conversion failed")
+
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }
 
 func TestBaseDeclarations_ReturnsSameSlice(t *testing.T) {

--- a/test/integration/suites/core/two_var_comprehensions_test.go
+++ b/test/integration/suites/core/two_var_comprehensions_test.go
@@ -1,0 +1,129 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+var _ = Describe("TwoVarComprehensions", func() {
+	It("should evaluate transformMap, transformMapEntry, and transformList in resource templates", func(ctx SpecContext) {
+		namespace := fmt.Sprintf("test-%s", rand.String(5))
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		Expect(env.Client.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, ns)).To(Succeed())
+		})
+
+		// Create an RGD that uses two-variable comprehension macros in CEL
+		// expressions to compute ConfigMap data values. This exercises the
+		// full pipeline: graph build → CEL compilation → runtime eval.
+		rgd := generator.NewResourceGraphDefinition("test-two-var-comp",
+			generator.WithSchema(
+				"TwoVarComp", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+				},
+				nil,
+			),
+			generator.WithResource("configmap", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}",
+				},
+				"data": map[string]interface{}{
+					// transformMap on a map: add 10 to each value, then read key 'a'
+					"transformMapValue": "${string({'a': 1, 'b': 2}.transformMap(k, v, v + 10)['a'])}",
+					// transformMapEntry on a list: build {value: index} map, read 'x'
+					"transformMapEntryValue": "${string(['x', 'y'].transformMapEntry(i, v, {v: string(i)})['x'])}",
+					// transformList on a map: extract keys, check size
+					"transformListSize": "${string({'p': 1, 'q': 2, 'r': 3}.transformList(k, v, k).size())}",
+					// transformMap on a list with filter: keep only index > 0
+					"transformMapFiltered": "${string([10, 20, 30].transformMap(i, v, i > 0, v * 2).size())}",
+				},
+			}, nil, nil),
+		)
+
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+
+		// Wait for the RGD to become Active (graph builds, CEL compiles)
+		createdRGD := &krov1alpha1.ResourceGraphDefinition{}
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name: rgd.Name,
+			}, createdRGD)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(createdRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// Create an instance of the RGD
+		instance := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+				"kind":       "TwoVarComp",
+				"metadata": map[string]interface{}{
+					"name":      "test-two-var",
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"name": "two-var-result",
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		// Verify the ConfigMap was created with correctly computed values
+		cm := &corev1.ConfigMap{}
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      "two-var-result",
+				Namespace: namespace,
+			}, cm)
+			g.Expect(err).ToNot(HaveOccurred())
+			// transformMap: {'a':1,'b':2}.transformMap(k,v,v+10)['a'] == 11
+			g.Expect(cm.Data["transformMapValue"]).To(Equal("11"))
+			// transformMapEntry: ['x','y'].transformMapEntry(i,v,{v:string(i)})['x'] == "0"
+			g.Expect(cm.Data["transformMapEntryValue"]).To(Equal("0"))
+			// transformList: {'p':1,'q':2,'r':3}.transformList(k,v,k).size() == 3
+			g.Expect(cm.Data["transformListSize"]).To(Equal("3"))
+			// transformMap filtered: [10,20,30].transformMap(i,v,i>0,v*2).size() == 2
+			g.Expect(cm.Data["transformMapFiltered"]).To(Equal("2"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// Cleanup
+		Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+	})
+})

--- a/website/docs/docs/concepts/rgd/03-cel-expressions.md
+++ b/website/docs/docs/concepts/rgd/03-cel-expressions.md
@@ -318,15 +318,16 @@ The `?` operator prevents kro from validating the field's existence at build tim
 
 ## Available CEL Libraries
 
-| Library | Documentation |
-|---------|---------------|
-| Lists | [cel-go/ext](https://pkg.go.dev/github.com/google/cel-go/ext#Lists) |
-| Strings | [cel-go/ext](https://pkg.go.dev/github.com/google/cel-go/ext#Strings) |
-| Encoders | [cel-go/ext](https://pkg.go.dev/github.com/google/cel-go/ext#Encoders) |
-| Random | [kro custom](https://github.com/kubernetes-sigs/kro/blob/main/pkg/cel/library/random.go) |
-| JSON | [kro custom](https://github.com/kubernetes-sigs/kro/blob/main/pkg/cel/library/json.go) |
-| URLs | [k8s.io/apiserver/pkg/cel/library](https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#URLs) |
-| Regex | [k8s.io/apiserver/pkg/cel/library](https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Regex) |
+| Library                     | Documentation                                                                                 |
+|-----------------------------|-----------------------------------------------------------------------------------------------|
+| Lists                       | [cel-go/ext](https://pkg.go.dev/github.com/google/cel-go/ext#Lists)                           |
+| Strings                     | [cel-go/ext](https://pkg.go.dev/github.com/google/cel-go/ext#Strings)                         |
+| Encoders                    | [cel-go/ext](https://pkg.go.dev/github.com/google/cel-go/ext#Encoders)                        |
+| Two-Variable Comprehensions | [cel-go/ext](https://pkg.go.dev/github.com/google/cel-go/ext#TwoVarComprehensions)            |
+| Random                      | [kro custom](https://github.com/kubernetes-sigs/kro/blob/main/pkg/cel/library/random.go)      |
+| JSON                        | [kro custom](https://github.com/kubernetes-sigs/kro/blob/main/pkg/cel/library/json.go)        |
+| URLs                        | [k8s.io/apiserver/pkg/cel/library](https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#URLs)  |
+| Regex                       | [k8s.io/apiserver/pkg/cel/library](https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Regex) |
 
 For the complete CEL language reference, see the [CEL language definitions](https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions).
 
@@ -464,6 +465,64 @@ allReady: ${schema.spec.services.all(s, s.enabled)}
 # Sort by a field (lexicographic ordering)
 sorted: ${items.sortBy(item, item.data.priority)}
 orderedNames: ${items.sortBy(i, i.data.priority).map(i, i.metadata.name).join(",")}
+```
+
+### Converting Between Lists and Maps
+
+The two-variable comprehension macros let you transform lists into maps, reshape maps, and extract lists from maps. Each macro provides access to both the key/index and the value of each entry.
+
+#### `transformMap` — Transform values, keeping keys
+
+Applies an expression to each value while preserving the original keys (or indices for lists):
+
+```kro
+# Double each value in a map
+scaled: ${{ "cpu": 2, "memory": 4 }.transformMap(k, v, v * 2)}
+# → {"cpu": 4, "memory": 8}
+
+# Convert a list to a map of {index: transformed_value}
+indexed: ${schema.spec.ports.transformMap(i, v, v + 1000)}
+# [80, 443] → {0: 1080, 1: 1443}
+```
+
+With an optional filter predicate (four-argument form), only entries where the predicate is true are included:
+
+```kro
+# Keep only entries with value > 1
+filtered: ${{ "a": 1, "b": 5, "c": 3 }.transformMap(k, v, v > 1, v * 10)}
+# → {"b": 50, "c": 30}
+```
+
+#### `transformMapEntry` — Build new key-value pairs
+
+Each iteration must return a single-entry map `{key: value}`. The results are merged into one map:
+
+```kro
+# Swap keys and values
+swapped: ${{ "us-east-1": "primary", "eu-west-1": "secondary" }.transformMapEntry(k, v, {v: k})}
+# → {"primary": "us-east-1", "secondary": "eu-west-1"}
+
+# Convert a list of names into a map of {name: index}
+nameIndex: ${schema.spec.items.transformMapEntry(i, v, {v: string(i)})}
+# ["app", "db"] → {"app": "0", "db": "1"}
+```
+
+#### `transformList` — Extract a list from a map
+
+Converts a map to a list by evaluating an expression for each entry:
+
+```kro
+# Extract all keys
+keys: ${{ "app": "nginx", "version": "1.19" }.transformList(k, v, k)}
+# → ["app", "version"]
+
+# Extract all values
+values: ${{ "app": "nginx", "version": "1.19" }.transformList(k, v, v)}
+# → ["nginx", "1.19"]
+
+# Build formatted strings from key-value pairs
+envVars: ${{ "APP": "nginx", "PORT": "8080" }.transformList(k, v, k + "=" + v)}
+# → ["APP=nginx", "PORT=8080"]
 ```
 
 ### Aggregating Status


### PR DESCRIPTION
- Integrate `TwoVarComprehensions` into the BaseDeclarations for CEL environments.
- Add unit tests validating `transformMap`, `transformMapEntry`, and `transformList` comprehension macros.
- Introduce integration tests to verify resource templates utilizing two-variable comprehension macros and full pipeline execution.

These introduce useful functions for converting lists and maps so its possible to do more complex transformations (i.e. when working with complex config or values objects)