### PR TITLE
docs: document cluster-scoped instance support

### DIFF
--- a/website/docs/api/specifications/simple-schema.md
+++ b/website/docs/api/specifications/simple-schema.md
@@ -18,6 +18,7 @@ spec:
   schema:
     apiVersion: v1alpha1
     kind: WebApplication
+    scope: Namespaced  # or "Cluster" for cluster-scoped instances
     spec:
       # Basic types
       name: string | required=true immutable=true description="My Name"

--- a/website/docs/docs/concepts/15-instances.md
+++ b/website/docs/docs/concepts/15-instances.md
@@ -108,7 +108,7 @@ Resources created by kro (Deployments, Services, ConfigMaps, etc.) receive label
 | `kro.run/kro-version` | Version of kro managing the resource |
 | `kro.run/instance-id` | UID of the instance that created this resource |
 | `kro.run/instance-name` | Name of the instance |
-| `kro.run/instance-namespace` | Namespace of the instance |
+| `kro.run/instance-namespace` | Namespace of the instance (only for namespaced instances) |
 | `kro.run/instance-group` | API group of the instance |
 | `kro.run/instance-version` | API version of the instance |
 | `kro.run/instance-kind` | Kind of the instance |
@@ -138,7 +138,7 @@ kro does not set Kubernetes owner references on managed resources by default. Th
 
 1. **Ordered deletion** - kro deletes resources in reverse topological order, respecting dependencies between resources. Owner references trigger Kubernetes garbage collection, which deletes resources without ordering guarantees.
 
-2. **Cross-scope limitations** - Namespaced resources cannot own cluster-scoped resources. Since kro instances are namespaced but can manage cluster-scoped resources (like ClusterRoles or Namespaces), owner references cannot express this relationship.
+2. **Cross-scope limitations** - Namespaced resources cannot own cluster-scoped resources. When a namespaced kro instance manages cluster-scoped resources (like ClusterRoles or Namespaces), owner references cannot express this relationship.
 
 Instead, kro uses labels and the ApplySet specification for ownership tracking and resource cleanup.
 

--- a/website/docs/docs/concepts/rgd/01-schema.md
+++ b/website/docs/docs/concepts/rgd/01-schema.md
@@ -11,6 +11,7 @@ The schema section of a ResourceGraphDefinition defines the shape of your custom
 The schema section specifies:
 
 - **API identification**: The `apiVersion`, `kind`, and optionally `group` for your custom resource
+- **Scope**: Whether instances are namespaced or cluster-scoped
 - **Spec fields**: What inputs users provide when creating instances
 - **Status fields**: What runtime information kro surfaces from managed resources
 - **Custom types**: Reusable type definitions for complex schemas
@@ -52,6 +53,58 @@ schema:
 ```
 
 This allows you to organize your custom APIs under your own domain, making the full API `mycompany.io/v1alpha1`.
+
+### Scope
+
+The `scope` field determines whether the generated CRD is namespaced or cluster-scoped:
+
+```yaml
+schema:
+  apiVersion: v1alpha1
+  kind: ClusterPolicy
+  scope: Cluster  # or "Namespaced" (default)
+```
+
+| Value | Description |
+|-------|-------------|
+| `Namespaced` | Instances exist within a namespace (default) |
+| `Cluster` | Instances are cluster-wide, with no namespace |
+
+:::warning Cluster-Scoped Instances
+When using `scope: Cluster`, all namespaced resources must explicitly set `metadata.namespace` (hardcoded or via CEL). kro validates this at RGD creation time.
+:::
+
+```yaml
+schema:
+  apiVersion: v1alpha1
+  kind: Tenant
+  scope: Cluster
+  spec:
+    targetNamespace: string | required=true
+
+resources:
+  # Template with explicit namespace
+  - id: configmap
+    template:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: ${schema.metadata.name}-config
+        namespace: ${schema.spec.targetNamespace}  # Required
+
+  # External ref also requires explicit namespace
+  - id: existingSecret
+    externalRef:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: db-credentials
+        namespace: ${schema.spec.targetNamespace}  # Required
+```
+
+:::note
+The `scope` field is immutable after creation.
+:::
 
 ## The spec Section
 


### PR DESCRIPTION
Document the `scope` field introduced in KREP-10 that allows generating
cluster-scoped instance CRDs. The schema docs now explain the field, its
values, and the validation requiring explicit namespaces on namespaced
child resources. Also updated the instances docs to reflect that not all
instances are namespaced.