### PR TITLE
Add client-go and reflector metrics registration

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -35,6 +35,7 @@ import (
 	resourcegraphdefinitionctrl "github.com/kubernetes-sigs/kro/pkg/controller/resourcegraphdefinition"
 	"github.com/kubernetes-sigs/kro/pkg/dynamiccontroller"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
+	"github.com/kubernetes-sigs/kro/pkg/metrics"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -52,6 +53,8 @@ func init() {
 }
 
 func main() {
+	metrics.Register()
+
 	var (
 		metricsAddr                                 string
 		enableLeaderElection                        bool

--- a/pkg/metrics/clientgo.go
+++ b/pkg/metrics/clientgo.go
@@ -1,0 +1,104 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"net/url"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	clientmetrics "k8s.io/client-go/tools/metrics"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	requestLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "rest_client_request_duration_seconds",
+		Help:    "Request latency in seconds, partitioned by verb.",
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
+	}, []string{"verb"})
+
+	rateLimiterLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "rest_client_rate_limiter_duration_seconds",
+		Help:    "Client-side rate limiter latency in seconds, partitioned by verb.",
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
+	}, []string{"verb"})
+
+	requestSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "rest_client_request_size_bytes",
+		Help:    "Request size in bytes, partitioned by verb.",
+		Buckets: prometheus.ExponentialBuckets(64, 2, 16),
+	}, []string{"verb"})
+
+	responseSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "rest_client_response_size_bytes",
+		Help:    "Response size in bytes, partitioned by verb.",
+		Buckets: prometheus.ExponentialBuckets(64, 2, 16),
+	}, []string{"verb"})
+
+	requestRetry = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "rest_client_request_retries_total",
+		Help: "Total number of request retries, partitioned by status code and method.",
+	}, []string{"code", "method"})
+)
+
+// Register registers client-go metrics with the controller-runtime
+// prometheus registry and wires up the client-go metrics adapters.
+func Register() {
+	ctrlmetrics.Registry.MustRegister(
+		requestLatency,
+		rateLimiterLatency,
+		requestSize,
+		responseSize,
+		requestRetry,
+	)
+
+	// controller-runtime v0.16+ removed these histograms from its client-go
+	// adapter. The one-shot clientmetrics.Register() has already been consumed
+	// by controller-runtime, so we assign the globals directly.
+	clientmetrics.RequestLatency = &latencyAdapter{metric: requestLatency}
+	clientmetrics.RateLimiterLatency = &latencyAdapter{metric: rateLimiterLatency}
+	clientmetrics.RequestSize = &sizeAdapter{metric: requestSize}
+	clientmetrics.ResponseSize = &sizeAdapter{metric: responseSize}
+	clientmetrics.RequestRetry = &retryAdapter{metric: requestRetry}
+}
+
+// latencyAdapter implements k8s.io/client-go/tools/metrics.LatencyMetric.
+type latencyAdapter struct {
+	metric *prometheus.HistogramVec
+}
+
+func (l *latencyAdapter) Observe(_ context.Context, verb string, _ url.URL, latency time.Duration) {
+	l.metric.WithLabelValues(verb).Observe(latency.Seconds())
+}
+
+// sizeAdapter implements k8s.io/client-go/tools/metrics.SizeMetric.
+type sizeAdapter struct {
+	metric *prometheus.HistogramVec
+}
+
+func (s *sizeAdapter) Observe(_ context.Context, verb string, _ string, size float64) {
+	s.metric.WithLabelValues(verb).Observe(size)
+}
+
+// retryAdapter implements k8s.io/client-go/tools/metrics.RetryMetric.
+type retryAdapter struct {
+	metric *prometheus.CounterVec
+}
+
+func (r *retryAdapter) IncrementRetry(_ context.Context, code string, method string, _ string) {
+	r.metric.WithLabelValues(code, method).Inc()
+}

--- a/pkg/metrics/doc.go
+++ b/pkg/metrics/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metrics registers additional Prometheus metrics that are not
+// included by controller-runtime's default client-go adapter.
+//
+// Import this package with a blank identifier to activate registration:
+//
+//	_ "github.com/kubernetes-sigs/kro/pkg/metrics"
+package metrics

--- a/website/docs/docs/advanced/04-metrics.md
+++ b/website/docs/docs/advanced/04-metrics.md
@@ -8,7 +8,7 @@ kro exposes Prometheus metrics for monitoring controller health and performance.
 
 :::warning Metrics Stability
 
-kro-specific metrics (Dynamic Controller, Schema Resolver) are in **ALPHA** and subject to change or removal without notice. Metric names, labels, and types may change between releases with no backwards-compatibility guarantees.
+kro-specific metrics (Dynamic Controller, Schema Resolver, REST Client) are in **ALPHA** and subject to change or removal without notice. Metric names, labels, and types may change between releases with no backwards-compatibility guarantees.
 
 Only **controller-runtime** and **workqueue** metrics are considered **STABLE**.
 
@@ -88,6 +88,18 @@ All RGD controller metrics include the label `rgd_kind` (the schema kind of the 
 | `rgd_state_transitions_total` | Counter | Total number of RGD state transitions (additional labels: `from`, `to`) | ALPHA |
 | `rgd_deletions_total` | Counter | Total number of RGD deletions | ALPHA |
 | `rgd_deletion_duration_seconds` | Histogram | Duration of RGD deletions in seconds | ALPHA |
+
+## REST Client Metrics
+
+Registered via `pkg/metrics/clientgo.go`. These fill gaps left by controller-runtime v0.16+, which stopped registering client-go latency, size, and retry histograms.
+
+| Metric | Type | Labels | Description | Stability |
+|--------|------|--------|-------------|-----------|
+| `rest_client_request_duration_seconds` | Histogram | `verb` | Request latency in seconds | ALPHA |
+| `rest_client_rate_limiter_duration_seconds` | Histogram | `verb` | Client-side rate limiter latency in seconds | ALPHA |
+| `rest_client_request_size_bytes` | Histogram | `verb` | Request payload size in bytes | ALPHA |
+| `rest_client_response_size_bytes` | Histogram | `verb` | Response payload size in bytes | ALPHA |
+| `rest_client_request_retries_total` | Counter | `code`, `method` | Total number of request retries | ALPHA |
 
 ## Controller Runtime Metrics
 


### PR DESCRIPTION
  controller-runtime v0.16+ stopped registering client-go latency, size,                                                                                      
  and retry histograms, and never registers reflector metrics. Add a                                                                                          
  `pkg/metrics` package that fills both gaps by assigning adapters directly                                                                                   
  to client-go globals and calling `cache.SetReflectorMetricsProvider`.

  New metrics:
  - `rest_client_request_duration_seconds` — histogram by verb
  - `rest_client_rate_limiter_duration_seconds` — histogram by verb
  - `rest_client_request_size_bytes` — histogram by verb
  - `rest_client_response_size_bytes` — histogram by verb
  - `rest_client_request_retries_total` — counter by code/method