### PR TITLE
feat(events): Add events for instance status condition transition

### DIFF
--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -27,11 +27,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	kroclient "github.com/kubernetes-sigs/kro/pkg/client"
 	"github.com/kubernetes-sigs/kro/pkg/dynamiccontroller"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/requeue"
@@ -90,6 +92,9 @@ type Controller struct {
 	childResourceLabeler metadata.Labeler
 	reconcileConfig      ReconcileConfig
 	coordinator          *dynamiccontroller.WatchCoordinator
+
+	// eventRecorder emits K8s Events on condition transitions.
+	eventRecorder record.EventRecorder
 }
 
 // NewController constructs a new controller with static RGD.
@@ -102,6 +107,7 @@ func NewController(
 	instanceLabeler metadata.Labeler,
 	childResourceLabeler metadata.Labeler,
 	coord *dynamiccontroller.WatchCoordinator,
+	eventRecorder record.EventRecorder,
 ) *Controller {
 	return &Controller{
 		log:                  log,
@@ -112,6 +118,7 @@ func NewController(
 		childResourceLabeler: childResourceLabeler,
 		reconcileConfig:      reconcileConfig,
 		coordinator:          coord,
+		eventRecorder:        eventRecorder,
 	}
 }
 
@@ -135,7 +142,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 	}()
 
 	//--------------------------------------------------------------
-	// 1. Load instance; if gone, nothing to do
+	// 1. Load instance; snapshot conditions for event diff
 	//--------------------------------------------------------------
 	ri := c.client.Dynamic().Resource(c.gvr)
 	var inst *unstructured.Unstructured
@@ -153,6 +160,20 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 		return err
 	}
 
+	// Emit condition events on every return path (behind feature gate).
+	var rcx *ReconcileContext
+	if features.FeatureGate.Enabled(features.InstanceConditionEvents) {
+		initialConditions := conditionsFromInstance(inst)
+		defer func() {
+			obj := inst
+			if rcx != nil {
+				obj = rcx.Instance
+			}
+			finalConditions := conditionsFromInstance(obj)
+			emitConditionEvents(c.eventRecorder, obj, initialConditions, finalConditions)
+		}()
+	}
+
 	//--------------------------------------------------------------
 	// 2. Create a fresh runtime for this reconciliation
 	//--------------------------------------------------------------
@@ -165,7 +186,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 	//--------------------------------------------------------------
 	// 3. Build reconciliation context (clients, mapper, labeler, runtime)
 	//--------------------------------------------------------------
