### PR TITLE
feat(cel): add omit() for conditional field omission in templates

### DIFF
--- a/pkg/cel/ast/inspector.go
+++ b/pkg/cel/ast/inspector.go
@@ -83,6 +83,16 @@ type ExpressionInspection struct {
 	UnknownFunctions []UnknownFunction
 }
 
+// UsesOmit reports whether the inspected expression contains a call to omit().
+func (e *ExpressionInspection) UsesOmit() bool {
+	for _, fc := range e.FunctionCalls {
+		if fc.Name == "omit" {
+			return true
+		}
+	}
+	return false
+}
+
 func (e *ExpressionInspection) merge(other ExpressionInspection) {
 	e.ResourceDependencies = append(e.ResourceDependencies, other.ResourceDependencies...)
 	e.FunctionCalls = append(e.FunctionCalls, other.FunctionCalls...)

--- a/pkg/cel/conversion/conversions.go
+++ b/pkg/cel/conversion/conversions.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
+	"github.com/kubernetes-sigs/kro/pkg/cel/sentinels"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -68,6 +69,10 @@ func GoNativeType(v ref.Val) (interface{}, error) {
 	case types.NullType:
 		return nil, nil
 	default:
+		// Check if this is the omit sentinel before falling through to error.
+		if _, ok := v.Value().(sentinels.Omit); ok {
+			return sentinels.Omit{}, nil
+		}
 		// For types we can't convert, return as is with an error
 		return v.Value(), fmt.Errorf("%w: %v", ErrUnsupportedType, v.Type())
 	}

--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -119,6 +119,11 @@ func BaseDeclarations() []cel.EnvOption {
 			library.Maps(),
 			library.JSON(),
 			library.Lists(),
+			// Omit() is registered globally so CEL can parse and type-check it
+			// everywhere. The graph builder rejects it in restricted contexts
+			// (includeWhen, readyWhen, forEach) via inspectExpressionRestricted
+			// and validateAndCompileForEach.
+			library.Omit(),
 		}
 	})
 	return cachedBaseDeclarations

--- a/pkg/cel/library/omit.go
+++ b/pkg/cel/library/omit.go
@@ -1,0 +1,103 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package library
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/kubernetes-sigs/kro/pkg/cel/sentinels"
+)
+
+// omitVal is the CEL ref.Val wrapper for the omit sentinel.
+type omitVal struct{}
+
+// singleton — there's only one omit sentinel.
+var omitInstance = &omitVal{}
+
+func (v *omitVal) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	if typeDesc == reflect.TypeOf(sentinels.Omit{}) {
+		return sentinels.Omit{}, nil
+	}
+	if typeDesc.Kind() == reflect.Interface {
+		return sentinels.Omit{}, nil
+	}
+	return nil, fmt.Errorf("unsupported native conversion from omit to %v", typeDesc)
+}
+
+func (v *omitVal) ConvertToType(typeVal ref.Type) ref.Val {
+	if typeVal == types.TypeType {
+		return types.NewObjectType("kro.omit")
+	}
+	return types.NewErr("unsupported conversion from omit to %v", typeVal)
+}
+
+func (v *omitVal) Equal(other ref.Val) ref.Val {
+	return types.NewErr("omit() is a field-removal sentinel and cannot be compared")
+}
+
+func (v *omitVal) Type() ref.Type {
+	return types.NewObjectType("kro.omit")
+}
+
+func (v *omitVal) Value() any {
+	return sentinels.Omit{}
+}
+
+// Omit returns a cel.EnvOption that registers the omit() function.
+//
+// omit() is a zero-argument function that returns a sentinel value.
+// When the resolver encounters this sentinel as a field's resolved value,
+// it removes the field (or array element) from the rendered object instead
+// of writing it.
+//
+// omit() is only valid in standalone template field expressions.
+// It must not be used in includeWhen, readyWhen, forEach, or string
+// template fragments.
+//
+// Example usage:
+//
+//	policy: ${schema.spec.policy != "" ? schema.spec.policy : omit()}
+//	scaling: ${schema.spec.autoscaling.enabled ? schema.spec.scaling : omit()}
+func Omit() cel.EnvOption {
+	return cel.Lib(&omitLib{})
+}
+
+type omitLib struct{}
+
+func (l *omitLib) LibraryName() string {
+	return "kro.omit"
+}
+
+func (l *omitLib) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Function("omit",
+			cel.Overload("omit_void",
+				[]*cel.Type{},
+				cel.DynType,
+				cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+					return omitInstance
+				}),
+			),
+		),
+	}
+}
+
+func (l *omitLib) ProgramOptions() []cel.ProgramOption {
+	return nil
+}

