### PR TITLE
Use RGD metadata.name as the label for ResourceGraphDefinition controller metrics.

### DIFF
--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -204,8 +204,8 @@ func (r *ResourceGraphDefinitionReconciler) Reconcile(
 		if err := r.setUnmanaged(ctx, o); err != nil {
 			return ctrl.Result{}, err
 		}
-		deletionDuration.WithLabelValues(o.Spec.Schema.Kind).Observe(time.Since(startTime).Seconds())
-		deletionsTotal.WithLabelValues(o.Spec.Schema.Kind).Inc()
+		deletionDuration.WithLabelValues(o.Name).Observe(time.Since(startTime).Seconds())
+		deletionsTotal.WithLabelValues(o.Name).Inc()
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile.go
@@ -120,13 +120,13 @@ func (r *ResourceGraphDefinitionReconciler) setupMicroController(
 func (r *ResourceGraphDefinitionReconciler) reconcileResourceGraphDefinitionGraph(_ context.Context, rgd *v1alpha1.ResourceGraphDefinition) (*graph.Graph, []v1alpha1.ResourceInformation, error) {
 	startTime := time.Now()
 	defer func() {
-		graphBuildDuration.WithLabelValues(rgd.Spec.Schema.Kind).Observe(time.Since(startTime).Seconds())
-		graphBuildTotal.WithLabelValues(rgd.Spec.Schema.Kind).Inc()
+		graphBuildDuration.WithLabelValues(rgd.Name).Observe(time.Since(startTime).Seconds())
+		graphBuildTotal.WithLabelValues(rgd.Name).Inc()
 	}()
 
 	processedRGD, err := r.rgBuilder.NewResourceGraphDefinition(rgd, r.rgdConfig)
 	if err != nil {
-		graphBuildErrorsTotal.WithLabelValues(rgd.Spec.Schema.Kind).Inc()
+		graphBuildErrorsTotal.WithLabelValues(rgd.Name).Inc()
 		return nil, nil, newGraphError(err)
 	}
 

--- a/pkg/controller/resourcegraphdefinition/controller_status.go
+++ b/pkg/controller/resourcegraphdefinition/controller_status.go
@@ -49,8 +49,8 @@ func (r *ResourceGraphDefinitionReconciler) updateStatus(
 		o.Status.State = v1alpha1.ResourceGraphDefinitionStateInactive
 	}
 
-	if oldState != o.Status.State && oldState != "" && o.Spec.Schema != nil {
-		stateTransitionsTotal.WithLabelValues(o.Spec.Schema.Kind, string(oldState), string(o.Status.State)).Inc()
+	if oldState != o.Status.State && oldState != "" {
+		stateTransitionsTotal.WithLabelValues(o.Name, string(oldState), string(o.Status.State)).Inc()
 	}
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/pkg/controller/resourcegraphdefinition/metrics.go
+++ b/pkg/controller/resourcegraphdefinition/metrics.go
@@ -20,7 +20,8 @@ import (
 )
 
 var (
-	rgdLabels = []string{"rgd_kind"}
+	rgdLabels             = []string{"name"}
+	stateTransitionLabels = []string{"name", "from", "to"}
 
 	graphBuildTotal       *prometheus.CounterVec
 	graphBuildDuration    *prometheus.HistogramVec
@@ -61,7 +62,7 @@ func init() {
 			Name: "rgd_state_transitions_total",
 			Help: "Total number of RGD state transitions",
 		},
-		append(rgdLabels, "from", "to"),
+		stateTransitionLabels,
 	)
 
 	deletionsTotal = prometheus.NewCounterVec(

--- a/website/docs/docs/advanced/04-metrics.md
+++ b/website/docs/docs/advanced/04-metrics.md
@@ -78,7 +78,7 @@ metrics:
 
 ## ResourceGraphDefinition Controller Metrics
 
-All RGD controller metrics include the label `rgd_kind` (the schema kind of the ResourceGraphDefinition).
+All RGD controller metrics include the label `name` (the `metadata.name` of the ResourceGraphDefinition).
 
 | Metric | Type | Description | Stability |
 |--------|------|-------------|-----------|


### PR DESCRIPTION
  Replace the rgd_kind label with the idiomatic `name` label keyed on
  metadata.name. The RGD name is the natural resource identifier, whereas
  kind is a derived schema artifact.