-	rcx := NewReconcileContext(
+	rcx = NewReconcileContext(
 		ctx, log, c.gvr,
 		c.client.Dynamic(),
 		c.client.RESTMapper(),

--- a/pkg/controller/instance/events.go
+++ b/pkg/controller/instance/events.go
@@ -1,0 +1,85 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+)
+
+// emitConditionEvents fires a K8s Event for every status condition that
+// transitioned between the initial and final snapshots.
+func emitConditionEvents(
+	recorder record.EventRecorder,
+	inst *unstructured.Unstructured,
+	initial, final []v1alpha1.Condition,
+) {
+	initialByType := indexConditionsByType(initial)
+
+	for _, cond := range final {
+		old, existed := initialByType[cond.Type]
+		if existed && old.Status == cond.Status {
+			continue
+		}
+
+		// default shown in transition events when a condition appears for the first time (e.g. "none -> True")
+		oldStatus := "none"
+		if existed {
+			oldStatus = string(old.Status)
+		}
+
+		reason := ""
+		if cond.Reason != nil {
+			reason = *cond.Reason
+		}
+
+		eventType := eventTypeForTransition(cond.Status)
+
+		recorder.Eventf(inst, eventType, string(cond.Type),
+			"%s -> %s: %s",
+			oldStatus, cond.Status, reason,
+		)
+	}
+}
+
+func eventTypeForTransition(newStatus metav1.ConditionStatus) string {
+	if newStatus == metav1.ConditionTrue {
+		return corev1.EventTypeNormal
+	}
+	return corev1.EventTypeWarning
+}
+
+// conditionsFromInstance extracts status conditions from an unstructured object.
+//
+// TODO(perf): This performs a JSON marshal/unmarshal round-trip via
+// unstructuredWrapper.GetConditions(). For better performance we could
+// keep raw []v1alpha1.Condition at the resource level to avoid the
+// conversion on every reconciliation.
+func conditionsFromInstance(inst *unstructured.Unstructured) []v1alpha1.Condition {
+	return (&unstructuredWrapper{inst}).GetConditions()
+}
+
+// indexConditionsByType builds a lookup map from condition type to condition.
+func indexConditionsByType(conditions []v1alpha1.Condition) map[v1alpha1.ConditionType]v1alpha1.Condition {
+	m := make(map[v1alpha1.ConditionType]v1alpha1.Condition, len(conditions))
+	for _, c := range conditions {
+		m[c.Type] = c
+	}
+	return m
+}

--- a/pkg/controller/instance/events_test.go
+++ b/pkg/controller/instance/events_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+)
+
+func strPtr(s string) *string { return &s }
+
+func newTestInst() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "kro.run/v1alpha1",
+			"kind":       "WebApp",
+			"metadata": map[string]interface{}{
+				"name":      "test-inst",
+				"namespace": "default",
+			},
+		},
+	}
+}
+
+func drainEvents(recorder *record.FakeRecorder) []string {
+	var events []string
+	for {
+		select {
+		case e := <-recorder.Events:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+func TestEmitConditionEvents_NoChange(t *testing.T) {
+	recorder := record.NewFakeRecorder(100)
+	inst := newTestInst()
+
+	conditions := []v1alpha1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue, Reason: strPtr("AllGood")},
+	}
+
+	emitConditionEvents(recorder, inst, conditions, conditions)
+	assert.Empty(t, drainEvents(recorder), "no events expected when conditions are unchanged")
+}
+
+func TestEmitConditionEvents_NewCondition(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   metav1.ConditionStatus
+		wantType string
+		wantOld  string
+	}{
+		{"True", metav1.ConditionTrue, corev1.EventTypeNormal, "none -> True"},
+		{"False", metav1.ConditionFalse, corev1.EventTypeWarning, "none -> False"},
+		{"Unknown", metav1.ConditionUnknown, corev1.EventTypeWarning, "none -> Unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := record.NewFakeRecorder(100)
+			inst := newTestInst()
+
+			final := []v1alpha1.Condition{
+				{Type: "Ready", Status: tt.status, Reason: strPtr("TestReason")},
+			}
+
+			emitConditionEvents(recorder, inst, nil, final)
+
+			events := drainEvents(recorder)
+			require.Len(t, events, 1)
+			assert.Contains(t, events[0], tt.wantType)
+			assert.Contains(t, events[0], tt.wantOld)
+		})
+	}
+}
+
+func TestEmitConditionEvents_TrueToFalseIsWarning(t *testing.T) {
+	recorder := record.NewFakeRecorder(100)
+	inst := newTestInst()
+
+	initial := []v1alpha1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue, Reason: strPtr("AllGood")},
+	}
+	final := []v1alpha1.Condition{
+		{Type: "Ready", Status: metav1.ConditionFalse, Reason: strPtr("Degraded")},
+	}
+
+	emitConditionEvents(recorder, inst, initial, final)
+
+	events := drainEvents(recorder)
+	require.Len(t, events, 1)
+	assert.Contains(t, events[0], corev1.EventTypeWarning)
+	assert.Contains(t, events[0], "True -> False")
+	assert.Contains(t, events[0], "Degraded")
+}
+
+func TestEmitConditionEvents_FalseToTrueIsNormal(t *testing.T) {
+	recorder := record.NewFakeRecorder(100)
+	inst := newTestInst()
+
+	initial := []v1alpha1.Condition{
+		{Type: "Ready", Status: metav1.ConditionFalse, Reason: strPtr("Degraded")},
+	}
+	final := []v1alpha1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue, Reason: strPtr("Recovered")},
+	}
+
+	emitConditionEvents(recorder, inst, initial, final)
+
+	events := drainEvents(recorder)
+	require.Len(t, events, 1)
+	assert.Contains(t, events[0], corev1.EventTypeNormal)
+	assert.Contains(t, events[0], "False -> True")
+	assert.Contains(t, events[0], "Recovered")
+}
+
+func TestEmitConditionEvents_MultipleConditions(t *testing.T) {
+	recorder := record.NewFakeRecorder(100)
+	inst := newTestInst()
+
+	initial := []v1alpha1.Condition{
+		{Type: "InstanceManaged", Status: metav1.ConditionTrue, Reason: strPtr("OK")},
+		{Type: "ResourcesReady", Status: metav1.ConditionFalse, Reason: strPtr("Pending")},
+	}
+	final := []v1alpha1.Condition{
+		{Type: "InstanceManaged", Status: metav1.ConditionTrue, Reason: strPtr("OK")},      // no change
+		{Type: "ResourcesReady", Status: metav1.ConditionTrue, Reason: strPtr("AllReady")}, // changed
+		{Type: "GraphResolved", Status: metav1.ConditionTrue, Reason: strPtr("Resolved")},  // new
+	}
+
+	emitConditionEvents(recorder, inst, initial, final)
+
+	events := drainEvents(recorder)
+	require.Len(t, events, 2, "should only emit events for changed/new conditions")
+
+	eventTypes := make(map[string]bool)
+	for _, e := range events {
+		if strings.Contains(e, "ResourcesReady") {
+			eventTypes["ResourcesReady"] = true
+		}
+		if strings.Contains(e, "GraphResolved") {
+			eventTypes["GraphResolved"] = true
+		}
+	}
+	assert.True(t, eventTypes["ResourcesReady"])
+	assert.True(t, eventTypes["GraphResolved"])
+}