--- a/pkg/cel/library/omit_test.go
+++ b/pkg/cel/library/omit_test.go
@@ -1,0 +1,145 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package library
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubernetes-sigs/kro/pkg/cel/conversion"
+	"github.com/kubernetes-sigs/kro/pkg/cel/sentinels"
+)
+
+func TestOmit(t *testing.T) {
+	env, err := cel.NewEnv(Omit())
+	require.NoError(t, err)
+
+	ast, issues := env.Compile("omit()")
+	require.NoError(t, issues.Err())
+
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	out, _, err := prg.Eval(map[string]interface{}{})
+	require.NoError(t, err)
+
+	native, err := conversion.GoNativeType(out)
+	require.NoError(t, err)
+	assert.True(t, sentinels.IsOmit(native))
+}
+
+func TestOmitInTernary(t *testing.T) {
+	env, err := cel.NewEnv(Omit(), cel.Variable("x", cel.StringType))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		expr        string
+		ctx         map[string]interface{}
+		wantOmit    bool
+		wantEvalErr bool
+		wantString  string
+	}{
+		{
+			name:     "ternary selects omit branch",
+			expr:     `x == "" ? omit() : x`,
+			ctx:      map[string]interface{}{"x": ""},
+			wantOmit: true,
+		},
+		{
+			name:       "ternary selects value branch",
+			expr:       `x == "" ? omit() : x`,
+			ctx:        map[string]interface{}{"x": "hello"},
+			wantOmit:   false,
+			wantString: "hello",
+		},
+		{
+			name:       "omit in else branch, condition true",
+			expr:       `x != "" ? x : omit()`,
+			ctx:        map[string]interface{}{"x": "hello"},
+			wantOmit:   false,
+			wantString: "hello",
+		},
+		{
+			name:     "omit in else branch, condition false",
+			expr:     `x != "" ? x : omit()`,
+			ctx:      map[string]interface{}{"x": ""},
+			wantOmit: true,
+		},
+		{
+			name:        "invalid omit operation, arithmetic",
+			expr:        `omit() + 1`,
+			wantOmit:    false,
+			wantEvalErr: true,
+		},
+		{
+			name:        "invalid omit operation, same-type equality",
+			expr:        `omit() == omit()`,
+			wantOmit:    false,
+			wantEvalErr: true,
+		},
+		{
+			name:        "invalid omit in string template, prefix",
+			expr:        `"prefix-" + omit()`,
+			wantOmit:    false,
+			wantEvalErr: true,
+		},
+		{
+			name:        "invalid omit in string template, full",
+			expr:        `"prefix-" + omit() + "-suffix"`,
+			wantOmit:    false,
+			wantEvalErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ast, issues := env.Compile(tc.expr)
+			require.NoError(t, issues.Err())
+
+			prg, err := env.Program(ast)
+			require.NoError(t, err)
+
+			out, _, err := prg.Eval(tc.ctx)
+			if tc.wantEvalErr {
+				if err != nil {
+					return
+				}
+				assert.True(t, types.IsError(out), "expected error but got %v", out)
+				return
+			}
+			assert.NoError(t, err)
+
+			native, err := conversion.GoNativeType(out)
+			require.NoError(t, err)
+
+			if tc.wantOmit {
+				assert.True(t, sentinels.IsOmit(native))
+			} else {
+				assert.False(t, sentinels.IsOmit(native))
+				assert.Equal(t, tc.wantString, native)
+			}
+		})
+	}
+}
+
+func TestOmitLibraryName(t *testing.T) {
+	lib := &omitLib{}
+	assert.Equal(t, "kro.omit", lib.LibraryName())
+}

