### PR TITLE
feat(cel): add metrics for CEL cache hit/miss tracking

### DIFF
--- a/pkg/cel/cache/builder_cache.go
+++ b/pkg/cel/cache/builder_cache.go
@@ -47,11 +47,14 @@ func (c *BuilderCache) SchemaDeclType(schema *spec.Schema, create func(*spec.Sch
 		return nil
 	}
 	if v, ok := c.declTypes.Load(schema); ok {
+		builderCacheHitsTotal.WithLabelValues("decl_type").Inc()
 		return v.(*apiservercel.DeclType)
 	}
+	builderCacheMissesTotal.WithLabelValues("decl_type").Inc()
 	declType := create(schema)
 	if declType != nil {
 		c.declTypes.Store(schema, declType)
+		builderCacheSize.WithLabelValues("decl_type").Inc()
 	}
 	return declType
 }
@@ -62,10 +65,13 @@ func (c *BuilderCache) SchemaDeclType(schema *spec.Schema, create func(*spec.Sch
 func (c *BuilderCache) MaybeAssignTypeName(schema *spec.Schema, declType *apiservercel.DeclType, typeName string) *apiservercel.DeclType {
 	key := namedTypeCacheKey{schema: schema, name: typeName}
 	if v, ok := c.namedTypes.Load(key); ok {
+		builderCacheHitsTotal.WithLabelValues("named_type").Inc()
 		return v.(*apiservercel.DeclType)
 	}
+	builderCacheMissesTotal.WithLabelValues("named_type").Inc()
 	named := declType.MaybeAssignTypeName(typeName)
 	c.namedTypes.Store(key, named)
+	builderCacheSize.WithLabelValues("named_type").Inc()
 	return named
 }
 
@@ -77,14 +83,17 @@ func (c *BuilderCache) TypedEnvironmentWithProvider(schemas map[string]*spec.Sch
 	if len(schemas) > 0 {
 		key := MakeEnvCacheKey(schemas)
 		if v, ok := c.typedEnvs.Load(key); ok {
+			builderCacheHitsTotal.WithLabelValues("typed_env").Inc()
 			entry := v.(*TypedEnvEntry)
 			return entry.Env, entry.Provider, nil
 		}
+		builderCacheMissesTotal.WithLabelValues("typed_env").Inc()
 		env, provider, err := create()
 		if err != nil {
 			return nil, nil, err
 		}
 		c.typedEnvs.Store(key, &TypedEnvEntry{Env: env, Provider: provider})
+		builderCacheSize.WithLabelValues("typed_env").Inc()
 		return env, provider, nil
 	}
 	return create()
@@ -94,9 +103,12 @@ func (c *BuilderCache) TypedEnvironmentWithProvider(schemas map[string]*spec.Sch
 // On cache miss, the create callback is called to build the map.
 func (c *BuilderCache) FieldTypeMap(t *apiservercel.DeclType, create func() map[string]*apiservercel.DeclType) map[string]*apiservercel.DeclType {
 	if v, ok := c.fieldTypeMaps.Load(t); ok {
+		builderCacheHitsTotal.WithLabelValues("field_type_map").Inc()
 		return v.(map[string]*apiservercel.DeclType)
 	}
+	builderCacheMissesTotal.WithLabelValues("field_type_map").Inc()
 	m := create()
 	c.fieldTypeMaps.Store(t, m)
+	builderCacheSize.WithLabelValues("field_type_map").Inc()
 	return m
 }

--- a/pkg/cel/cache/metrics.go
+++ b/pkg/cel/cache/metrics.go
@@ -1,0 +1,80 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// BuilderCache metrics — long-lived, cross-RGD cache.
+
+	builderCacheHitsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cel_cache_builder_hits_total",
+			Help: "Total number of builder cache hits",
+		},
+		[]string{"cache_type"},
+	)
+	builderCacheMissesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cel_cache_builder_misses_total",
+			Help: "Total number of builder cache misses",
+		},
+		[]string{"cache_type"},
+	)
+	builderCacheSize = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "cel_cache_builder_size",
+			Help: "Current number of entries in the builder cache",
+		},
+		[]string{"cache_type"},
+	)
+
+	// SessionCache metrics — short-lived, per-RGD-build cache.
+
+	sessionCacheHitsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cel_cache_session_hits_total",
+			Help: "Total number of session cache hits",
+		},
+		[]string{"cache_type"},
+	)
+	sessionCacheMissesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cel_cache_session_misses_total",
+			Help: "Total number of session cache misses",
+		},
+		[]string{"cache_type"},
+	)
+	sessionCacheASTReuseTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "cel_cache_session_ast_reuse_total",
+			Help: "Total number of checked ASTs reused during program compilation (skipping parse+check)",
+		},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		builderCacheHitsTotal,
+		builderCacheMissesTotal,
+		builderCacheSize,
+		sessionCacheHitsTotal,
+		sessionCacheMissesTotal,
+		sessionCacheASTReuseTotal,
+	)
+}