--- a/pkg/controller/instance/test_helpers_test.go
+++ b/pkg/controller/instance/test_helpers_test.go
@@ -35,6 +35,7 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	metadatafake "k8s.io/client-go/metadata/fake"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -228,6 +229,7 @@ func newControllerUnderTest(t *testing.T, raw *dynamicfake.FakeDynamicClient, g 
 		metadata.NewKROMetaLabeler(),
 		metadata.NewKROMetaLabeler(),
 		newControllerTestCoordinator(t),
+		record.NewFakeRecorder(100),
 	)
 
 	return controller, clientSet

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -23,6 +23,7 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,6 +62,8 @@ type ResourceGraphDefinitionReconciler struct {
 	dynamicController       *dynamiccontroller.DynamicController
 	maxConcurrentReconciles int
 	rgdConfig               graph.RGDConfig
+
+	newEventRecorder func(string) record.EventRecorder
 }
 
 func NewResourceGraphDefinitionReconciler(
@@ -90,6 +93,7 @@ func (r *ResourceGraphDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) e
 	r.Client = mgr.GetClient()
 	r.clientSet.SetRESTMapper(mgr.GetRESTMapper())
 	r.instanceLogger = mgr.GetLogger()
+	r.newEventRecorder = mgr.GetEventRecorderFor
 
 	logConstructor := func(req *reconcile.Request) logr.Logger {
 		log := mgr.GetLogger().WithName("rgd-controller").WithValues(

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile.go
@@ -111,6 +111,8 @@ func (r *ResourceGraphDefinitionReconciler) setupMicroController(
 		instanceLabeler,
 		r.metadataLabeler,
 		r.dynamicController.Coordinator(),
+		// recorder keyed by CRD name to uniquely identify the event source
+		r.newEventRecorder(fmt.Sprintf("kro/%s-controller", processedRGD.CRD.Name)),
 	)
 }
 

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile_test.go
@@ -124,6 +124,7 @@ func TestReconcileResourceGraphDefinition(t *testing.T) {
 					crdManager:        manager,
 					clientSet:         newKROFakeSet(),
 					instanceLogger:    logr.Discard(),
+					newEventRecorder:  newFakeEventRecorderFactory(),
 				}, rgd, manager
 			},
 			check: func(t *testing.T, topologicalOrder []string, resourcesInfo []v1alpha1.ResourceInformation, err error, rgd *v1alpha1.ResourceGraphDefinition, manager *stubCRDManager) {
@@ -214,6 +215,7 @@ func TestReconcileResourceGraphDefinition(t *testing.T) {
 					crdManager:        manager,
 					clientSet:         newKROFakeSet(),
 					instanceLogger:    logr.Discard(),
+					newEventRecorder:  newFakeEventRecorderFactory(),
 				}, rgd, manager
 			},
 			check: func(t *testing.T, topologicalOrder []string, resourcesInfo []v1alpha1.ResourceInformation, err error, rgd *v1alpha1.ResourceGraphDefinition, _ *stubCRDManager) {
@@ -236,6 +238,7 @@ func TestReconcileResourceGraphDefinition(t *testing.T) {
 					crdManager:        &stubCRDManager{},
 					clientSet:         newKROFakeSet(),
 					instanceLogger:    logr.Discard(),
+					newEventRecorder:  newFakeEventRecorderFactory(),
 				}, rgd, nil
 			},
 			check: func(t *testing.T, topologicalOrder []string, resourcesInfo []v1alpha1.ResourceInformation, err error, _ *v1alpha1.ResourceGraphDefinition, _ *stubCRDManager) {

--- a/pkg/controller/resourcegraphdefinition/controller_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_test.go
@@ -34,6 +34,7 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	metadatafake "k8s.io/client-go/metadata/fake"
 	toolscache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -156,6 +157,18 @@ func (m *stubManager) GetControllerOptions() config.Controller {
 
 func (m *stubManager) GetCache() cache.Cache {
 	return m.cache
+}
+
+// newFakeEventRecorderFactory returns a blanket default for tests.
+// Tweak buffer size if the need arises.
+func newFakeEventRecorderFactory() func(string) record.EventRecorder {
+	return func(_ string) record.EventRecorder {
+		return record.NewFakeRecorder(100)
+	}
+}
+
+func (m *stubManager) GetEventRecorderFor(name string) record.EventRecorder {
+	return newFakeEventRecorderFactory()(name)
 }
 
 func (s *stubGraphBuilder) NewResourceGraphDefinition(rgd *v1alpha1.ResourceGraphDefinition, config graph.RGDConfig) (*graph.Graph, error) {
@@ -681,6 +694,7 @@ func TestReconcile(t *testing.T) {
 					crdManager:        manager,
 					clientSet:         newKROFakeSet(),
 					instanceLogger:    logr.Discard(),
+					newEventRecorder:  newFakeEventRecorderFactory(),
 				}, c, rgd, manager
 			},
 			check: func(t *testing.T, result ctrl.Result, err error, c client.WithWatch, rgd *v1alpha1.ResourceGraphDefinition, _ *stubCRDManager) {


### PR DESCRIPTION
### What

Emits Kubernetes Events on instance status condition transitions. Every time a condition's status changes (e.g., `ResourcesReady` goes from `False` → `True`, or `InstanceManaged` appears for the first time), the controller fires an `Eventf` on the instance object. This is always on — no feature gate, no opt-in required.

### Why

Today, when an instance gets stuck or flaps between states, there's no native Kubernetes breadcrumb trail to show what happened. You have to dig through controller logs and correlate timestamps manually.

With condition events:

- __`kubectl describe`__ on any instance now shows a history of condition transitions — what changed, from/to status, and reason — right in the Events section.
- __Event watchers__ (monitoring tools, dashboards, alert pipelines) can subscribe to these transitions without parsing logs.

This lays the foundation for richer telemetry (metrics, structured logs) in a follow-up, but stands on its own as immediately useful observability that every user gets out of the box.


### Testing
#### With no feature gate passed or when `InstanceConditionEvents=false`
```
go run ./cmd/controller --zap-log-level=info --allow-crd-deletion
Events:                    <none>
```


#### With `InstanceConditionEvents=true`
```
go run ./cmd/controller --zap-log-level=info --allow-crd-deletion --feature-gates=InstanceConditionEvents=true

Events:
  Type     Reason                   Age   From                                 Message
  ----     ------                   ----  ----                                 -------
  Normal   InstanceManaged          7s    kro/applications.kro.run-controller  none -> True: Managed
  Normal   GraphResolved            7s    kro/applications.kro.run-controller  none -> True: Resolved
  Warning  ReconciliationSuspended  7s    kro/applications.kro.run-controller  none -> False: Active
  Warning  ResourcesReady           7s    kro/applications.kro.run-controller  none -> False: NotReady
  Warning  Ready                    7s    kro/applications.kro.run-controller  none -> False: NotReady
  Normal   ResourcesReady           6s    kro/applications.kro.run-controller  False -> True: AllResourcesReady
  Normal   Ready                    6s    kro/applications.kro.run-controller  False -> True: Ready
```