--- a/pkg/cel/sentinels/sentinels.go
+++ b/pkg/cel/sentinels/sentinels.go
@@ -1,0 +1,26 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sentinels
+
+// Omit is a marker value that signals the resolver to remove the
+// containing field or array element from the rendered object instead
+// of writing a value.
+type Omit struct{}
+
+// IsOmit returns true if the value is an Omit sentinel.
+func IsOmit(v interface{}) bool {
+	_, ok := v.(Omit)
+	return ok
+}

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -843,6 +843,12 @@ func inspectExpressionRestricted(inspector *ast.Inspector, expr string, allowedI
 	if len(result.UnknownFunctions) > 0 {
 		return ast.ExpressionInspection{}, fmt.Errorf("uses unknown functions: %v", result.UnknownFunctions)
 	}
+	// omit() is registered globally but is only valid in resource template
+	// expressions. Reject it in restricted contexts (includeWhen, readyWhen,
+	// instance status).
+	if result.UsesOmit() {
+		return ast.ExpressionInspection{}, fmt.Errorf("omit() can only be used in resource template expressions")
+	}
 	return result, nil
 }
 
@@ -1085,7 +1091,7 @@ func validateAndCompileNode(builderCache *celcache.BuilderCache, sessionCache *c
 	// If this node has forEach iterators, validate and compile them
 	if len(node.ForEach) > 0 {
 		var err error
-		iteratorTypes, err = validateAndCompileForEach(sessionCache, env, node)
+		iteratorTypes, err = validateAndCompileForEach(sessionCache, env, node, inspector)
 		if err != nil {
 			return err
 		}
@@ -1159,7 +1165,14 @@ func validateAndCompileTemplates(
 	typeProvider *krocel.DeclTypeProvider,
 	iteratorTypes map[string]*cel.Type,
 ) error {
-	// If we have iterator types (from forEach), extend the environment with those declarations
+	// NOTE: omit() is allowed in template expressions. Restricted-context
+	// rejection (includeWhen, readyWhen, forEach) is handled by the compiler
+	// in inspectExpressionRestricted and validateAndCompileForEach.
+	//
+	// TODO: Add validation that required resource fields (e.g. metadata.name)
+	// cannot evaluate to null or omit(). Currently nothing prevents a user
+	// from writing `metadata.name: ${omit()}`, which produces an invalid
+	// resource at apply time.
 	compileEnv := env
 	if len(iteratorTypes) > 0 {
 		opts := make([]cel.EnvOption, 0, len(iteratorTypes))
@@ -1293,7 +1306,7 @@ func validateAndCompileReadyWhen(sessionCache *celcache.SessionCache, env *cel.E
 //
 // The inferred element type of each list is used to declare the iterator variable
 // in the CEL environment for validating template expressions.
-func validateAndCompileForEach(sessionCache *celcache.SessionCache, env *cel.Env, node *Node) (map[string]*cel.Type, error) {
+func validateAndCompileForEach(sessionCache *celcache.SessionCache, env *cel.Env, node *Node, inspector *ast.Inspector) (map[string]*cel.Type, error) {
 	if len(node.ForEach) == 0 {
 		return nil, nil
 	}
@@ -1301,6 +1314,17 @@ func validateAndCompileForEach(sessionCache *celcache.SessionCache, env *cel.Env
 	iteratorTypes := make(map[string]*cel.Type, len(node.ForEach))
 
 	for _, iter := range node.ForEach {
+		// Reject omit() in forEach expressions — it's only valid in resource
+		// template expressions. We check the inspection result here to avoid
+		// a redundant inspector.Inspect() call in a separate pass.
+		inspection, inspErr := inspector.Inspect(iter.Expression.Original)
+		if inspErr != nil {
+			return nil, fmt.Errorf("node %q: forEach iterator %q: failed to inspect expression: %w", node.Meta.ID, iter.Name, inspErr)
+		}
+		if inspection.UsesOmit() {
+			return nil, fmt.Errorf("node %q: forEach iterator %q: omit() can only be used in resource template expressions", node.Meta.ID, iter.Name)
+		}
+
 		// Parse, type-check, and compile the forEach expression
 		checkedAST, err := parseCheckAndCompile(sessionCache, env, iter.Expression)
 		if err != nil {

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -4105,7 +4105,8 @@ func TestBuilderHelperCases(t *testing.T) {
 		{
 			name: "validateAndCompileForEach handles empty and invalid expressions",
 			run: func(t *testing.T) {
-				iteratorTypes, err := validateAndCompileForEach(sessionCache, plainEnv, &Node{})
+				inspector := newUnitInspector(t, "schema")
+				iteratorTypes, err := validateAndCompileForEach(sessionCache, plainEnv, &Node{}, inspector)
 				require.NoError(t, err)
 				assert.Nil(t, iteratorTypes)
 
@@ -4114,7 +4115,7 @@ func TestBuilderHelperCases(t *testing.T) {
 					ForEach: []ForEachDimension{
 						{Name: "item", Expression: expr("items +")},
 					},
-				})
+				}, inspector)
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), `node "resource": forEach iterator "item"`)
 			},
@@ -4155,6 +4156,33 @@ func TestBuilderHelperCases(t *testing.T) {
 			},
 		},
 		{
+			name: "extractDependencies accepts omit as a known function",
+			run: func(t *testing.T) {
+				inspector := newUnitInspector(t, "schema", "resource")
+				deps, _, err := extractDependencies(inspector, expr("schema.spec.x != '' ? schema.spec.x : omit()"), nil)
+				require.NoError(t, err)
+				assert.Empty(t, deps, "omit() should not produce resource dependencies")
+			},
+		},
+		{
+			name: "extractDependencies accepts standalone omit call",
+			run: func(t *testing.T) {
+				inspector := newUnitInspector(t, "schema")
+				deps, _, err := extractDependencies(inspector, expr("omit()"), nil)
+				require.NoError(t, err)
+				assert.Empty(t, deps)
+			},
+		},
+		{
+			name: "inspectExpressionRestricted rejects omit in restricted context",
+			run: func(t *testing.T) {
+				inspector := newUnitInspector(t, "schema", "resource")
+				_, err := inspectExpressionRestricted(inspector, "schema.spec.x != '' ? schema.spec.x : omit()", []string{"schema"})
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "omit() can only be used in resource template expressions")
+			},
+		},
+		{
 			name: "buildDependencyGraph rejects duplicate node IDs",
 			run: func(t *testing.T) {
 				builder := &Builder{}
@@ -4181,6 +4209,47 @@ func TestBuilderHelperCases(t *testing.T) {
 				_, err := extractForEachDependencies(inspector, node, []string{"item"})
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to extract dependencies from forEach iterator")
+			},
+		},
+		{
+			name: "includeWhen rejects omit function",
+			run: func(t *testing.T) {
+				node := &Node{
+					Meta:        NodeMeta{ID: "resource", Type: NodeTypeResource},
+					IncludeWhen: []*krocel.Expression{expr("omit()")},
+				}
+				err := validateAndCompileNode(builderCache, sessionCache, node, newUnitInspector(t, "schema", "resource"), resourceEnv, rootSchema, provider)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "includeWhen")
+				assert.Contains(t, err.Error(), "must return bool or optional_type(bool), but returns \"dyn\"")
+			},
+		},
+		{
+			name: "readyWhen rejects omit function",
+			run: func(t *testing.T) {
+				node := &Node{
+					Meta:      NodeMeta{ID: "resource", Type: NodeTypeResource},
+					ReadyWhen: []*krocel.Expression{expr("omit()")},
+				}
+				err := validateAndCompileNode(builderCache, sessionCache, node, newUnitInspector(t, "schema", "resource"), resourceEnv, rootSchema, provider)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "readyWhen")
+				assert.Contains(t, err.Error(), "omit() can only be used in resource template expressions")
+			},
+		},
+		{
+			name: "forEach rejects omit function",
+			run: func(t *testing.T) {
+				node := &Node{
+					Meta: NodeMeta{ID: "resource", Type: NodeTypeCollection},
+					ForEach: []ForEachDimension{
+						{Name: "item", Expression: expr("omit()")},
+					},
+				}
+				err := validateAndCompileNode(builderCache, sessionCache, node, newUnitInspector(t, "schema", "resource"), resourceEnv, rootSchema, provider)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "forEach")
+				assert.Contains(t, err.Error(), "omit() can only be used in resource template expressions")
 			},
 		},
 	}

--- a/pkg/runtime/resolver/resolver.go
+++ b/pkg/runtime/resolver/resolver.go
@@ -17,6 +17,7 @@ package resolver
 import (
 	"fmt"
 
+	"github.com/kubernetes-sigs/kro/pkg/cel/sentinels"
 	"github.com/kubernetes-sigs/kro/pkg/graph/fieldpath"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 )
@@ -58,6 +59,10 @@ func NewResolver(resource map[string]interface{}, data map[string]interface{}) *
 
 // Resolve processes all the given ExpressionFields and resolves their CEL expressions.
 // It returns a ResolutionSummary containing information about the resolution process.
+//
+// Omit sentinels are written into the resource like normal values during
+// resolution. After all expressions are evaluated, a single cleanup pass
+// removes any map keys or array elements that hold an omit sentinel.
 func (r *Resolver) Resolve(expressions []variable.FieldDescriptor) ResolutionSummary {
 	summary := ResolutionSummary{
 		TotalExpressions: len(expressions),
@@ -74,6 +79,8 @@ func (r *Resolver) Resolve(expressions []variable.FieldDescriptor) ResolutionSum
 			summary.Errors = append(summary.Errors, result.Error)
 		}
 	}
+
+	cleanOmitSentinels(r.resource)
 
 	return summary
 }
@@ -104,13 +111,43 @@ func (r *Resolver) resolveField(field variable.FieldDescriptor) ResolutionResult
 		result.Error = fmt.Errorf("no data provided for expression: %s", field.Expression.UserExpression())
 		return result
 	}