--- a/pkg/cel/cache/session_cache.go
+++ b/pkg/cel/cache/session_cache.go
@@ -48,14 +48,18 @@ func (c *SessionCache) ParseAndCheck(env *cel.Env, expr string) (*cel.Ast, error
 
 	// Check if we already have a full program cached — reuse its AST.
 	if v, ok := c.programs.Load(key); ok {
+		sessionCacheHitsTotal.WithLabelValues("checked_ast").Inc()
 		entry := v.(*ProgramCacheEntry)
 		return entry.Ast, nil
 	}
 
 	// Check the AST-only cache.
 	if v, ok := c.checkedASTs.Load(key); ok {
+		sessionCacheHitsTotal.WithLabelValues("checked_ast").Inc()
 		return v.(*cel.Ast), nil
 	}
+
+	sessionCacheMissesTotal.WithLabelValues("checked_ast").Inc()
 
 	parsedAST, issues := env.Parse(expr)
 	if issues != nil && issues.Err() != nil {
@@ -79,13 +83,17 @@ func (c *SessionCache) ParseAndCheck(env *cel.Env, expr string) (*cel.Ast, error
 func (c *SessionCache) ParseCheckAndCompile(env *cel.Env, expr string) (cel.Program, *cel.Ast, error) {
 	key := ProgramCacheKey{Expr: expr, Env: env}
 	if v, ok := c.programs.Load(key); ok {
+		sessionCacheHitsTotal.WithLabelValues("program").Inc()
 		entry := v.(*ProgramCacheEntry)
 		return entry.Program, entry.Ast, nil
 	}
 
+	sessionCacheMissesTotal.WithLabelValues("program").Inc()
+
 	// Try to reuse a previously cached checked AST.
 	var checkedAST *cel.Ast
 	if v, ok := c.checkedASTs.Load(key); ok {
+		sessionCacheASTReuseTotal.Inc()
 		checkedAST = v.(*cel.Ast)
 	} else {
 		parsedAST, issues := env.Parse(expr)
@@ -116,8 +124,11 @@ func (c *SessionCache) ParseCheckAndCompile(env *cel.Env, expr string) (cel.Prog
 func (c *SessionCache) ExtendWithTypedVar(parent *cel.Env, varName string, schema *spec.Schema, create func() (*cel.Env, error)) (*cel.Env, error) {
 	key := extendedEnvCacheKey{parentEnv: parent, varName: varName, schema: schema}
 	if v, ok := c.extendedEnvs.Load(key); ok {
+		sessionCacheHitsTotal.WithLabelValues("extended_env").Inc()
 		return v.(*cel.Env), nil
 	}
+
+	sessionCacheMissesTotal.WithLabelValues("extended_env").Inc()
 
 	extended, err := create()
 	if err != nil {


### PR DESCRIPTION
  Track hit/miss rates and size for BuilderCache and SessionCache.
  Includes AST reuse counter for the parse+check skip optimization.