### PR TITLE
fix: reconcile on annotation changes

### DIFF
--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -17,6 +17,7 @@ package resourcegraphdefinition
 import (
 	"context"
 	"errors"
+	"maps"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -141,7 +142,8 @@ func (r *ResourceGraphDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) e
 // server.
 //
 // This predicate reconciles when:
-//   - spec changes  (generation changed), or
+//   - spec changes  (generation changed),
+//   - annotation changes, or
 //   - deletion begins (deletionTimestamp transitions from zero to non-zero).
 //
 // It skips:
@@ -156,7 +158,10 @@ func resourceGraphDefinitionPrimaryWatchPredicate() predicate.Predicate {
 
 			oldDeleting := !e.ObjectOld.GetDeletionTimestamp().IsZero()
 			newDeleting := !e.ObjectNew.GetDeletionTimestamp().IsZero()
-			return e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration() || oldDeleting != newDeleting
+			// Annotations control behavior but don't trigger new generation
+			return e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration() ||
+				oldDeleting != newDeleting ||
+				!maps.Equal(e.ObjectNew.GetAnnotations(), e.ObjectOld.GetAnnotations())
 		},
 		DeleteFunc: func(event.DeleteEvent) bool {
 			return false

--- a/pkg/controller/resourcegraphdefinition/controller_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_test.go
@@ -847,6 +847,46 @@ func TestResourceGraphDefinitionPrimaryWatchPredicate(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "accepts annotation changes",
+			run: func(pred predicate.Predicate) bool {
+				old := newPredicateTestRGD(1, nil)
+				old.Annotations = map[string]string{"key": "value1"}
+				new := newPredicateTestRGD(1, nil)
+				new.Annotations = map[string]string{"key": "value2"}
+				return pred.Update(event.UpdateEvent{
+					ObjectOld: old,
+					ObjectNew: new,
+				})
+			},
+			want: true,
+		},
+		{
+			name: "accepts annotation additions",
+			run: func(pred predicate.Predicate) bool {
+				old := newPredicateTestRGD(1, nil)
+				new := newPredicateTestRGD(1, nil)
+				new.Annotations = map[string]string{"key": "value"}
+				return pred.Update(event.UpdateEvent{
+					ObjectOld: old,
+					ObjectNew: new,
+				})
+			},
+			want: true,
+		},
+		{
+			name: "accepts annotation removals",
+			run: func(pred predicate.Predicate) bool {
+				old := newPredicateTestRGD(1, nil)
+				old.Annotations = map[string]string{"key": "value"}
+				new := newPredicateTestRGD(1, nil)
+				return pred.Update(event.UpdateEvent{
+					ObjectOld: old,
+					ObjectNew: new,
+				})
+			},
+			want: true,
+		},
+		{
 			name: "ignores status only updates",
 			run: func(pred predicate.Predicate) bool {
 				return pred.Update(event.UpdateEvent{


### PR DESCRIPTION
Fix a bug of Kro not reconciling on annotation changes

A user could update an RGD with `kro.run/allow-breaking-changes` but this update may not be considered by kro until another reconcile is triggered.

Mentioned in this issue https://github.com/kubernetes-sigs/kro/issues/1031#issuecomment-3960682798