+
 	// setValueAtPath cannot fail here: if getValueFromPath succeeded,
-	// the path is valid and traversable.
+	// the path is valid and traversable. Omit sentinels are written as
+	// normal values; Resolve strips them in a cleanup pass afterwards.
 	_ = r.setValueAtPath(field.Path, resolvedValue)
 	result.Resolved = true
 	result.Replaced = resolvedValue
 
 	return result
+}
+
+// cleanOmitSentinels recursively walks a resource tree and removes any
+// map keys or array elements whose value is an omit sentinel.
+// For maps, sentinel keys are deleted in place.
+// For arrays, a new filtered slice is returned to the caller.
+func cleanOmitSentinels(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		for k, child := range val {
+			if sentinels.IsOmit(child) {
+				delete(val, k)
+			} else {
+				val[k] = cleanOmitSentinels(child)
+			}
+		}
+		return val
+	case []interface{}:
+		filtered := make([]interface{}, 0, len(val))
+		for _, elem := range val {
+			if !sentinels.IsOmit(elem) {
+				filtered = append(filtered, cleanOmitSentinels(elem))
+			}
+		}
+		return filtered
+	default:
+		return v
+	}
 }
 
 // getValueFromPath retrieves a value from the resource using a dot-separated path.
@@ -119,29 +156,27 @@ func (r *Resolver) getValueFromPath(path string) (interface{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid path '%s': %v", path, err)
 	}
+	return traverse(r.resource, segments)
+}
 
