### PR TITLE
Use expressive histogram buckets for controller reconciliation metrics

### DIFF
--- a/pkg/controller/instance/metrics.go
+++ b/pkg/controller/instance/metrics.go
@@ -41,7 +41,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "instance_reconcile_duration_seconds",
 			Help:    "Duration of instance reconciliation in seconds per GVR",
-			Buckets: prometheus.DefBuckets,
+			Buckets: []float64{.01, .05, .1, .25, .5, 1, 2.5, 5, 10, 15, 20, 25, 30, 45, 60, 120},
 		},
 		[]string{"gvr"},
 	)

--- a/pkg/controller/resourcegraphdefinition/metrics.go
+++ b/pkg/controller/resourcegraphdefinition/metrics.go
@@ -43,7 +43,7 @@ func init() {
 		prometheus.HistogramOpts{
 			Name:    "rgd_graph_build_duration_seconds",
 			Help:    "Duration of resource graph builds in seconds",
-			Buckets: prometheus.DefBuckets,
+			Buckets: []float64{.01, .05, .1, .25, .5, 1, 2.5, 5, 10, 15, 20, 25, 30, 45, 60, 120},
 		},
 		rgdLabels,
 	)
@@ -76,7 +76,7 @@ func init() {
 		prometheus.HistogramOpts{
 			Name:    "rgd_deletion_duration_seconds",
 			Help:    "Duration of RGD deletions in seconds",
-			Buckets: prometheus.DefBuckets,
+			Buckets: []float64{.01, .05, .1, .25, .5, 1, 2.5, 5, 10, 15, 20, 25, 30, 45, 60, 120},
 		},
 		rgdLabels,
 	)

--- a/pkg/dynamiccontroller/metrics.go
+++ b/pkg/dynamiccontroller/metrics.go
@@ -63,7 +63,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "dynamic_controller_reconcile_duration_seconds",
 			Help:    "Duration of reconciliations per GVR",
-			Buckets: prometheus.DefBuckets,
+			Buckets: []float64{.01, .05, .1, .25, .5, 1, 2.5, 5, 10, 15, 20, 25, 30, 45, 60, 120},
 		},
 		[]string{"gvr"},
 	)
@@ -102,7 +102,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "dynamic_controller_informer_sync_duration_seconds",
 			Help:    "Duration of informer cache sync per GVR",
-			Buckets: prometheus.DefBuckets,
+			Buckets: []float64{.01, .05, .1, .25, .5, 1, 2.5, 5, 10, 15, 20, 25, 30, 45, 60, 120},
 		},
 		[]string{"gvr"},
 	)


### PR DESCRIPTION
Replace prometheus.DefBuckets with wider bucket ranges (10ms–5min) in                                                                 the dynamic controller, instance controller, and RGD controller metrics.