-	current := interface{}(r.resource)
-
+// traverse walks the given segments read-only and returns the value at the end.
+func traverse(root interface{}, segments []fieldpath.Segment) (interface{}, error) {
+	current := root
 	for _, segment := range segments {
 		if segment.Index >= 0 {
-			// Handle array access
 			array, ok := current.([]interface{})
 			if !ok {
 				return nil, fmt.Errorf("expected array at path segment: %v", segment)
 			}
-
 			if segment.Index >= len(array) {
 				return nil, fmt.Errorf("array index out of bounds: %d", segment.Index)
 			}
-
 			current = array[segment.Index]
 		} else {
-			// Handle object access
 			currentMap, ok := current.(map[string]interface{})
 			if !ok {
 				return nil, fmt.Errorf("expected map at path segment: %v", segment)
 			}
-
 			value, ok := currentMap[segment.Name]
 			if !ok {
 				return nil, fmt.Errorf("key not found: %s", segment.Name)
@@ -149,7 +184,6 @@ func (r *Resolver) getValueFromPath(path string) (interface{}, error) {
 			current = value
 		}
 	}
-
 	return current, nil
 }
 

--- a/pkg/runtime/resolver/resolver_test.go
+++ b/pkg/runtime/resolver/resolver_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
+	"github.com/kubernetes-sigs/kro/pkg/cel/sentinels"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 )
 
@@ -834,6 +835,189 @@ func TestResolveFieldWithEmptyBraces(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.want.Replaced, value)
 			}
+		})
+	}
+}
+
+func TestResolveFieldOmit(t *testing.T) {
+	tests := []struct {
+		name         string
+		resource     map[string]interface{}
+		data         map[string]interface{}
+		field        variable.FieldDescriptor
+		wantResolved bool
+		wantSentinel bool
+	}{
+		{
+			name: "omit sentinel is placed in map field",
+			resource: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"name":   "test",
+					"policy": "${expr}",
+				},
+			},
+			data: map[string]interface{}{
+				"expr": sentinels.Omit{},
+			},
+			field: variable.FieldDescriptor{
+				Path:       "spec.policy",
+				Expression: krocel.NewUncompiled("expr"),
+			},
+			wantResolved: true,
+			wantSentinel: true,
+		},
+		{
+			name: "omit sentinel is placed in array element",
+			resource: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"args": []interface{}{"${expr}", "keep"},
+				},
+			},
+			data: map[string]interface{}{
+				"expr": sentinels.Omit{},
+			},
+			field: variable.FieldDescriptor{
+				Path:       "spec.args[0]",
+				Expression: krocel.NewUncompiled("expr"),
+			},
+			wantResolved: true,
+			wantSentinel: true,
+		},
+		{
+			name: "non-sentinel value writes normally",
+			resource: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"policy": "${expr}",
+				},
+			},
+			data: map[string]interface{}{
+				"expr": "my-policy",
+			},
+			field: variable.FieldDescriptor{
+				Path:       "spec.policy",
+				Expression: krocel.NewUncompiled("expr"),
+			},
+			wantResolved: true,
+			wantSentinel: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewResolver(tt.resource, tt.data)
+			result := r.resolveField(tt.field)
+
+			assert.Equal(t, tt.wantResolved, result.Resolved)
+			assert.NoError(t, result.Error)
+
+			value, err := r.getValueFromPath(tt.field.Path)
+			assert.NoError(t, err)
+
+			if tt.wantSentinel {
+				assert.True(t, sentinels.IsOmit(value))
+				assert.True(t, sentinels.IsOmit(result.Replaced))
+			} else {
+				assert.False(t, sentinels.IsOmit(value))
+				assert.Equal(t, tt.data[tt.field.Expression.Original], value)
+			}
+		})
+	}
+}
+
+func TestCleanOmitSentinels(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]interface{}
+		want map[string]interface{}
+	}{
+		{
+			name: "removes top-level map key",
+			in: map[string]interface{}{
+				"keep": "value",
+				"drop": sentinels.Omit{},
+			},
+			want: map[string]interface{}{
+				"keep": "value",
+			},
+		},
+		{
+			name: "removes nested map key",
+			in: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"name":   "test",
+					"policy": sentinels.Omit{},
+				},
+			},
+			want: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"name": "test",
+				},
+			},
+		},
+		{
+			name: "filters array elements",
+			in: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"args": []interface{}{sentinels.Omit{}, "keep1", sentinels.Omit{}, "keep2"},
+				},
+			},
+			want: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"args": []interface{}{"keep1", "keep2"},
+				},
+			},
+		},
+		{
+			name: "filters single-element array to empty",
+			in: map[string]interface{}{
+				"items": []interface{}{sentinels.Omit{}},
+			},
+			want: map[string]interface{}{
+				"items": []interface{}{},
+			},
+		},
+		{
+			name: "cleans deeply nested array inside array",
+			in: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"args": []interface{}{"keep", sentinels.Omit{}, "also-keep"},
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"args": []interface{}{"keep", "also-keep"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no sentinels leaves resource unchanged",
+			in: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"name": "test",
+					"args": []interface{}{"a", "b"},
+				},
+			},
+			want: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"name": "test",
+					"args": []interface{}{"a", "b"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanOmitSentinels(tt.in)
+			assert.Equal(t, tt.want, tt.in)
 		})
 	}
 }

--- a/test/integration/suites/core/omit_test.go
+++ b/test/integration/suites/core/omit_test.go
@@ -1,0 +1,331 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+var _ = Describe("Omit", func() {
+	var namespace string
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		Expect(env.Client.Create(ctx, ns)).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})).To(Succeed())
+	})
+
+	It("should omit a ConfigMap data field when omit() is triggered", func(ctx SpecContext) {
+		rgd := generator.NewResourceGraphDefinition("test-omit",
+			generator.WithSchema(
+				"TestOmit", "v1alpha1",
+				map[string]interface{}{
+					"name":     "string",
+					"optional": "string | default=\"\"",
+				},
+				nil,
+			),
+			generator.WithResource("configmap", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}",
+				},
+				"data": map[string]interface{}{
+					"always":   "present",
+					"optional": `${schema.spec.optional != "" ? schema.spec.optional : omit()}`,
+				},
+			}, nil, nil),
+		)
+
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+
+		// Wait for RGD to become active.
+		createdRGD := &krov1alpha1.ResourceGraphDefinition{}
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, createdRGD)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(createdRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// --- Case 1: optional is empty → field should be omitted ---
+		name1 := fmt.Sprintf("omit-yes-%s", rand.String(4))
+		instance1 := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+				"kind":       "TestOmit",
+				"metadata": map[string]interface{}{
+					"name":      name1,
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"name":     name1,
+					"optional": "",
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance1)).To(Succeed())
+
+		// Wait for instance to become ACTIVE.
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name1, Namespace: namespace}, instance1)
+			g.Expect(err).ToNot(HaveOccurred())
+			val, found, err := unstructured.NestedString(instance1.Object, "status", "state")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(val).To(Equal("ACTIVE"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// Verify ConfigMap: "always" present, "optional" absent.
+		cm1 := &corev1.ConfigMap{}
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name1, Namespace: namespace}, cm1)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(cm1.Data).To(HaveKey("always"))
+			g.Expect(cm1.Data).ToNot(HaveKey("optional"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// --- Case 1b: update instance1 to set optional → field should appear ---
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name1, Namespace: namespace}, instance1)
+			g.Expect(err).ToNot(HaveOccurred())
+		}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		Expect(unstructured.SetNestedField(instance1.Object, "now-present", "spec", "optional")).To(Succeed())
+		Expect(env.Client.Update(ctx, instance1)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name1, Namespace: namespace}, cm1)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(cm1.Data).To(HaveKeyWithValue("always", "present"))
+			g.Expect(cm1.Data).To(HaveKeyWithValue("optional", "now-present"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// --- Case 2: optional is set → field should be present ---
+		name2 := fmt.Sprintf("omit-no-%s", rand.String(4))
+		instance2 := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+				"kind":       "TestOmit",
+				"metadata": map[string]interface{}{
+					"name":      name2,
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"name":     name2,
+					"optional": "my-value",
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance2)).To(Succeed())
+
+		// Wait for instance to become ACTIVE.
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name2, Namespace: namespace}, instance2)
+			g.Expect(err).ToNot(HaveOccurred())
+			val, found, err := unstructured.NestedString(instance2.Object, "status", "state")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(val).To(Equal("ACTIVE"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// Verify ConfigMap: both "always" and "optional" present.
+		cm2 := &corev1.ConfigMap{}
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name2, Namespace: namespace}, cm2)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(cm2.Data).To(HaveKeyWithValue("always", "present"))
+			g.Expect(cm2.Data).To(HaveKeyWithValue("optional", "my-value"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// Cleanup
+		Expect(env.Client.Delete(ctx, instance1)).To(Succeed())
+		Expect(env.Client.Delete(ctx, instance2)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name1, Namespace: namespace}, instance1)
+			g.Expect(err).To(MatchError(errors.IsNotFound, "instance1 should be deleted"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name2, Namespace: namespace}, instance2)
+			g.Expect(err).To(MatchError(errors.IsNotFound, "instance2 should be deleted"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, &krov1alpha1.ResourceGraphDefinition{})
+			g.Expect(err).To(MatchError(errors.IsNotFound, "rgd should be deleted"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+
+	It("should omit array elements when omit() is triggered", func(ctx SpecContext) {
+		rgd := generator.NewResourceGraphDefinition("test-omit-array",
+			generator.WithSchema(
+				"TestOmitArray", "v1alpha1",
+				map[string]interface{}{
+					"name":        "string",
+					"optionalArg": "string | default=\"\"",
+				},
+				nil,
+			),
+			generator.WithResource("pod", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}",
+				},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "main",
+							"image": "busybox",
+							"command": []interface{}{
+								"echo",
+								`${schema.spec.optionalArg != "" ? schema.spec.optionalArg : omit()}`,
+							},
+						},
+					},
+				},
+			}, nil, nil),
+		)
+
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+
+		createdRGD := &krov1alpha1.ResourceGraphDefinition{}
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, createdRGD)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(createdRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// --- Case 1: optionalArg is empty → array element should be omitted ---
+		name1 := fmt.Sprintf("omit-arr-yes-%s", rand.String(4))
+		instance1 := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+				"kind":       "TestOmitArray",
+				"metadata": map[string]interface{}{
+					"name":      name1,
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"name":        name1,
+					"optionalArg": "",
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance1)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name1, Namespace: namespace}, instance1)
+			g.Expect(err).ToNot(HaveOccurred())
+			val, found, err := unstructured.NestedString(instance1.Object, "status", "state")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(val).To(Equal("ACTIVE"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		pod1 := &corev1.Pod{}
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name1, Namespace: namespace}, pod1)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(pod1.Spec.Containers).To(HaveLen(1))
+			g.Expect(pod1.Spec.Containers[0].Command).To(Equal([]string{"echo"}))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// --- Case 2: optionalArg is set → array element should be present ---
+		name2 := fmt.Sprintf("omit-arr-no-%s", rand.String(4))
+		instance2 := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+				"kind":       "TestOmitArray",
+				"metadata": map[string]interface{}{
+					"name":      name2,
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"name":        name2,
+					"optionalArg": "hello",
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance2)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name2, Namespace: namespace}, instance2)
+			g.Expect(err).ToNot(HaveOccurred())
+			val, found, err := unstructured.NestedString(instance2.Object, "status", "state")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(val).To(Equal("ACTIVE"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		pod2 := &corev1.Pod{}
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name2, Namespace: namespace}, pod2)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(pod2.Spec.Containers).To(HaveLen(1))
+			g.Expect(pod2.Spec.Containers[0].Command).To(Equal([]string{"echo", "hello"}))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// Cleanup
+		Expect(env.Client.Delete(ctx, instance1)).To(Succeed())
+		Expect(env.Client.Delete(ctx, instance2)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name1, Namespace: namespace}, instance1)
+			g.Expect(err).To(MatchError(errors.IsNotFound, "instance1 should be deleted"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name2, Namespace: namespace}, instance2)
+			g.Expect(err).To(MatchError(errors.IsNotFound, "instance2 should be deleted"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, &krov1alpha1.ResourceGraphDefinition{})
+			g.Expect(err).To(MatchError(errors.IsNotFound, "rgd should be deleted"))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+})


### PR DESCRIPTION
Implements KREP-017 #1121
When a CEL expression resolves to the `omit()` sentinel, the resolver
removes the containing field from the rendered object instead of writing
a value. This lets users author optional fields that are absent from the apply
payload when a condition is met, which is required by many CRDs that distinguish
between field absence and an explicit null/empty value.

Since kro uses ServerSideApply, this field will no longer be managed by
kro. Any drifts that may occur to the omitted field will not be
detected.

Example usage:
```yaml
policy: ${schema.spec.policy != "" ? schema.spec.policy : omit()}
```