### PR TITLE
refactor(dynamic): refactor dynamic controller to be truly atomic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ test-coverage: ## Run all tests and report coverage
 	@echo "Combined:    $$(go tool cover -func=combined-cover.out | grep total | awk '{print $$NF}')"
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.8.0
+GOLANGCI_LINT_VERSION ?= v2.11.3
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\

--- a/pkg/dynamiccontroller/coordinator.go
+++ b/pkg/dynamiccontroller/coordinator.go
@@ -153,6 +153,7 @@ func (c *WatchCoordinator) addWatch(key instanceKey, req WatchRequest) error {
 			previous: make(map[string]*WatchRequest),
 		}
 		c.instances[key] = state
+		instanceWatchCount.WithLabelValues(key.parentGVR.String()).Inc()
 	}
 
 	// Fix reverse index orphaning on nodeID reuse: if an existing entry
@@ -178,7 +179,6 @@ func (c *WatchCoordinator) addWatch(key instanceKey, req WatchRequest) error {
 		}
 	}
 
-	c.updateWatchRequestMetrics()
 	gvr := req.GVR
 	c.mu.Unlock()
 
@@ -213,7 +213,6 @@ func (c *WatchCoordinator) abortInstance(key instanceKey) {
 
 	state.current = make(map[string]*WatchRequest)
 
-	c.updateWatchRequestMetrics()
 	orphanedGVRs := c.findOrphanedGVRsLocked(affectedGVRs)
 	c.mu.Unlock()
 
@@ -246,7 +245,6 @@ func (c *WatchCoordinator) doneInstance(key instanceKey) {
 	state.previous = state.current
 	state.current = make(map[string]*WatchRequest)
 
-	c.updateWatchRequestMetrics()
 	orphanedGVRs := c.findOrphanedGVRsLocked(affectedGVRs)
 	c.mu.Unlock()
 
@@ -279,8 +277,8 @@ func (c *WatchCoordinator) RemoveInstance(parentGVR schema.GroupVersionResource,
 	}
 
 	delete(c.instances, key)
+	c.decInstanceWatchCount(parentGVR)
 
-	c.updateWatchRequestMetrics()
 	orphanedGVRs := c.findOrphanedGVRsLocked(affectedGVRs)
 	c.mu.Unlock()
 
@@ -318,8 +316,8 @@ func (c *WatchCoordinator) RemoveParentGVR(parentGVR schema.GroupVersionResource
 		}
 		delete(c.instances, key)
 	}
+	c.decInstanceWatchCount(parentGVR)
 
-	c.updateWatchRequestMetrics()
 	orphanedGVRs := c.findOrphanedGVRsLocked(affectedGVRs)
 	c.mu.Unlock()
 
@@ -407,6 +405,7 @@ func (c *WatchCoordinator) addScalarIndexLocked(key instanceKey, req WatchReques
 		nodeID: req.NodeID,
 		key:    key,
 	})
+	watchRequestCount.WithLabelValues(req.GVR.String(), "scalar").Inc()
 }
 
 func (c *WatchCoordinator) addCollectionIndexLocked(key instanceKey, req WatchRequest) {
@@ -425,6 +424,7 @@ func (c *WatchCoordinator) addCollectionIndexLocked(key instanceKey, req WatchRe
 		namespace: req.Namespace,
 		key:       key,
 	})
+	watchRequestCount.WithLabelValues(req.GVR.String(), "collection").Inc()
 }
 
 func (c *WatchCoordinator) removeRequestFromIndexesLocked(key instanceKey, req *WatchRequest) {
@@ -445,9 +445,11 @@ func (c *WatchCoordinator) removeScalarIndexLocked(key instanceKey, req *WatchRe
 	if !ok {
 		return
 	}
+	removed := 0
 	filtered := entries[:0]
 	for _, entry := range entries {
 		if entry.key == key && entry.nodeID == req.NodeID {
+			removed++
 			continue
 		}
 		filtered = append(filtered, entry)
@@ -457,8 +459,16 @@ func (c *WatchCoordinator) removeScalarIndexLocked(key instanceKey, req *WatchRe
 	} else {
 		byName[nn] = filtered
 	}
+	gvrStr := req.GVR.String()
 	if len(byName) == 0 {
 		delete(c.scalarIndex, req.GVR)
+		// If this GVR is also gone from collectionIndex, delete its gauge labels.
+		if len(c.collectionIndex[req.GVR]) == 0 {
+			watchRequestCount.DeleteLabelValues(gvrStr, "scalar")
+			watchRequestCount.DeleteLabelValues(gvrStr, "collection")
+		}
+	} else if removed > 0 {
+		watchRequestCount.WithLabelValues(gvrStr, "scalar").Sub(float64(removed))
 	}
 }
 
@@ -487,21 +497,45 @@ func (c *WatchCoordinator) stopWatches(gvrs []schema.GroupVersionResource) {
 
 func (c *WatchCoordinator) removeCollectionIndexLocked(key instanceKey, req *WatchRequest) {
 	entries := c.collectionIndex[req.GVR]
+	removed := 0
 	filtered := entries[:0]
 	for _, e := range entries {
 		if e.key == key &&
 			e.nodeID == req.NodeID &&
 			e.namespace == req.Namespace &&
 			e.selector.String() == req.Selector.String() {
+			removed++
 			continue
 		}
 		filtered = append(filtered, e)
 	}
+	gvrStr := req.GVR.String()
 	if len(filtered) == 0 {
 		delete(c.collectionIndex, req.GVR)
+		// If this GVR is also gone from scalarIndex, delete its gauge labels.
+		if len(c.scalarIndex[req.GVR]) == 0 {
+			watchRequestCount.DeleteLabelValues(gvrStr, "scalar")
+			watchRequestCount.DeleteLabelValues(gvrStr, "collection")
+		}
 	} else {
 		c.collectionIndex[req.GVR] = filtered
+		if removed > 0 {
+			watchRequestCount.WithLabelValues(gvrStr, "collection").Sub(float64(removed))
+		}
 	}
+}
+
+// decInstanceWatchCount decrements the instanceWatchCount gauge for the given
+// parent GVR, deleting the label set entirely when no instances remain.
+// Must be called with c.mu held, after the instance has been deleted.
+func (c *WatchCoordinator) decInstanceWatchCount(parentGVR schema.GroupVersionResource) {
+	for key := range c.instances {
+		if key.parentGVR == parentGVR {
+			instanceWatchCount.WithLabelValues(parentGVR.String()).Dec()
+			return
+		}
+	}
+	instanceWatchCount.DeleteLabelValues(parentGVR.String())
 }
 
 // NoopInstanceWatcher is a no-op implementation of InstanceWatcher for use
@@ -538,36 +572,6 @@ func (w *instanceWatcher) Done(commit bool) {
 		return
 	}
 	w.coordinator.doneInstance(key)
-}
-
-// updateWatchRequestMetrics recalculates the watch request gauge metrics
-// from the current index state. Must be called with c.mu held (at least RLock).
-func (c *WatchCoordinator) updateWatchRequestMetrics() {
-	// Per-GVR scalar/collection breakdown.
-	gvrs := make(map[schema.GroupVersionResource]struct{})
-	for gvr := range c.scalarIndex {
-		gvrs[gvr] = struct{}{}
-	}
-	for gvr := range c.collectionIndex {
-		gvrs[gvr] = struct{}{}
-	}
-	for gvr := range gvrs {
-		scalar := 0
-		for _, entries := range c.scalarIndex[gvr] {
-			scalar += len(entries)
-		}
-		watchRequestCount.WithLabelValues(gvr.String(), "scalar").Set(float64(scalar))
-		watchRequestCount.WithLabelValues(gvr.String(), "collection").Set(float64(len(c.collectionIndex[gvr])))
-	}
-
-	// Per-parent instance watch count.
-	parentCounts := make(map[schema.GroupVersionResource]int)
-	for key := range c.instances {
-		parentCounts[key.parentGVR]++
-	}
-	for parentGVR, count := range parentCounts {
-		instanceWatchCount.WithLabelValues(parentGVR.String()).Set(float64(count))
-	}
 }
 
 func sameWatchTarget(a, b *WatchRequest) bool {

--- a/pkg/dynamiccontroller/coordinator.go
+++ b/pkg/dynamiccontroller/coordinator.go
@@ -184,7 +184,7 @@ func (c *WatchCoordinator) addWatch(key instanceKey, req WatchRequest) error {
 	// Ensure an informer is running for this GVR.
 	// Called outside the coordinator lock to avoid holding it while
 	// the WatchManager acquires its own lock.
-	if err := c.watches.EnsureWatch(gvr); err != nil {
+	if err := c.watches.EnsureWatch(gvr, "coordinator"); err != nil {
 		c.log.Error(err, "Failed to ensure watch", "gvr", gvr)
 	}
 
@@ -381,14 +381,6 @@ func (c *WatchCoordinator) WatchRequestCount() (scalar, collection int) {
 	return
 }
 
-// HasRequestsForGVR reports whether any child or external watch requests still
-// exist for the given GVR.
-func (c *WatchCoordinator) HasRequestsForGVR(gvr schema.GroupVersionResource) bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return len(c.scalarIndex[gvr]) > 0 || len(c.collectionIndex[gvr]) > 0
-}
-
 // --- internal helpers ---
 
 func (c *WatchCoordinator) addScalarIndexLocked(key instanceKey, req WatchRequest) {
@@ -474,12 +466,13 @@ func (c *WatchCoordinator) findOrphanedGVRsLocked(gvrs []schema.GroupVersionReso
 	return orphaned
 }
 
-// stopWatches stops informers for the given GVRs. Must be called without
+// stopWatches releases the coordinator's ownership of the given GVRs and
+// stops informers that have no remaining owners. Must be called without
 // c.mu held to avoid holding the coordinator lock while the WatchManager
 // acquires its own lock.
 func (c *WatchCoordinator) stopWatches(gvrs []schema.GroupVersionResource) {
 	for _, gvr := range gvrs {
-		c.watches.StopWatch(gvr)
+		c.watches.ReleaseWatch(gvr, "coordinator")
 		c.log.V(1).Info("Stopped orphaned child watch", "gvr", gvr)
 	}
 }

--- a/pkg/dynamiccontroller/coordinator.go
+++ b/pkg/dynamiccontroller/coordinator.go
@@ -33,8 +33,6 @@ type InstanceWatcher interface {
 	//
 	// For scalar resources: set Name + Namespace.
 	// For collections: set Selector + Namespace.
-	//
-	// Call Watch() BEFORE operating on the resource to avoid event gaps.
 	Watch(req WatchRequest) error
 
 	// Done signals that all Watch() calls for this reconciliation cycle
@@ -77,23 +75,32 @@ type instanceKey struct {
 	instance  types.NamespacedName
 }
 
-// instanceState tracks watch requests for a single instance across
-// reconciliation cycles. The coordinator uses current vs previous to
-// detect and clean up stale requests.
-type instanceState struct {
-	current  map[string]*WatchRequest // keyed by nodeID
-	previous map[string]*WatchRequest // from last Done() cycle
+// watchIdentity identifies a watch by its content (GVR + target).
+// Used for diffing between reconciliation cycles instead of nodeID-based identity.
+type watchIdentity struct {
+	gvr       schema.GroupVersionResource
+	name      string
+	namespace string
+	selector  string // Selector.String() for collections, "" for scalar
 }
 
-// scalarEntry is a single scalar watch in the reverse index.
-type scalarEntry struct {
-	nodeID string
-	key    instanceKey
+func identityOf(r WatchRequest) watchIdentity {
+	sel := ""
+	if r.Selector != nil {
+		sel = r.Selector.String()
+	}
+	return watchIdentity{gvr: r.GVR, name: r.Name, namespace: r.Namespace, selector: sel}
 }
 
-// collectionEntry is a single collection watch in the reverse index.
-type collectionEntry struct {
-	nodeID    string // enables identity-based matching for dedup and removal
+// scalarRouteKey identifies a specific scalar resource in the reverse index.
+type scalarRouteKey struct {
+	gvr       schema.GroupVersionResource
+	name      string
+	namespace string
+}
+
+// collectionRoute is a single collection watch in the reverse index.
+type collectionRoute struct {
 	selector  labels.Selector
 	namespace string
 	key       instanceKey
@@ -102,6 +109,11 @@ type collectionEntry struct {
 // WatchCoordinator aggregates watch requests from all instances, manages
 // shared watches via WatchManager, and routes events back to the correct
 // instances.
+//
+// Watch requests are collected locally by each instanceWatcher and committed
+// atomically when Done(true) is called. This avoids locking the coordinator
+// during the reconciliation loop and eliminates per-cycle current/previous
+// tracking.
 type WatchCoordinator struct {
 	mu sync.RWMutex
 
@@ -109,145 +121,103 @@ type WatchCoordinator struct {
 	enqueue EnqueueFunc
 	log     logr.Logger
 
-	// Per-instance state: tracks what each instance is watching.
-	instances map[instanceKey]*instanceState
+	// Per-instance: the last committed watch set.
+	committed map[instanceKey][]WatchRequest
 
 	// Reverse indexes for event routing.
-	// GVR -> namespace/name -> list of node-owned scalar watch entries.
-	scalarIndex map[schema.GroupVersionResource]map[types.NamespacedName][]scalarEntry
+	scalarRoutes     map[scalarRouteKey]map[instanceKey]struct{}
+	collectionRoutes map[schema.GroupVersionResource][]collectionRoute
 
-	// GVR -> list of collection watchers.
-	collectionIndex map[schema.GroupVersionResource][]collectionEntry
+	// Reference count per GVR across both indexes, for orphan detection.
+	gvrRefCount map[schema.GroupVersionResource]int
 }
 
 // NewWatchCoordinator creates a new WatchCoordinator.
 func NewWatchCoordinator(watches *WatchManager, enqueue EnqueueFunc, log logr.Logger) *WatchCoordinator {
 	return &WatchCoordinator{
-		watches:         watches,
-		enqueue:         enqueue,
-		log:             log.WithName("watch-coordinator"),
-		instances:       make(map[instanceKey]*instanceState),
-		scalarIndex:     make(map[schema.GroupVersionResource]map[types.NamespacedName][]scalarEntry),
-		collectionIndex: make(map[schema.GroupVersionResource][]collectionEntry),
+		watches:          watches,
+		enqueue:          enqueue,
+		log:              log.WithName("watch-coordinator"),
+		committed:        make(map[instanceKey][]WatchRequest),
+		scalarRoutes:     make(map[scalarRouteKey]map[instanceKey]struct{}),
+		collectionRoutes: make(map[schema.GroupVersionResource][]collectionRoute),
+		gvrRefCount:      make(map[schema.GroupVersionResource]int),
 	}
 }
 
 // ForInstance returns a scoped InstanceWatcher handle for the given instance.
+// Watch() calls on the returned handle accumulate locally; nothing is written
+// to the coordinator until Done(true) is called.
 func (c *WatchCoordinator) ForInstance(parentGVR schema.GroupVersionResource, instance types.NamespacedName) InstanceWatcher {
 	return &instanceWatcher{
 		coordinator: c,
-		parentGVR:   parentGVR,
-		instance:    instance,
+		key:         instanceKey{parentGVR: parentGVR, instance: instance},
 	}
 }
 
-// addWatch registers a watch request for the given instance.
-func (c *WatchCoordinator) addWatch(key instanceKey, req WatchRequest) error {
+// commitWatches atomically updates the watch set for an instance by diffing
+// the new requests against the previously committed set.
+func (c *WatchCoordinator) commitWatches(key instanceKey, newReqs []WatchRequest) {
+	newReqs = dedupWatchRequests(newReqs)
+
 	c.mu.Lock()
 
-	// Ensure instance state exists.
-	state, ok := c.instances[key]
-	if !ok {
-		state = &instanceState{
-			current:  make(map[string]*WatchRequest),
-			previous: make(map[string]*WatchRequest),
-		}
-		c.instances[key] = state
-		instanceWatchCount.WithLabelValues(key.parentGVR.String()).Inc()
-	}
+	oldReqs, existed := c.committed[key]
 
-	// Fix reverse index orphaning on nodeID reuse: if an existing entry
-	// for this nodeID has a different target, remove it from indexes first.
-	if old, exists := state.current[req.NodeID]; exists {
-		if !sameWatchTarget(old, &req) {
-			if prev, shared := state.previous[req.NodeID]; !shared || !sameWatchTarget(prev, old) {
-				c.removeRequestFromIndexesLocked(key, old)
-			}
-		}
-	}
-
-	// Add to current cycle.
-	state.current[req.NodeID] = &req
-
-	// Add to reverse index only when this request is not already covered by
-	// the previously committed watch set for the same node.
-	if prev, shared := state.previous[req.NodeID]; !shared || !sameWatchTarget(prev, &req) {
-		if req.isCollection() {
-			c.addCollectionIndexLocked(key, req)
-		} else {
-			c.addScalarIndexLocked(key, req)
-		}
-	}
-
-	gvr := req.GVR
-	c.mu.Unlock()
-
-	// Ensure an informer is running for this GVR.
-	// Called outside the coordinator lock to avoid holding it while
-	// the WatchManager acquires its own lock.
-	if err := c.watches.EnsureWatch(gvr, "coordinator"); err != nil {
-		c.log.Error(err, "Failed to ensure watch", "gvr", gvr)
-	}
-
-	return nil
-}
-
-// abortInstance discards the current reconciliation cycle for an instance.
-func (c *WatchCoordinator) abortInstance(key instanceKey) {
-	c.mu.Lock()
-
-	state, ok := c.instances[key]
-	if !ok {
+	// Nothing to do if there were no watches before and none now.
+	if !existed && len(newReqs) == 0 {
 		c.mu.Unlock()
 		return
 	}
 
-	var affectedGVRs []schema.GroupVersionResource
-	for nodeID, req := range state.current {
-		if prev, shared := state.previous[nodeID]; shared && sameWatchTarget(prev, req) {
-			continue
-		}
-		c.removeRequestFromIndexesLocked(key, req)
-		affectedGVRs = append(affectedGVRs, req.GVR)
+	// Build identity sets for diffing.
+	oldSet := make(map[watchIdentity]WatchRequest, len(oldReqs))
+	for _, r := range oldReqs {
+		oldSet[identityOf(r)] = r
+	}
+	newSet := make(map[watchIdentity]WatchRequest, len(newReqs))
+	for _, r := range newReqs {
+		newSet[identityOf(r)] = r
 	}
 
-	state.current = make(map[string]*WatchRequest)
+	// Remove routes no longer needed.
+	var removedGVRs []schema.GroupVersionResource
+	for id, old := range oldSet {
+		if _, ok := newSet[id]; !ok {
+			c.removeRouteLocked(key, old)
+			removedGVRs = append(removedGVRs, old.GVR)
+		}
+	}
 
-	orphanedGVRs := c.findOrphanedGVRsLocked(affectedGVRs)
+	// Add routes that are new.
+	ensureGVRs := make(map[schema.GroupVersionResource]struct{})
+	for id, req := range newSet {
+		if _, ok := oldSet[id]; !ok {
+			c.addRouteLocked(key, req)
+			ensureGVRs[req.GVR] = struct{}{}
+		}
+	}
+
+	// Update committed state.
+	if len(newReqs) > 0 {
+		c.committed[key] = newReqs
+		if !existed {
+			instanceWatchCount.WithLabelValues(key.parentGVR.String()).Inc()
+		}
+	} else if existed {
+		delete(c.committed, key)
+		c.decInstanceWatchCount(key.parentGVR)
+	}
+
+	orphanedGVRs := c.findOrphanedGVRsLocked(removedGVRs)
 	c.mu.Unlock()
 
-	c.stopWatches(orphanedGVRs)
-}
-
-// doneInstance finalizes the reconciliation cycle for an instance.
-func (c *WatchCoordinator) doneInstance(key instanceKey) {
-	c.mu.Lock()
-
-	state, ok := c.instances[key]
-	if !ok {
-		c.mu.Unlock()
-		return
-	}
-
-	// Remove requests that were in previous but NOT in current, or whose
-	// target changed (same nodeID but different GVR/name/namespace).
-	// Collect affected GVRs for orphan cleanup.
-	var affectedGVRs []schema.GroupVersionResource
-	for nodeID, oldReq := range state.previous {
-		if newReq, stillActive := state.current[nodeID]; stillActive && sameWatchTarget(newReq, oldReq) {
-			continue
+	// Ensure informers for new GVRs (outside lock).
+	for gvr := range ensureGVRs {
+		if err := c.watches.EnsureWatch(gvr, "coordinator"); err != nil {
+			c.log.Error(err, "Failed to ensure watch", "gvr", gvr)
 		}
-		c.removeRequestFromIndexesLocked(key, oldReq)
-		affectedGVRs = append(affectedGVRs, oldReq.GVR)
 	}
-
-	// Swap: previous = current, current = new empty map.
-	state.previous = state.current
-	state.current = make(map[string]*WatchRequest)
-
-	orphanedGVRs := c.findOrphanedGVRsLocked(affectedGVRs)
-	c.mu.Unlock()
-
 	c.stopWatches(orphanedGVRs)
 }
 
@@ -258,25 +228,19 @@ func (c *WatchCoordinator) RemoveInstance(parentGVR schema.GroupVersionResource,
 
 	c.mu.Lock()
 
-	state, ok := c.instances[key]
+	reqs, ok := c.committed[key]
 	if !ok {
 		c.mu.Unlock()
 		return
 	}
 
-	// Remove all current and previous requests from indexes.
-	// Collect affected GVRs for orphan cleanup.
 	var affectedGVRs []schema.GroupVersionResource
-	for _, req := range state.current {
-		c.removeRequestFromIndexesLocked(key, req)
-		affectedGVRs = append(affectedGVRs, req.GVR)
-	}
-	for _, req := range state.previous {
-		c.removeRequestFromIndexesLocked(key, req)
+	for _, req := range reqs {
+		c.removeRouteLocked(key, req)
 		affectedGVRs = append(affectedGVRs, req.GVR)
 	}
 
-	delete(c.instances, key)
+	delete(c.committed, key)
 	c.decInstanceWatchCount(parentGVR)
 
 	orphanedGVRs := c.findOrphanedGVRsLocked(affectedGVRs)
@@ -290,31 +254,20 @@ func (c *WatchCoordinator) RemoveInstance(parentGVR schema.GroupVersionResource,
 func (c *WatchCoordinator) RemoveParentGVR(parentGVR schema.GroupVersionResource) {
 	c.mu.Lock()
 
-	// Collect instance keys to remove.
 	var toRemove []instanceKey
-	for key := range c.instances {
+	for key := range c.committed {
 		if key.parentGVR == parentGVR {
 			toRemove = append(toRemove, key)
 		}
 	}
 
-	capacity := 0
+	var affectedGVRs []schema.GroupVersionResource
 	for _, key := range toRemove {
-		state := c.instances[key]
-		capacity += len(state.current) + len(state.previous)
-	}
-	affectedGVRs := make([]schema.GroupVersionResource, 0, capacity)
-	for _, key := range toRemove {
-		state := c.instances[key]
-		for _, req := range state.current {
-			c.removeRequestFromIndexesLocked(key, req)
+		for _, req := range c.committed[key] {
+			c.removeRouteLocked(key, req)
 			affectedGVRs = append(affectedGVRs, req.GVR)
 		}
-		for _, req := range state.previous {
-			c.removeRequestFromIndexesLocked(key, req)
-			affectedGVRs = append(affectedGVRs, req.GVR)
-		}
-		delete(c.instances, key)
+		delete(c.committed, key)
 	}
 	c.decInstanceWatchCount(parentGVR)
 
@@ -332,18 +285,16 @@ func (c *WatchCoordinator) RouteEvent(event Event) {
 	c.mu.RLock()
 	matched := make(map[instanceKey]struct{})
 
-	// Scalar matches (O(1) per GVR+name).
-	if byName, ok := c.scalarIndex[event.GVR]; ok {
-		key := types.NamespacedName{Name: event.Name, Namespace: event.Namespace}
-		for _, entry := range byName[key] {
-			matched[entry.key] = struct{}{}
-		}
+	// Scalar matches (O(1) lookup).
+	rk := scalarRouteKey{gvr: event.GVR, name: event.Name, namespace: event.Namespace}
+	for key := range c.scalarRoutes[rk] {
+		matched[key] = struct{}{}
 	}
 
 	// Collection matches (selector scan).
 	// Match against both current and old labels so that an object losing
 	// matching labels still triggers re-reconciliation.
-	for _, entry := range c.collectionIndex[event.GVR] {
+	for _, entry := range c.collectionRoutes[event.GVR] {
 		if entry.namespace != "" && event.Namespace != entry.namespace {
 			continue
 		}
@@ -368,7 +319,7 @@ func (c *WatchCoordinator) RouteEvent(event Event) {
 func (c *WatchCoordinator) InstanceWatchCount() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return len(c.instances)
+	return len(c.committed)
 }
 
 // WatchRequestCount returns the total number of active watch requests.
@@ -376,12 +327,10 @@ func (c *WatchCoordinator) WatchRequestCount() (scalar, collection int) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	for _, byName := range c.scalarIndex {
-		for _, entries := range byName {
-			scalar += len(entries)
-		}
+	for _, keys := range c.scalarRoutes {
+		scalar += len(keys)
 	}
-	for _, entries := range c.collectionIndex {
+	for _, entries := range c.collectionRoutes {
 		collection += len(entries)
 	}
 	return
@@ -389,95 +338,77 @@ func (c *WatchCoordinator) WatchRequestCount() (scalar, collection int) {
 
 // --- internal helpers ---
 
-func (c *WatchCoordinator) addScalarIndexLocked(key instanceKey, req WatchRequest) {
-	byName, ok := c.scalarIndex[req.GVR]
-	if !ok {
-		byName = make(map[types.NamespacedName][]scalarEntry)
-		c.scalarIndex[req.GVR] = byName
-	}
-	nn := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	for _, entry := range byName[nn] {
-		if entry.key == key && entry.nodeID == req.NodeID {
-			return
-		}
-	}
-	byName[nn] = append(byName[nn], scalarEntry{
-		nodeID: req.NodeID,
-		key:    key,
-	})
-	watchRequestCount.WithLabelValues(req.GVR.String(), "scalar").Inc()
-}
-
-func (c *WatchCoordinator) addCollectionIndexLocked(key instanceKey, req WatchRequest) {
-	entries := c.collectionIndex[req.GVR]
-	for _, e := range entries {
-		if e.key == key &&
-			e.nodeID == req.NodeID &&
-			e.namespace == req.Namespace &&
-			e.selector.String() == req.Selector.String() {
-			return
-		}
-	}
-	c.collectionIndex[req.GVR] = append(entries, collectionEntry{
-		nodeID:    req.NodeID,
-		selector:  req.Selector,
-		namespace: req.Namespace,
-		key:       key,
-	})
-	watchRequestCount.WithLabelValues(req.GVR.String(), "collection").Inc()
-}
-
-func (c *WatchCoordinator) removeRequestFromIndexesLocked(key instanceKey, req *WatchRequest) {
+func (c *WatchCoordinator) addRouteLocked(key instanceKey, req WatchRequest) {
 	if req.isCollection() {
-		c.removeCollectionIndexLocked(key, req)
+		c.collectionRoutes[req.GVR] = append(c.collectionRoutes[req.GVR], collectionRoute{
+			selector:  req.Selector,
+			namespace: req.Namespace,
+			key:       key,
+		})
+		watchRequestCount.WithLabelValues(req.GVR.String(), "collection").Inc()
 	} else {
-		c.removeScalarIndexLocked(key, req)
+		rk := scalarRouteKey{gvr: req.GVR, name: req.Name, namespace: req.Namespace}
+		if c.scalarRoutes[rk] == nil {
+			c.scalarRoutes[rk] = make(map[instanceKey]struct{})
+		}
+		c.scalarRoutes[rk][key] = struct{}{}
+		watchRequestCount.WithLabelValues(req.GVR.String(), "scalar").Inc()
+	}
+	c.gvrRefCount[req.GVR]++
+}
+
+func (c *WatchCoordinator) removeRouteLocked(key instanceKey, req WatchRequest) {
+	if req.isCollection() {
+		sel := req.Selector.String()
+		entries := c.collectionRoutes[req.GVR]
+		filtered := entries[:0]
+		for _, e := range entries {
+			if e.key == key && e.namespace == req.Namespace && e.selector.String() == sel {
+				continue
+			}
+			filtered = append(filtered, e)
+		}
+		// Zero trailing elements so removed collectionRoute values (which hold
+		// labels.Selector interface references) can be garbage-collected.
+		for i := len(filtered); i < len(entries); i++ {
+			entries[i] = collectionRoute{}
+		}
+		if len(filtered) == 0 {
+			delete(c.collectionRoutes, req.GVR)
+		} else {
+			c.collectionRoutes[req.GVR] = filtered
+		}
+	} else {
+		rk := scalarRouteKey{gvr: req.GVR, name: req.Name, namespace: req.Namespace}
+		if keys := c.scalarRoutes[rk]; keys != nil {
+			delete(keys, key)
+			if len(keys) == 0 {
+				delete(c.scalarRoutes, rk)
+			}
+		}
+	}
+
+	c.gvrRefCount[req.GVR]--
+	if c.gvrRefCount[req.GVR] <= 0 {
+		delete(c.gvrRefCount, req.GVR)
+		gvrStr := req.GVR.String()
+		watchRequestCount.DeleteLabelValues(gvrStr, "scalar")
+		watchRequestCount.DeleteLabelValues(gvrStr, "collection")
+	} else {
+		typ := "scalar"
+		if req.isCollection() {
+			typ = "collection"
+		}
+		watchRequestCount.WithLabelValues(req.GVR.String(), typ).Dec()
 	}
 }
 
-func (c *WatchCoordinator) removeScalarIndexLocked(key instanceKey, req *WatchRequest) {
-	byName, ok := c.scalarIndex[req.GVR]
-	if !ok {
-		return
-	}
-	nn := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	entries, ok := byName[nn]
-	if !ok {
-		return
-	}
-	removed := 0
-	filtered := entries[:0]
-	for _, entry := range entries {
-		if entry.key == key && entry.nodeID == req.NodeID {
-			removed++
-			continue
-		}
-		filtered = append(filtered, entry)
-	}
-	if len(filtered) == 0 {
-		delete(byName, nn)
-	} else {
-		byName[nn] = filtered
-	}
-	gvrStr := req.GVR.String()
-	if len(byName) == 0 {
-		delete(c.scalarIndex, req.GVR)
-		// If this GVR is also gone from collectionIndex, delete its gauge labels.
-		if len(c.collectionIndex[req.GVR]) == 0 {
-			watchRequestCount.DeleteLabelValues(gvrStr, "scalar")
-			watchRequestCount.DeleteLabelValues(gvrStr, "collection")
-		}
-	} else if removed > 0 {
-		watchRequestCount.WithLabelValues(gvrStr, "scalar").Sub(float64(removed))
-	}
-}
-
-// findOrphanedGVRsLocked returns GVRs that have zero entries in both the
-// scalar and collection indexes. Must be called with c.mu held.
+// findOrphanedGVRsLocked returns GVRs from the candidate list that have zero
+// route entries. Must be called with c.mu held.
 func (c *WatchCoordinator) findOrphanedGVRsLocked(gvrs []schema.GroupVersionResource) []schema.GroupVersionResource {
 	var orphaned []schema.GroupVersionResource
 	for _, gvr := range gvrs {
-		if len(c.scalarIndex[gvr]) == 0 && len(c.collectionIndex[gvr]) == 0 {
+		if c.gvrRefCount[gvr] == 0 {
 			orphaned = append(orphaned, gvr)
 		}
 	}
@@ -495,47 +426,35 @@ func (c *WatchCoordinator) stopWatches(gvrs []schema.GroupVersionResource) {
 	}
 }
 
-func (c *WatchCoordinator) removeCollectionIndexLocked(key instanceKey, req *WatchRequest) {
-	entries := c.collectionIndex[req.GVR]
-	removed := 0
-	filtered := entries[:0]
-	for _, e := range entries {
-		if e.key == key &&
-			e.nodeID == req.NodeID &&
-			e.namespace == req.Namespace &&
-			e.selector.String() == req.Selector.String() {
-			removed++
-			continue
-		}
-		filtered = append(filtered, e)
-	}
-	gvrStr := req.GVR.String()
-	if len(filtered) == 0 {
-		delete(c.collectionIndex, req.GVR)
-		// If this GVR is also gone from scalarIndex, delete its gauge labels.
-		if len(c.scalarIndex[req.GVR]) == 0 {
-			watchRequestCount.DeleteLabelValues(gvrStr, "scalar")
-			watchRequestCount.DeleteLabelValues(gvrStr, "collection")
-		}
-	} else {
-		c.collectionIndex[req.GVR] = filtered
-		if removed > 0 {
-			watchRequestCount.WithLabelValues(gvrStr, "collection").Sub(float64(removed))
-		}
-	}
-}
-
 // decInstanceWatchCount decrements the instanceWatchCount gauge for the given
 // parent GVR, deleting the label set entirely when no instances remain.
 // Must be called with c.mu held, after the instance has been deleted.
 func (c *WatchCoordinator) decInstanceWatchCount(parentGVR schema.GroupVersionResource) {
-	for key := range c.instances {
+	for key := range c.committed {
 		if key.parentGVR == parentGVR {
 			instanceWatchCount.WithLabelValues(parentGVR.String()).Dec()
 			return
 		}
 	}
 	instanceWatchCount.DeleteLabelValues(parentGVR.String())
+}
+
+// dedupWatchRequests removes duplicate watch requests by content identity.
+func dedupWatchRequests(reqs []WatchRequest) []WatchRequest {
+	if len(reqs) <= 1 {
+		return reqs
+	}
+	seen := make(map[watchIdentity]struct{}, len(reqs))
+	result := make([]WatchRequest, 0, len(reqs))
+	for _, r := range reqs {
+		id := identityOf(r)
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		result = append(result, r)
+	}
+	return result
 }
 
 // NoopInstanceWatcher is a no-op implementation of InstanceWatcher for use
@@ -546,46 +465,32 @@ func (NoopInstanceWatcher) Watch(_ WatchRequest) error { return nil }
 func (NoopInstanceWatcher) Done(bool)                  {}
 
 // instanceWatcher is the concrete implementation of InstanceWatcher.
+// Watch() calls append to a local pending slice with no coordinator
+// interaction. Done(true) commits the pending set atomically.
+//
+// Not safe for concurrent use — callers must serialize Watch/Done calls.
+// This is guaranteed by controller-runtime which processes one reconcile
+// per instance at a time.
 type instanceWatcher struct {
 	coordinator *WatchCoordinator
-	parentGVR   schema.GroupVersionResource
-	instance    types.NamespacedName
+	key         instanceKey
+	pending     []WatchRequest
 }
 
-// Watch registers a watch request for this instance.
+// Watch appends a watch request to the local pending set.
+// No locks are acquired and the call never fails.
 func (w *instanceWatcher) Watch(req WatchRequest) error {
-	return w.coordinator.addWatch(instanceKey{
-		parentGVR: w.parentGVR,
-		instance:  w.instance,
-	}, req)
+	w.pending = append(w.pending, req)
+	return nil
 }
 
-// Done finalizes the current reconciliation cycle. If commit is false, the
-// provisional watch set is discarded and the previous one stays active.
+// Done finalizes the current reconciliation cycle. If commit is true, the
+// pending watch set replaces the previously committed set and indexes are
+// updated atomically. If commit is false, the pending set is discarded and
+// the previously committed watches remain active.
 func (w *instanceWatcher) Done(commit bool) {
-	key := instanceKey{
-		parentGVR: w.parentGVR,
-		instance:  w.instance,
-	}
 	if !commit {
-		w.coordinator.abortInstance(key)
 		return
 	}
-	w.coordinator.doneInstance(key)
-}
-
-func sameWatchTarget(a, b *WatchRequest) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	if a.GVR != b.GVR || a.Name != b.Name || a.Namespace != b.Namespace {
-		return false
-	}
-	if a.isCollection() != b.isCollection() {
-		return false
-	}
-	if !a.isCollection() {
-		return true
-	}
-	return a.Selector.String() == b.Selector.String()
+	w.coordinator.commitWatches(w.key, w.pending)
 }

--- a/pkg/dynamiccontroller/coordinator.go
+++ b/pkg/dynamiccontroller/coordinator.go
@@ -178,6 +178,7 @@ func (c *WatchCoordinator) addWatch(key instanceKey, req WatchRequest) error {
 		}
 	}
 
+	c.updateWatchRequestMetrics()
 	gvr := req.GVR
 	c.mu.Unlock()
 
@@ -212,6 +213,7 @@ func (c *WatchCoordinator) abortInstance(key instanceKey) {
 
 	state.current = make(map[string]*WatchRequest)
 
+	c.updateWatchRequestMetrics()
 	orphanedGVRs := c.findOrphanedGVRsLocked(affectedGVRs)
 	c.mu.Unlock()
 
@@ -244,6 +246,7 @@ func (c *WatchCoordinator) doneInstance(key instanceKey) {
 	state.previous = state.current
 	state.current = make(map[string]*WatchRequest)
 
+	c.updateWatchRequestMetrics()
 	orphanedGVRs := c.findOrphanedGVRsLocked(affectedGVRs)
 	c.mu.Unlock()
 
@@ -277,6 +280,7 @@ func (c *WatchCoordinator) RemoveInstance(parentGVR schema.GroupVersionResource,
 
 	delete(c.instances, key)
 
+	c.updateWatchRequestMetrics()
 	orphanedGVRs := c.findOrphanedGVRsLocked(affectedGVRs)
 	c.mu.Unlock()
 
@@ -315,6 +319,7 @@ func (c *WatchCoordinator) RemoveParentGVR(parentGVR schema.GroupVersionResource
 		delete(c.instances, key)
 	}
 
+	c.updateWatchRequestMetrics()
 	orphanedGVRs := c.findOrphanedGVRsLocked(affectedGVRs)
 	c.mu.Unlock()
 
@@ -324,6 +329,8 @@ func (c *WatchCoordinator) RemoveParentGVR(parentGVR schema.GroupVersionResource
 // RouteEvent routes a watch event to all matching instances.
 // Called by the watch handler for every event.
 func (c *WatchCoordinator) RouteEvent(event Event) {
+	routeTotal.WithLabelValues(event.GVR.String()).Inc()
+
 	c.mu.RLock()
 	matched := make(map[instanceKey]struct{})
 
@@ -354,6 +361,7 @@ func (c *WatchCoordinator) RouteEvent(event Event) {
 		c.enqueue(key.parentGVR, key.instance)
 	}
 	if len(matched) > 0 {
+		routeMatchTotal.WithLabelValues(event.GVR.String()).Inc()
 		c.log.V(2).Info("Routed event", "gvr", event.GVR, "name", event.Name, "namespace", event.Namespace, "type", event.Type)
 	}
 }
@@ -530,6 +538,36 @@ func (w *instanceWatcher) Done(commit bool) {
 		return
 	}
 	w.coordinator.doneInstance(key)
+}
+
+// updateWatchRequestMetrics recalculates the watch request gauge metrics
+// from the current index state. Must be called with c.mu held (at least RLock).
+func (c *WatchCoordinator) updateWatchRequestMetrics() {
+	// Per-GVR scalar/collection breakdown.
+	gvrs := make(map[schema.GroupVersionResource]struct{})
+	for gvr := range c.scalarIndex {
+		gvrs[gvr] = struct{}{}
+	}
+	for gvr := range c.collectionIndex {
+		gvrs[gvr] = struct{}{}
+	}
+	for gvr := range gvrs {
+		scalar := 0
+		for _, entries := range c.scalarIndex[gvr] {
+			scalar += len(entries)
+		}
+		watchRequestCount.WithLabelValues(gvr.String(), "scalar").Set(float64(scalar))
+		watchRequestCount.WithLabelValues(gvr.String(), "collection").Set(float64(len(c.collectionIndex[gvr])))
+	}
+
+	// Per-parent instance watch count.
+	parentCounts := make(map[schema.GroupVersionResource]int)
+	for key := range c.instances {
+		parentCounts[key.parentGVR]++
+	}
+	for parentGVR, count := range parentCounts {
+		instanceWatchCount.WithLabelValues(parentGVR.String()).Set(float64(count))
+	}
 }
 
 func sameWatchTarget(a, b *WatchRequest) bool {

--- a/pkg/dynamiccontroller/coordinator_test.go
+++ b/pkg/dynamiccontroller/coordinator_test.go
@@ -299,9 +299,9 @@ func TestStopOrphanedWatch_RemoveInstance(t *testing.T) {
 	coord.RemoveInstance(testParentGVR, instance)
 	assert.Equal(t, 0, coord.watches.ActiveWatchCount(), "expected 0 active watches after removing last requestor")
 
-	// EnsureWatch can re-create it.
-	assert.NoError(t, coord.watches.EnsureWatch(testDeployGVR))
-	assert.Equal(t, 1, coord.watches.ActiveWatchCount(), "expected watch to be re-created after EnsureWatch")
+	// ensureWatch can re-create it.
+	assert.NoError(t, coord.watches.ensureWatch(testDeployGVR))
+	assert.Equal(t, 1, coord.watches.ActiveWatchCount(), "expected watch to be re-created after ensureWatch")
 }
 
 func TestStopOrphanedWatch_DoneCleanup(t *testing.T) {
@@ -863,14 +863,14 @@ func TestAddWatch_EnsureWatchSyncError(t *testing.T) {
 
 	watcher := coord.ForInstance(testParentGVR, instance)
 
-	// EnsureWatch will fail sync but addWatch logs and returns nil.
+	// ensureWatch will fail sync but addWatch logs and returns nil.
 	err := watcher.Watch(WatchRequest{
 		NodeID:    "deploy",
 		GVR:       testDeployGVR,
 		Name:      "d1",
 		Namespace: "default",
 	})
-	assert.NoError(t, err) // addWatch does not propagate EnsureWatch errors
+	assert.NoError(t, err) // addWatch does not propagate ensureWatch errors
 
 	wm.Shutdown()
 }

--- a/pkg/dynamiccontroller/coordinator_test.go
+++ b/pkg/dynamiccontroller/coordinator_test.go
@@ -299,9 +299,9 @@ func TestStopOrphanedWatch_RemoveInstance(t *testing.T) {
 	coord.RemoveInstance(testParentGVR, instance)
 	assert.Equal(t, 0, coord.watches.ActiveWatchCount(), "expected 0 active watches after removing last requestor")
 
-	// ensureWatch can re-create it.
-	assert.NoError(t, coord.watches.ensureWatch(testDeployGVR))
-	assert.Equal(t, 1, coord.watches.ActiveWatchCount(), "expected watch to be re-created after ensureWatch")
+	// EnsureWatch can re-create it.
+	assert.NoError(t, coord.watches.EnsureWatch(testDeployGVR, "test"))
+	assert.Equal(t, 1, coord.watches.ActiveWatchCount(), "expected watch to be re-created after EnsureWatch")
 }
 
 func TestStopOrphanedWatch_DoneCleanup(t *testing.T) {
@@ -863,14 +863,14 @@ func TestAddWatch_EnsureWatchSyncError(t *testing.T) {
 
 	watcher := coord.ForInstance(testParentGVR, instance)
 
-	// ensureWatch will fail sync but addWatch logs and returns nil.
+	// EnsureWatch will fail sync but addWatch logs and returns nil.
 	err := watcher.Watch(WatchRequest{
 		NodeID:    "deploy",
 		GVR:       testDeployGVR,
 		Name:      "d1",
 		Namespace: "default",
 	})
-	assert.NoError(t, err) // addWatch does not propagate ensureWatch errors
+	assert.NoError(t, err) // addWatch does not propagate EnsureWatch errors
 
 	wm.Shutdown()
 }
@@ -889,6 +889,82 @@ func TestRemoveInstance_ScalarIndexCleanup(t *testing.T) {
 	scalar, collection := coord.WatchRequestCount()
 	assert.Equal(t, 0, scalar)
 	assert.Equal(t, 0, collection)
+}
+
+func TestUpdateWatchRequestMetrics_ClearsStaleGauges(t *testing.T) {
+	// Regression test: when a GVR is fully removed, its gauge value must
+	// not persist in Prometheus forever. Gauge labels should be deleted
+	// when a GVR is removed from the indexes.
+	coord, _ := newTestCoordinator(t)
+	instance := types.NamespacedName{Name: "my-app", Namespace: "default"}
+
+	// Watch a deployment and a configmap collection.
+	watcher := coord.ForInstance(testParentGVR, instance)
+	require.NoError(t, watcher.Watch(WatchRequest{
+		NodeID:    "deploy",
+		GVR:       testDeployGVR,
+		Name:      "d1",
+		Namespace: "default",
+	}))
+	selector, _ := labels.Parse("app=test")
+	require.NoError(t, watcher.Watch(WatchRequest{
+		NodeID:    "configs",
+		GVR:       testCmGVR,
+		Namespace: "default",
+		Selector:  selector,
+	}))
+	watcher.Done(true)
+
+	// Verify gauges are set.
+	scalar, collection := coord.WatchRequestCount()
+	assert.Equal(t, 1, scalar)
+	assert.Equal(t, 1, collection)
+
+	// Remove the instance — all watches should be cleaned up.
+	coord.RemoveInstance(testParentGVR, instance)
+	assert.Equal(t, 0, coord.InstanceWatchCount())
+
+	// After removal, both watch request counts should be zero.
+	// Before the fix, the gauges for the removed GVRs would retain
+	// their last non-zero values.
+	scalar, collection = coord.WatchRequestCount()
+	assert.Equal(t, 0, scalar, "scalar gauge should be zero after GVR removal")
+	assert.Equal(t, 0, collection, "collection gauge should be zero after GVR removal")
+}
+
+func TestUpdateWatchRequestMetrics_PartialRemoval(t *testing.T) {
+	// Verify that removing one GVR's watches doesn't affect another's gauges.
+	coord, _ := newTestCoordinator(t)
+	inst1 := types.NamespacedName{Name: "app1", Namespace: "default"}
+	inst2 := types.NamespacedName{Name: "app2", Namespace: "default"}
+
+	// inst1 watches deployments, inst2 watches configmaps.
+	w1 := coord.ForInstance(testParentGVR, inst1)
+	require.NoError(t, w1.Watch(WatchRequest{
+		NodeID:    "deploy",
+		GVR:       testDeployGVR,
+		Name:      "d1",
+		Namespace: "default",
+	}))
+	w1.Done(true)
+
+	w2 := coord.ForInstance(testParentGVR, inst2)
+	require.NoError(t, w2.Watch(WatchRequest{
+		NodeID:    "service",
+		GVR:       testServiceGVR,
+		Name:      "s1",
+		Namespace: "default",
+	}))
+	w2.Done(true)
+
+	scalar, _ := coord.WatchRequestCount()
+	assert.Equal(t, 2, scalar, "should have 2 scalar watch requests")
+
+	// Remove only inst1 — inst2's watches should remain.
+	coord.RemoveInstance(testParentGVR, inst1)
+
+	scalar, _ = coord.WatchRequestCount()
+	assert.Equal(t, 1, scalar, "should have 1 scalar watch request after partial removal")
 }
 
 func TestRemoveParentGVR_NonExistent(t *testing.T) {

--- a/pkg/dynamiccontroller/coordinator_test.go
+++ b/pkg/dynamiccontroller/coordinator_test.go
@@ -109,7 +109,7 @@ func TestWatchAndDone_ScalarWatch(t *testing.T) {
 
 	watcher := coord.ForInstance(testParentGVR, instance)
 
-	// Watch a deployment.
+	// Watch a deployment and commit.
 	err := watcher.Watch(WatchRequest{
 		NodeID:    "deployment",
 		GVR:       testDeployGVR,
@@ -117,6 +117,7 @@ func TestWatchAndDone_ScalarWatch(t *testing.T) {
 		Namespace: "default",
 	})
 	require.NoError(t, err)
+	watcher.Done(true)
 
 	// Verify instance is tracked.
 	assert.Equal(t, 1, coord.InstanceWatchCount())
@@ -138,8 +139,6 @@ func TestWatchAndDone_ScalarWatch(t *testing.T) {
 		Namespace: "default",
 	})
 	assert.Equal(t, 1, recorder.count())
-
-	watcher.Done(true)
 }
 
 func TestWatchAndDone_CleanupStaleRequests(t *testing.T) {
@@ -722,7 +721,7 @@ func TestAbortInstance_RollsBackFailedCycleTargetChange(t *testing.T) {
 	assert.Equal(t, 1, recorder.count(), "previous committed watch should remain active after abort")
 
 	assert.NotNil(t, coord.watches.GetInformer(testDeployGVR), "previous informer should stay running")
-	assert.Nil(t, coord.watches.GetInformer(testServiceGVR), "orphaned failed-cycle informer should be stopped")
+	assert.Nil(t, coord.watches.GetInformer(testServiceGVR), "aborted cycle informer should never have started")
 
 	scalar, collection := coord.WatchRequestCount()
 	assert.Equal(t, 1, scalar)
@@ -843,7 +842,7 @@ func TestAbortInstance_RollsBackCollectionSelectorChange(t *testing.T) {
 	assert.Equal(t, 1, recorder.count(), "previous committed selector should remain active after abort")
 }
 
-func TestAddWatch_EnsureWatchSyncError(t *testing.T) {
+func TestEnsureWatch_SyncError(t *testing.T) {
 	log := zap.New(zap.UseDevMode(true))
 
 	scheme := runtime.NewScheme()
@@ -863,26 +862,30 @@ func TestAddWatch_EnsureWatchSyncError(t *testing.T) {
 
 	watcher := coord.ForInstance(testParentGVR, instance)
 
-	// EnsureWatch will fail sync but addWatch logs and returns nil.
+	// Watch always returns nil (local append only).
 	err := watcher.Watch(WatchRequest{
 		NodeID:    "deploy",
 		GVR:       testDeployGVR,
 		Name:      "d1",
 		Namespace: "default",
 	})
-	assert.NoError(t, err) // addWatch does not propagate EnsureWatch errors
+	assert.NoError(t, err)
+
+	// Done(true) calls EnsureWatch internally — should not panic even on sync error.
+	watcher.Done(true)
 
 	wm.Shutdown()
 }
 
-func TestRemoveInstance_ScalarIndexCleanup(t *testing.T) {
+func TestRemoveInstance_UncommittedWatchesIgnored(t *testing.T) {
 	coord, _ := newTestCoordinator(t)
 	instance := types.NamespacedName{Name: "my-app", Namespace: "default"}
 
-	// Watch, Done, then remove.
+	// Watch without Done — pending watches are local to the instanceWatcher.
 	watcher := coord.ForInstance(testParentGVR, instance)
 	require.NoError(t, watcher.Watch(WatchRequest{NodeID: "deploy", GVR: testDeployGVR, Name: "d1", Namespace: "default"}))
-	// Don't call Done — tests that RemoveInstance cleans up current entries too.
+
+	// RemoveInstance has nothing to clean up (nothing committed).
 	coord.RemoveInstance(testParentGVR, instance)
 
 	assert.Equal(t, 0, coord.InstanceWatchCount())
@@ -925,8 +928,6 @@ func TestUpdateWatchRequestMetrics_ClearsStaleGauges(t *testing.T) {
 	assert.Equal(t, 0, coord.InstanceWatchCount())
 
 	// After removal, both watch request counts should be zero.
-	// Before the fix, the gauges for the removed GVRs would retain
-	// their last non-zero values.
 	scalar, collection = coord.WatchRequestCount()
 	assert.Equal(t, 0, scalar, "scalar gauge should be zero after GVR removal")
 	assert.Equal(t, 0, collection, "collection gauge should be zero after GVR removal")
@@ -938,7 +939,7 @@ func TestUpdateWatchRequestMetrics_PartialRemoval(t *testing.T) {
 	inst1 := types.NamespacedName{Name: "app1", Namespace: "default"}
 	inst2 := types.NamespacedName{Name: "app2", Namespace: "default"}
 
-	// inst1 watches deployments, inst2 watches configmaps.
+	// inst1 watches deployments, inst2 watches services.
 	w1 := coord.ForInstance(testParentGVR, inst1)
 	require.NoError(t, w1.Watch(WatchRequest{
 		NodeID:    "deploy",

--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -129,7 +129,7 @@ type ObjectIdentifiers struct {
 //
 // The DynamicController uses a layered architecture:
 //
-//  1. WatchManager: manages informer lifecycle per GVR (reference-counted).
+//  1. WatchManager: manages informer lifecycle per GVR (owner-set based).
 //
 //  2. WatchCoordinator: aggregates watch requests from all instance reconcilers,
 //     maintains reverse indexes for event routing, and manages shared watches
@@ -354,72 +354,73 @@ func (dc *DynamicController) Register(
 	// Store handler.
 	dc.handlers.Store(parent, instanceHandler)
 
-	// Create parent watch if it doesn't exist.
-	if _, exists := dc.parentWatches[parent]; !exists {
-		// Retain the shared informer for the parent and wait for cache sync.
-		if err := dc.watches.EnsureParentWatch(parent); err != nil {
-			dc.handlers.Delete(parent)
-			return fmt.Errorf("add parent handler %s: %w", parent, err)
-		}
-
-		inf := dc.watches.GetInformer(parent)
-		if inf == nil {
-			dc.watches.ReleaseParentWatch(parent)
-			if !dc.coordinator.HasRequestsForGVR(parent) {
-				dc.watches.StopWatch(parent)
-			}
-			dc.handlers.Delete(parent)
-			return fmt.Errorf("add parent handler %s: informer not found after EnsureWatch", parent)
-		}
-
-		// Register event handler directly on the parent informer.
-		parentHandler := cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				dc.enqueueFromInformer(parent, obj, EventAdd)
-			},
-			UpdateFunc: func(_, newObj interface{}) {
-				dc.enqueueFromInformer(parent, newObj, EventUpdate)
-			},
-			DeleteFunc: func(obj interface{}) {
-				dc.enqueueFromInformer(parent, obj, EventDelete)
-			},
-		}
-		reg, err := inf.AddEventHandler(parentHandler)
-		if err != nil {
-			dc.watches.ReleaseParentWatch(parent)
-			if !dc.coordinator.HasRequestsForGVR(parent) {
-				dc.watches.StopWatch(parent)
-			}
-			dc.handlers.Delete(parent)
-			return fmt.Errorf("add parent handler %s: %w", parent, err)
-		}
-		dc.parentWatches[parent] = reg
-
-		gvrCount.Inc()
-		handlerAttachTotal.WithLabelValues("parent").Inc()
-		handlerCount.WithLabelValues("parent").Inc()
-		dc.log.V(1).Info("Attached parent watch", "gvr", parent)
+	// Re-registration: just enqueue existing instances.
+	if _, exists := dc.parentWatches[parent]; exists {
+		dc.enqueueExistingInstances(parent)
+		return nil
 	}
+
+	// Retain the shared informer for the parent and wait for cache sync.
+	if err := dc.watches.EnsureWatch(parent, "parent"); err != nil {
+		dc.handlers.Delete(parent)
+		return fmt.Errorf("add parent handler %s: %w", parent, err)
+	}
+
+	// Deferred cleanup on any error below.
+	cleanupWatch := true
+	defer func() {
+		if cleanupWatch {
+			dc.watches.ReleaseWatch(parent, "parent")
+			dc.handlers.Delete(parent)
+		}
+	}()
+
+	// Register event handler directly on the parent informer.
+	reg, err := dc.watches.GetInformer(parent).AddEventHandler(dc.parentEventHandlerFor(parent))
+	if err != nil {
+		return fmt.Errorf("add parent handler %s: %w", parent, err)
+	}
+
+	// Success — cancel deferred cleanup.
+	cleanupWatch = false
+	dc.parentWatches[parent] = reg
+
+	gvrCount.Inc()
+	handlerAttachTotal.WithLabelValues("parent").Inc()
+	handlerCount.WithLabelValues("parent").Inc()
+	dc.log.V(1).Info("Attached parent watch", "gvr", parent)
 
 	// Enqueue existing instances from parent cache.
-	if inf := dc.watches.GetInformer(parent); inf != nil && !inf.IsStopped() {
-		objects := inf.GetStore().List()
-		for _, obj := range objects {
-			mobj, err := meta.Accessor(obj)
-			if err != nil {
-				continue
-			}
-			dc.enqueueParent(parent, Event{
-				Type:      EventUpdate,
-				GVR:       parent,
-				Name:      mobj.GetName(),
-				Namespace: mobj.GetNamespace(),
-			})
-		}
-	}
+	dc.enqueueExistingInstances(parent)
 
 	dc.log.V(1).Info("Successfully registered GVR", "gvr", keyFromGVR(parent))
 	return nil
+}
+
+// parentEventHandlerFor generates a cache handler function set
+// for enqueuing a new event for a given parent gvr
+func (dc *DynamicController) parentEventHandlerFor(parent schema.GroupVersionResource) cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			dc.enqueueFromInformer(parent, obj, EventAdd)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			dc.enqueueFromInformer(parent, newObj, EventUpdate)
+		},
+		DeleteFunc: func(obj interface{}) {
+			dc.enqueueFromInformer(parent, obj, EventDelete)
+		},
+	}
+}
+
+// enqueueExistingInstances enqueues all objects currently in the parent
+// informer's cache store for re-reconciliation.
+func (dc *DynamicController) enqueueExistingInstances(parent schema.GroupVersionResource) {
+	if inf := dc.watches.GetInformer(parent); inf != nil && !inf.IsStopped() {
+		for _, obj := range inf.GetStore().List() {
+			dc.enqueueFromInformer(parent, obj, EventUpdate)
+		}
+	}
 }
 
 // enqueueFromInformer converts a raw informer callback into an enqueue call.
@@ -456,12 +457,9 @@ func (dc *DynamicController) Deregister(_ context.Context, parent schema.GroupVe
 		}
 		delete(dc.parentWatches, parent)
 
-		// Release the parent retention and stop the shared informer only if
-		// no child/external watches still depend on it.
-		dc.watches.ReleaseParentWatch(parent)
-		if !dc.coordinator.HasRequestsForGVR(parent) {
-			dc.watches.StopWatch(parent)
-		}
+		// Release the parent ownership; ReleaseWatch stops the informer
+		// automatically if no other owners remain.
+		dc.watches.ReleaseWatch(parent, "parent")
 
 		gvrCount.Dec()
 		handlerDetachTotal.WithLabelValues("parent").Inc()

--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -376,7 +376,11 @@ func (dc *DynamicController) Register(
 	}()
 
 	// Register event handler directly on the parent informer.
-	reg, err := dc.watches.GetInformer(parent).AddEventHandler(dc.parentEventHandlerFor(parent))
+	inf := dc.watches.GetInformer(parent)
+	if inf == nil {
+		return fmt.Errorf("add parent handler %s: informer not found after EnsureWatch", parent)
+	}
+	reg, err := inf.AddEventHandler(dc.parentEventHandlerFor(parent))
 	if err != nil {
 		return fmt.Errorf("add parent handler %s: %w", parent, err)
 	}

--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -595,3 +595,28 @@ func TestRegister_EnsureWatchSyncError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cache sync timeout")
 }
+
+func TestDeregister_HandlerNoLongerReceivesEvents(t *testing.T) {
+	logger := noopLogger()
+	client, mapper := setupFakeClient(t)
+
+	dc := NewDynamicController(logger, testConfig(), client, mapper)
+	ctx := t.Context()
+	dc.ctx.Store(&ctx)
+
+	parentGVR := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
+
+	handlerCalled := false
+	handlerFunc := Handler(func(ctx context.Context, req controllerruntime.Request) error {
+		handlerCalled = true
+		return nil
+	})
+
+	require.NoError(t, dc.Register(ctx, parentGVR, handlerFunc))
+	require.NoError(t, dc.Deregister(ctx, parentGVR))
+
+	// After deregister, handler lookup should fail.
+	_, ok := dc.handlers.Load(parentGVR)
+	assert.False(t, ok, "handler should be removed after deregister")
+	assert.False(t, handlerCalled)
+}

--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -596,6 +596,24 @@ func TestRegister_EnsureWatchSyncError(t *testing.T) {
 	assert.Contains(t, err.Error(), "cache sync timeout")
 }
 
+func TestGetInformer_ReturnsNil_ForMissingWatch(t *testing.T) {
+	// Verify that GetInformer returns nil when no watch exists, and
+	// non-nil when a watch is active. This is the condition the nil
+	// guard in Register protects against.
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1.AddMetaToScheme(scheme))
+	wm := NewWatchManager(fake.NewSimpleMetadataClient(scheme), 1*time.Hour, func(Event) {}, noopLogger())
+
+	gvr := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
+	assert.Nil(t, wm.GetInformer(gvr), "GetInformer should return nil for unwatched GVR")
+
+	require.NoError(t, wm.EnsureWatch(gvr, "owner"))
+	assert.NotNil(t, wm.GetInformer(gvr))
+
+	wm.forceStopWatch(gvr)
+	assert.Nil(t, wm.GetInformer(gvr), "GetInformer should return nil after forceStopWatch")
+}
+
 func TestDeregister_HandlerNoLongerReceivesEvents(t *testing.T) {
 	logger := noopLogger()
 	client, mapper := setupFakeClient(t)

--- a/pkg/dynamiccontroller/watch_manager.go
+++ b/pkg/dynamiccontroller/watch_manager.go
@@ -31,26 +31,23 @@ import (
 )
 
 // WatchManager manages informer lifecycle per GVR.
-// Informers start lazily on first use and stay alive until Shutdown().
-// This avoids all start/stop races and lock-while-blocking issues.
+// Informers start lazily on first use and stay alive until all owners release
+// them or Shutdown() is called.
 type WatchManager struct {
 	mu      sync.Mutex
 	watches map[schema.GroupVersionResource]*gvrWatch
-	// parentRefs keeps parent informers alive while a registered parent GVR
-	// still depends on the shared watch.
-	// TODO: If watch ownership gets more complex, replace the split
-	// parent-retention + coordinator-index model with a unified owner set in
-	// WatchManager so informer lifetime is derived from one source of truth.
-	parentRefs map[schema.GroupVersionResource]int
-	client     metadata.Interface
-	resync     time.Duration
-	log        logr.Logger
+	// owners tracks who retains each GVR. An informer is eligible for
+	// shutdown only when its owner set is empty.
+	owners map[schema.GroupVersionResource]map[string]struct{}
+	client metadata.Interface
+	resync time.Duration
+	log    logr.Logger
 
 	// onEvent is the single callback invoked for every informer event.
 	// Set at construction time; never nil.
 	onEvent EventHandler
 
-	// SyncTimeout is the maximum time to wait for cache sync in EnsureWatch.
+	// SyncTimeout is the maximum time to wait for cache sync in ensureWatch.
 	// Zero means use the default (30s).
 	SyncTimeout time.Duration
 
@@ -60,62 +57,67 @@ type WatchManager struct {
 }
 
 // gvrWatch wraps a single SharedIndexInformer for one GVR.
-// Once started, the informer runs until Shutdown().
+// Once started, the informer runs until all owners release it or Shutdown().
 type gvrWatch struct {
-	gvr      schema.GroupVersionResource
-	informer cache.SharedIndexInformer
-	stopCh   chan struct{}
-	log      logr.Logger
+	gvr        schema.GroupVersionResource
+	informer   cache.SharedIndexInformer
+	handlerReg cache.ResourceEventHandlerRegistration
+	cancel     context.CancelFunc
+	log        logr.Logger
 }
 
 // NewWatchManager creates a new WatchManager. The onEvent callback is invoked
 // for every informer event across all GVRs.
 func NewWatchManager(client metadata.Interface, resync time.Duration, onEvent EventHandler, log logr.Logger) *WatchManager {
 	wm := &WatchManager{
-		watches:    make(map[schema.GroupVersionResource]*gvrWatch),
-		parentRefs: make(map[schema.GroupVersionResource]int),
-		client:     client,
-		resync:     resync,
-		onEvent:    onEvent,
-		log:        log.WithName("watch-manager"),
+		watches: make(map[schema.GroupVersionResource]*gvrWatch),
+		owners:  make(map[schema.GroupVersionResource]map[string]struct{}),
+		client:  client,
+		resync:  resync,
+		onEvent: onEvent,
+		log:     log.WithName("watch-manager"),
 	}
 	wm.createInformer = wm.defaultCreateInformer
 	return wm
 }
 
-// EnsureParentWatch retains the watch for a registered parent GVR and ensures
-// the underlying informer is running.
-func (m *WatchManager) EnsureParentWatch(gvr schema.GroupVersionResource) error {
+// EnsureWatch ensures a watch on the given GVR registered under a given owner.
+// If the informer fails to start, the owner is removed.
+func (m *WatchManager) EnsureWatch(gvr schema.GroupVersionResource, ownerID string) error {
 	m.mu.Lock()
-	m.parentRefs[gvr]++
+	if m.owners[gvr] == nil {
+		m.owners[gvr] = make(map[string]struct{})
+	}
+	m.owners[gvr][ownerID] = struct{}{}
 	m.mu.Unlock()
 
-	if err := m.EnsureWatch(gvr); err != nil {
-		m.ReleaseParentWatch(gvr)
+	if err := m.ensureWatch(gvr); err != nil {
+		m.ReleaseWatch(gvr, ownerID)
 		return err
 	}
 	return nil
 }
 
-// ReleaseParentWatch drops one parent retention for the given GVR.
-func (m *WatchManager) ReleaseParentWatch(gvr schema.GroupVersionResource) {
+// ReleaseWatch removes an owner from the GVR. If no owners remain, the
+// informer is stopped automatically.
+func (m *WatchManager) ReleaseWatch(gvr schema.GroupVersionResource, ownerID string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	refs := m.parentRefs[gvr]
-	switch {
-	case refs <= 1:
-		delete(m.parentRefs, gvr)
-	default:
-		m.parentRefs[gvr] = refs - 1
+	if owners := m.owners[gvr]; owners != nil {
+		delete(owners, ownerID)
+		if len(owners) == 0 {
+			delete(m.owners, gvr)
+		}
 	}
+	m.stopWatchLocked(gvr, false)
 }
 
-// EnsureWatch idempotently ensures an informer is running for the given GVR.
+// ensureWatch idempotently ensures an informer is running for the given GVR.
 // If the informer is already running, this is a no-op. After starting the
 // informer it waits for the initial cache sync with a timeout and returns an
 // error if the sync does not complete.
-func (m *WatchManager) EnsureWatch(gvr schema.GroupVersionResource) error {
+func (m *WatchManager) ensureWatch(gvr schema.GroupVersionResource) error {
 	m.mu.Lock()
 
 	if _, ok := m.watches[gvr]; ok {
@@ -126,33 +128,29 @@ func (m *WatchManager) EnsureWatch(gvr schema.GroupVersionResource) error {
 	w := m.newWatch(gvr)
 	m.watches[gvr] = w
 
-	go w.informer.Run(w.stopCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	w.cancel = cancel
+	go w.informer.RunWithContext(ctx)
 	m.log.V(1).Info("Informer started", "gvr", gvr)
 
 	// Release the lock before blocking on cache sync.
 	m.mu.Unlock()
 
 	// Wait for initial list/sync with a timeout so callers get a usable cache.
+	syncStart := time.Now()
 	syncCtx, cancel := context.WithTimeout(context.Background(), m.syncTimeout())
 	defer cancel()
 
 	if !cache.WaitForCacheSync(syncCtx.Done(), w.informer.HasSynced) {
-		// Stop and remove the broken watch so a future EnsureWatch can retry
+		informerSyncDuration.WithLabelValues(gvr.String()).Observe(time.Since(syncStart).Seconds())
+		// Stop and remove the broken watch so a future ensureWatch can retry
 		// with a fresh informer instead of returning early for a registered
 		// but non-functional watch.
 		m.forceStopWatch(gvr)
 		return fmt.Errorf("cache sync timeout for %s", gvr)
 	}
+	informerSyncDuration.WithLabelValues(gvr.String()).Observe(time.Since(syncStart).Seconds())
 	return nil
-}
-
-// StopWatch stops the informer for the given GVR and removes it from the
-// watches map. It is non-blocking and idempotent. A subsequent EnsureWatch
-// for the same GVR will create a fresh informer.
-func (m *WatchManager) StopWatch(gvr schema.GroupVersionResource) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.stopWatchLocked(gvr, false)
 }
 
 // GetInformer returns the SharedIndexInformer for the given GVR, or nil
@@ -178,12 +176,11 @@ func (m *WatchManager) Shutdown() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	for gvr, w := range m.watches {
-		m.log.V(1).Info("Shutting down watch", "gvr", gvr)
-		close(w.stopCh)
+	for gvr := range m.watches {
+		m.stopWatchLocked(gvr, true)
 	}
 	m.watches = make(map[schema.GroupVersionResource]*gvrWatch)
-	m.parentRefs = make(map[schema.GroupVersionResource]int)
+	m.owners = make(map[schema.GroupVersionResource]map[string]struct{})
 }
 
 const defaultSyncTimeout = 30 * time.Second
@@ -213,15 +210,16 @@ func (m *WatchManager) newWatch(gvr schema.GroupVersionResource) *gvrWatch {
 	w := &gvrWatch{
 		gvr:      gvr,
 		informer: inf,
-		stopCh:   make(chan struct{}),
 		log:      m.log.WithValues("gvr", gvr.String()),
 	}
 
 	// Register a single event handler that converts informer callbacks
 	// into normalized Event structs and dispatches via onEvent.
-	if _, err := inf.AddEventHandler(w.eventHandlerFuncs(m.onEvent)); err != nil {
+	reg, err := inf.AddEventHandler(w.eventHandlerFuncs(m.onEvent))
+	if err != nil {
 		m.log.Error(err, "Failed to add event handler to informer", "gvr", gvr)
 	}
+	w.handlerReg = reg
 
 	return w
 }
@@ -238,12 +236,15 @@ func (m *WatchManager) stopWatchLocked(gvr schema.GroupVersionResource, force bo
 		return
 	}
 	if !force {
-		if refs := m.parentRefs[gvr]; refs > 0 {
-			m.log.V(1).Info("Watch retained by registered parent", "gvr", gvr, "parentRefs", refs)
+		if owners := m.owners[gvr]; len(owners) > 0 {
+			m.log.V(1).Info("Watch retained by owners", "gvr", gvr, "owners", len(owners))
 			return
 		}
 	}
-	close(w.stopCh)
+	// event handler registration can only fail if the handler type is
+	// mismatched, which can never happen since we own all handlers
+	_ = w.informer.RemoveEventHandler(w.handlerReg)
+	w.cancel()
 	delete(m.watches, gvr)
 	m.log.V(1).Info("Watch stopped", "gvr", gvr)
 }

--- a/pkg/dynamiccontroller/watch_manager.go
+++ b/pkg/dynamiccontroller/watch_manager.go
@@ -131,6 +131,7 @@ func (m *WatchManager) ensureWatch(gvr schema.GroupVersionResource) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	w.cancel = cancel
 	go w.informer.RunWithContext(ctx)
+	watchCount.Set(float64(len(m.watches)))
 	m.log.V(1).Info("Informer started", "gvr", gvr)
 
 	// Release the lock before blocking on cache sync.
@@ -246,6 +247,7 @@ func (m *WatchManager) stopWatchLocked(gvr schema.GroupVersionResource, force bo
 	_ = w.informer.RemoveEventHandler(w.handlerReg)
 	w.cancel()
 	delete(m.watches, gvr)
+	watchCount.Set(float64(len(m.watches)))
 	m.log.V(1).Info("Watch stopped", "gvr", gvr)
 }
 

--- a/pkg/dynamiccontroller/watch_manager.go
+++ b/pkg/dynamiccontroller/watch_manager.go
@@ -47,7 +47,7 @@ type WatchManager struct {
 	// Set at construction time; never nil.
 	onEvent EventHandler
 
-	// SyncTimeout is the maximum time to wait for cache sync in ensureWatch.
+	// SyncTimeout is the maximum time to wait for cache sync in EnsureWatch.
 	// Zero means use the default (30s).
 	SyncTimeout time.Duration
 
@@ -89,12 +89,38 @@ func (m *WatchManager) EnsureWatch(gvr schema.GroupVersionResource, ownerID stri
 		m.owners[gvr] = make(map[string]struct{})
 	}
 	m.owners[gvr][ownerID] = struct{}{}
+
+	// Check if watch already exists while still holding the lock.
+	if _, ok := m.watches[gvr]; ok {
+		m.mu.Unlock()
+		return nil
+	}
+
+	// Create and start the informer while still holding the lock,
+	// so no ReleaseWatch can remove our owner before the watch exists.
+	w := m.newWatch(gvr)
+	m.watches[gvr] = w
+	ctx, cancel := context.WithCancel(context.Background())
+	w.cancel = cancel
+	go w.informer.RunWithContext(ctx)
+	watchCount.Set(float64(len(m.watches)))
+	m.log.V(1).Info("Informer started", "gvr", gvr)
+
+	// Release the lock before blocking on cache sync.
 	m.mu.Unlock()
 
-	if err := m.ensureWatch(gvr); err != nil {
+	// Wait for initial list/sync with a timeout so callers get a usable cache.
+	syncStart := time.Now()
+	syncCtx, syncCancel := context.WithTimeout(context.Background(), m.syncTimeout())
+	defer syncCancel()
+
+	if !cache.WaitForCacheSync(syncCtx.Done(), w.informer.HasSynced) {
+		informerSyncDuration.WithLabelValues(gvr.String()).Observe(time.Since(syncStart).Seconds())
+		m.forceStopWatch(gvr)
 		m.ReleaseWatch(gvr, ownerID)
-		return err
+		return fmt.Errorf("cache sync timeout for %s", gvr)
 	}
+	informerSyncDuration.WithLabelValues(gvr.String()).Observe(time.Since(syncStart).Seconds())
 	return nil
 }
 
@@ -111,47 +137,6 @@ func (m *WatchManager) ReleaseWatch(gvr schema.GroupVersionResource, ownerID str
 		}
 	}
 	m.stopWatchLocked(gvr, false)
-}
-
-// ensureWatch idempotently ensures an informer is running for the given GVR.
-// If the informer is already running, this is a no-op. After starting the
-// informer it waits for the initial cache sync with a timeout and returns an
-// error if the sync does not complete.
-func (m *WatchManager) ensureWatch(gvr schema.GroupVersionResource) error {
-	m.mu.Lock()
-
-	if _, ok := m.watches[gvr]; ok {
-		m.mu.Unlock()
-		return nil
-	}
-
-	w := m.newWatch(gvr)
-	m.watches[gvr] = w
-
-	ctx, cancel := context.WithCancel(context.Background())
-	w.cancel = cancel
-	go w.informer.RunWithContext(ctx)
-	watchCount.Set(float64(len(m.watches)))
-	m.log.V(1).Info("Informer started", "gvr", gvr)
-
-	// Release the lock before blocking on cache sync.
-	m.mu.Unlock()
-
-	// Wait for initial list/sync with a timeout so callers get a usable cache.
-	syncStart := time.Now()
-	syncCtx, cancel := context.WithTimeout(context.Background(), m.syncTimeout())
-	defer cancel()
-
-	if !cache.WaitForCacheSync(syncCtx.Done(), w.informer.HasSynced) {
-		informerSyncDuration.WithLabelValues(gvr.String()).Observe(time.Since(syncStart).Seconds())
-		// Stop and remove the broken watch so a future ensureWatch can retry
-		// with a fresh informer instead of returning early for a registered
-		// but non-functional watch.
-		m.forceStopWatch(gvr)
-		return fmt.Errorf("cache sync timeout for %s", gvr)
-	}
-	informerSyncDuration.WithLabelValues(gvr.String()).Observe(time.Since(syncStart).Seconds())
-	return nil
 }
 
 // GetInformer returns the SharedIndexInformer for the given GVR, or nil

--- a/pkg/dynamiccontroller/watch_manager_test.go
+++ b/pkg/dynamiccontroller/watch_manager_test.go
@@ -148,13 +148,13 @@ func TestEnsureWatch_Idempotent(t *testing.T) {
 	wm := newTestWatchManager(t)
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	assert.NoError(t, wm.ensureWatch(gvr))
+	assert.NoError(t, wm.EnsureWatch(gvr, "test"))
 	inf1 := wm.GetInformer(gvr)
 	assert.NotNil(t, inf1)
 	assert.Equal(t, 1, wm.ActiveWatchCount())
 
 	// Second call is a no-op; same informer, same count.
-	assert.NoError(t, wm.ensureWatch(gvr))
+	assert.NoError(t, wm.EnsureWatch(gvr, "test"))
 	inf2 := wm.GetInformer(gvr)
 	assert.Same(t, inf1, inf2)
 	assert.Equal(t, 1, wm.ActiveWatchCount())
@@ -165,8 +165,8 @@ func TestShutdown(t *testing.T) {
 	gvr1 := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 	gvr2 := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
 
-	assert.NoError(t, wm.ensureWatch(gvr1))
-	assert.NoError(t, wm.ensureWatch(gvr2))
+	assert.NoError(t, wm.EnsureWatch(gvr1, "test"))
+	assert.NoError(t, wm.EnsureWatch(gvr2, "test"))
 	assert.Equal(t, 2, wm.ActiveWatchCount())
 
 	wm.Shutdown()
@@ -278,7 +278,7 @@ func TestNewWatch_WatchErrorHandler(t *testing.T) {
 
 	wm := NewWatchManager(failClient, 1*time.Hour, func(e Event) {}, noopLogger())
 	wm.SyncTimeout = 500 * time.Millisecond
-	_ = wm.ensureWatch(gvr)
+	_ = wm.EnsureWatch(gvr, "test")
 
 	// Give the informer goroutine time to hit the error handler.
 	time.Sleep(200 * time.Millisecond)
@@ -366,11 +366,11 @@ func TestEnsureWatch_SyncTimeout(t *testing.T) {
 	wm.SyncTimeout = 200 * time.Millisecond
 
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
-	err := wm.ensureWatch(gvr)
+	err := wm.EnsureWatch(gvr, "test")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cache sync timeout")
 
-	// Broken watch should be cleaned up so a future ensureWatch can retry.
+	// Broken watch should be cleaned up so a future EnsureWatch can retry.
 	assert.Equal(t, 0, wm.ActiveWatchCount())
 }
 
@@ -394,14 +394,14 @@ func TestEnsureWatch_SyncTimeout_RetrySucceeds(t *testing.T) {
 
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	err := wm.ensureWatch(gvr)
+	err := wm.EnsureWatch(gvr, "test")
 	assert.Error(t, err)
 	assert.Equal(t, 0, wm.ActiveWatchCount(), "broken watch should be removed")
 
 	// Second call: lists succeed → should create fresh informer and sync.
 	failList.Store(false)
 	wm.SyncTimeout = 5 * time.Second
-	err = wm.ensureWatch(gvr)
+	err = wm.EnsureWatch(gvr, "test")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, wm.ActiveWatchCount(), "retry should succeed with fresh informer")
 	wm.Shutdown()
@@ -412,7 +412,7 @@ func TestEnsureWatch_SyncSuccess(t *testing.T) {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 	wm.SyncTimeout = 5 * time.Second
 
-	err := wm.ensureWatch(gvr)
+	err := wm.EnsureWatch(gvr, "test")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, wm.ActiveWatchCount())
 	wm.Shutdown()
@@ -422,11 +422,11 @@ func TestEnsureWatch_ConcurrentCalls(t *testing.T) {
 	wm := newTestWatchManager(t)
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	// Launch multiple concurrent ensureWatch calls.
+	// Launch multiple concurrent EnsureWatch calls.
 	errs := make(chan error, 10)
 	for i := 0; i < 10; i++ {
 		go func() {
-			errs <- wm.ensureWatch(gvr)
+			errs <- wm.EnsureWatch(gvr, "test")
 		}()
 	}
 	for i := 0; i < 10; i++ {
@@ -461,6 +461,101 @@ func TestConcurrentRetainWatch_ReleaseWatch(t *testing.T) {
 	<-done
 
 	// Should not panic. Final state: 0 watches (all owners released).
+	assert.Equal(t, 0, wm.ActiveWatchCount())
+}
+
+func TestEnsureWatch_RaceCondition_ReleaseBeforeInformerCreated(t *testing.T) {
+	// Regression test: EnsureWatch must hold the lock through both owner
+	// registration and informer creation. Without this, a concurrent
+	// ReleaseWatch between AddOwner and EnsureWatch could remove the owner,
+	// leaving a leaked watch with zero owners.
+	//
+	// With the fix, ReleaseWatch blocks until EnsureWatch releases the
+	// lock (after informer creation but before cache sync). ReleaseWatch
+	// then removes the owner and stops the watch, which cancels the
+	// informer context and causes cache sync to fail.
+	scheme := runtime.NewScheme()
+	_ = v1.AddMetaToScheme(scheme)
+	client := fake.NewSimpleMetadataClient(scheme)
+
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+	wm := NewWatchManager(client, 1*time.Hour, func(Event) {}, noopLogger())
+	wm.SyncTimeout = 1 * time.Second
+
+	// Use a slow createInformer so the lock is held longer, giving
+	// ReleaseWatch time to block on the mutex.
+	wm.createInformer = func(gvr schema.GroupVersionResource) cache.SharedIndexInformer {
+		time.Sleep(50 * time.Millisecond)
+		return wm.defaultCreateInformer(gvr)
+	}
+
+	// Start EnsureWatch in a goroutine.
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- wm.EnsureWatch(gvr, "owner-a")
+	}()
+
+	// Give EnsureWatch time to acquire the lock. The slow createInformer
+	// means the lock is held for ~50ms, during which ReleaseWatch blocks.
+	time.Sleep(10 * time.Millisecond)
+
+	// ReleaseWatch while EnsureWatch holds the lock for informer creation.
+	// With the fix, ReleaseWatch blocks until the lock is released (after
+	// informer start but before cache sync), then removes the owner and
+	// stops the informer — causing cache sync to fail in EnsureWatch.
+	wm.ReleaseWatch(gvr, "owner-a")
+
+	// EnsureWatch may return an error (cache sync timeout because the
+	// informer was stopped) or succeed (if cache synced before ReleaseWatch
+	// ran). Either way, the key invariant holds: no leaked watches.
+	<-errCh
+
+	// The key invariant: no leaked watch with zero owners.
+	assert.Equal(t, 0, wm.ActiveWatchCount(), "watch should be stopped after sole owner released")
+}
+
+func TestEnsureWatch_AtomicOwnerAndWatch(t *testing.T) {
+	// Verify that after EnsureWatch returns successfully, both the owner
+	// and the watch exist — i.e., they were created atomically.
+	wm := newTestWatchManager(t)
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+	assert.NoError(t, wm.EnsureWatch(gvr, "owner-a"))
+
+	// Both owner and watch should exist.
+	assert.Equal(t, 1, wm.ActiveWatchCount())
+	assert.NotNil(t, wm.GetInformer(gvr))
+
+	// ReleaseWatch should be able to clean up properly.
+	wm.ReleaseWatch(gvr, "owner-a")
+	assert.Equal(t, 0, wm.ActiveWatchCount())
+	assert.Nil(t, wm.GetInformer(gvr))
+}
+
+func TestEnsureWatch_SyncTimeout_CleansUpOwner(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1.AddMetaToScheme(scheme)
+	client := fake.NewSimpleMetadataClient(scheme)
+	client.PrependReactor("list", "*", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("simulated list error")
+	})
+
+	wm := NewWatchManager(client, 1*time.Hour, func(Event) {}, noopLogger())
+	wm.SyncTimeout = 200 * time.Millisecond
+
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+	err := wm.EnsureWatch(gvr, "owner-a")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cache sync timeout")
+
+	// Both the watch and the owner should be cleaned up.
+	assert.Equal(t, 0, wm.ActiveWatchCount())
+
+	// Verify owner was removed by checking that a new EnsureWatch + Release
+	// doesn't leave stale state.
+	wm.ReleaseWatch(gvr, "owner-a")
 	assert.Equal(t, 0, wm.ActiveWatchCount())
 }
 
@@ -509,7 +604,7 @@ func TestShutdown_HandlerRemoved(t *testing.T) {
 		noopLogger(),
 	)
 
-	assert.NoError(t, wm.ensureWatch(gvr))
+	assert.NoError(t, wm.EnsureWatch(gvr, "test"))
 	wm.Shutdown()
 	assert.Equal(t, 0, wm.ActiveWatchCount())
 }

--- a/pkg/dynamiccontroller/watch_manager_test.go
+++ b/pkg/dynamiccontroller/watch_manager_test.go
@@ -40,54 +40,71 @@ func newTestWatchManager(t *testing.T) *WatchManager {
 	return NewWatchManager(client, 1*time.Hour, func(Event) {}, noopLogger())
 }
 
-func TestStopWatch_Idempotent(t *testing.T) {
+func TestReleaseWatch_StopsUnowned(t *testing.T) {
 	wm := newTestWatchManager(t)
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	assert.NoError(t, wm.EnsureWatch(gvr))
+	assert.NoError(t, wm.EnsureWatch(gvr, "test"))
 	assert.Equal(t, 1, wm.ActiveWatchCount())
 
-	wm.StopWatch(gvr)
+	wm.ReleaseWatch(gvr, "test")
 	assert.Equal(t, 0, wm.ActiveWatchCount())
 
-	// Second StopWatch should not panic and count stays 0.
-	wm.StopWatch(gvr)
+	// Second release should not panic and count stays 0.
+	wm.ReleaseWatch(gvr, "test")
 	assert.Equal(t, 0, wm.ActiveWatchCount())
 }
 
-func TestStopWatch_ThenEnsureWatch_CreatesFresh(t *testing.T) {
+func TestReleaseWatch_ThenRetainWatch_CreatesFresh(t *testing.T) {
 	wm := newTestWatchManager(t)
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	assert.NoError(t, wm.EnsureWatch(gvr))
+	assert.NoError(t, wm.EnsureWatch(gvr, "test"))
 	inf1 := wm.GetInformer(gvr)
 	assert.NotNil(t, inf1)
 
-	wm.StopWatch(gvr)
+	wm.ReleaseWatch(gvr, "test")
 	assert.Nil(t, wm.GetInformer(gvr))
 
-	assert.NoError(t, wm.EnsureWatch(gvr))
+	assert.NoError(t, wm.EnsureWatch(gvr, "test"))
 	inf2 := wm.GetInformer(gvr)
 	assert.NotNil(t, inf2)
 
 	// Must be a new informer instance, not the old one.
-	assert.NotSame(t, inf1, inf2, "expected fresh informer after StopWatch + EnsureWatch")
+	assert.NotSame(t, inf1, inf2, "expected fresh informer after ReleaseWatch + EnsureWatch")
 }
 
-func TestStopWatch_RetainedByParent(t *testing.T) {
+func TestReleaseWatch_RetainedByOtherOwner(t *testing.T) {
 	wm := newTestWatchManager(t)
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	assert.NoError(t, wm.EnsureParentWatch(gvr))
+	assert.NoError(t, wm.EnsureWatch(gvr, "parent"))
 	assert.NotNil(t, wm.GetInformer(gvr))
 
-	// Child/orphan cleanup should not stop a parent-retained watch.
-	wm.StopWatch(gvr)
-	assert.NotNil(t, wm.GetInformer(gvr), "parent-retained informer should stay running")
+	// Releasing an unrelated owner should not stop an owned watch.
+	wm.ReleaseWatch(gvr, "other")
+	assert.NotNil(t, wm.GetInformer(gvr), "owned informer should stay running")
 
-	wm.ReleaseParentWatch(gvr)
-	wm.StopWatch(gvr)
-	assert.Nil(t, wm.GetInformer(gvr), "watch should stop after the parent releases it")
+	// Releasing the actual owner should stop it.
+	wm.ReleaseWatch(gvr, "parent")
+	assert.Nil(t, wm.GetInformer(gvr), "watch should stop after the owner releases it")
+}
+
+func TestRetainWatch_MultipleOwners(t *testing.T) {
+	wm := newTestWatchManager(t)
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+	assert.NoError(t, wm.EnsureWatch(gvr, "parent"))
+	assert.NoError(t, wm.EnsureWatch(gvr, "coordinator"))
+	assert.Equal(t, 1, wm.ActiveWatchCount())
+
+	// Release one owner — watch should stay.
+	wm.ReleaseWatch(gvr, "parent")
+	assert.NotNil(t, wm.GetInformer(gvr), "informer should stay running with one owner remaining")
+
+	// Release second owner — now it stops automatically.
+	wm.ReleaseWatch(gvr, "coordinator")
+	assert.Nil(t, wm.GetInformer(gvr), "informer should stop after all owners release")
 }
 
 func TestDeleteFunc_Tombstone(t *testing.T) {
@@ -131,13 +148,13 @@ func TestEnsureWatch_Idempotent(t *testing.T) {
 	wm := newTestWatchManager(t)
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	assert.NoError(t, wm.EnsureWatch(gvr))
+	assert.NoError(t, wm.ensureWatch(gvr))
 	inf1 := wm.GetInformer(gvr)
 	assert.NotNil(t, inf1)
 	assert.Equal(t, 1, wm.ActiveWatchCount())
 
 	// Second call is a no-op; same informer, same count.
-	assert.NoError(t, wm.EnsureWatch(gvr))
+	assert.NoError(t, wm.ensureWatch(gvr))
 	inf2 := wm.GetInformer(gvr)
 	assert.Same(t, inf1, inf2)
 	assert.Equal(t, 1, wm.ActiveWatchCount())
@@ -148,8 +165,8 @@ func TestShutdown(t *testing.T) {
 	gvr1 := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 	gvr2 := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
 
-	assert.NoError(t, wm.EnsureWatch(gvr1))
-	assert.NoError(t, wm.EnsureWatch(gvr2))
+	assert.NoError(t, wm.ensureWatch(gvr1))
+	assert.NoError(t, wm.ensureWatch(gvr2))
 	assert.Equal(t, 2, wm.ActiveWatchCount())
 
 	wm.Shutdown()
@@ -261,7 +278,7 @@ func TestNewWatch_WatchErrorHandler(t *testing.T) {
 
 	wm := NewWatchManager(failClient, 1*time.Hour, func(e Event) {}, noopLogger())
 	wm.SyncTimeout = 500 * time.Millisecond
-	_ = wm.EnsureWatch(gvr)
+	_ = wm.ensureWatch(gvr)
 
 	// Give the informer goroutine time to hit the error handler.
 	time.Sleep(200 * time.Millisecond)
@@ -349,11 +366,11 @@ func TestEnsureWatch_SyncTimeout(t *testing.T) {
 	wm.SyncTimeout = 200 * time.Millisecond
 
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
-	err := wm.EnsureWatch(gvr)
+	err := wm.ensureWatch(gvr)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cache sync timeout")
 
-	// Broken watch should be cleaned up so a future EnsureWatch can retry.
+	// Broken watch should be cleaned up so a future ensureWatch can retry.
 	assert.Equal(t, 0, wm.ActiveWatchCount())
 }
 
@@ -377,14 +394,14 @@ func TestEnsureWatch_SyncTimeout_RetrySucceeds(t *testing.T) {
 
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	err := wm.EnsureWatch(gvr)
+	err := wm.ensureWatch(gvr)
 	assert.Error(t, err)
 	assert.Equal(t, 0, wm.ActiveWatchCount(), "broken watch should be removed")
 
 	// Second call: lists succeed → should create fresh informer and sync.
 	failList.Store(false)
 	wm.SyncTimeout = 5 * time.Second
-	err = wm.EnsureWatch(gvr)
+	err = wm.ensureWatch(gvr)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, wm.ActiveWatchCount(), "retry should succeed with fresh informer")
 	wm.Shutdown()
@@ -395,7 +412,7 @@ func TestEnsureWatch_SyncSuccess(t *testing.T) {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 	wm.SyncTimeout = 5 * time.Second
 
-	err := wm.EnsureWatch(gvr)
+	err := wm.ensureWatch(gvr)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, wm.ActiveWatchCount())
 	wm.Shutdown()
@@ -405,11 +422,11 @@ func TestEnsureWatch_ConcurrentCalls(t *testing.T) {
 	wm := newTestWatchManager(t)
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	// Launch multiple concurrent EnsureWatch calls.
+	// Launch multiple concurrent ensureWatch calls.
 	errs := make(chan error, 10)
 	for i := 0; i < 10; i++ {
 		go func() {
-			errs <- wm.EnsureWatch(gvr)
+			errs <- wm.ensureWatch(gvr)
 		}()
 	}
 	for i := 0; i < 10; i++ {
@@ -421,31 +438,30 @@ func TestEnsureWatch_ConcurrentCalls(t *testing.T) {
 	wm.Shutdown()
 }
 
-func TestConcurrentEnsureWatch_StopWatch(t *testing.T) {
+func TestConcurrentRetainWatch_ReleaseWatch(t *testing.T) {
 	wm := newTestWatchManager(t)
 	wm.SyncTimeout = 500 * time.Millisecond
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
-	// Start and stop concurrently.
+	// Retain and release concurrently.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		for i := 0; i < 20; i++ {
-			_ = wm.EnsureWatch(gvr)
-			wm.StopWatch(gvr)
+			_ = wm.EnsureWatch(gvr, "a")
+			wm.ReleaseWatch(gvr, "a")
 		}
 	}()
 
 	// Concurrent EnsureWatch calls.
 	for i := 0; i < 20; i++ {
-		_ = wm.EnsureWatch(gvr)
+		_ = wm.EnsureWatch(gvr, "b")
+		wm.ReleaseWatch(gvr, "b")
 	}
 	<-done
 
-	// Should not panic. Final state is deterministic: either 0 or 1 watches.
-	count := wm.ActiveWatchCount()
-	assert.True(t, count == 0 || count == 1)
-	wm.Shutdown()
+	// Should not panic. Final state: 0 watches (all owners released).
+	assert.Equal(t, 0, wm.ActiveWatchCount())
 }
 
 func TestSyncTimeout_DefaultValue(t *testing.T) {
@@ -454,4 +470,46 @@ func TestSyncTimeout_DefaultValue(t *testing.T) {
 
 	wm.SyncTimeout = 5 * time.Second
 	assert.Equal(t, 5*time.Second, wm.syncTimeout())
+}
+
+func TestReleaseWatch_HandlerRemoved(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+	var eventCount atomic.Int32
+	wm := NewWatchManager(
+		fake.NewSimpleMetadataClient(func() *runtime.Scheme {
+			s := runtime.NewScheme()
+			_ = v1.AddMetaToScheme(s)
+			return s
+		}()),
+		1*time.Hour,
+		func(e Event) { eventCount.Add(1) },
+		noopLogger(),
+	)
+
+	assert.NoError(t, wm.EnsureWatch(gvr, "test"))
+	assert.NotNil(t, wm.GetInformer(gvr))
+
+	// Release stops the watch and removes the handler.
+	wm.ReleaseWatch(gvr, "test")
+	assert.Nil(t, wm.GetInformer(gvr))
+}
+
+func TestShutdown_HandlerRemoved(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+	wm := NewWatchManager(
+		fake.NewSimpleMetadataClient(func() *runtime.Scheme {
+			s := runtime.NewScheme()
+			_ = v1.AddMetaToScheme(s)
+			return s
+		}()),
+		1*time.Hour,
+		func(e Event) {},
+		noopLogger(),
+	)
+
+	assert.NoError(t, wm.ensureWatch(gvr))
+	wm.Shutdown()
+	assert.Equal(t, 0, wm.ActiveWatchCount())
 }


### PR DESCRIPTION
Replace the eager index-update design (current/previous maps, nodeID-based
identity, 4 near-duplicate lifecycle methods) with a fundamentally simpler
model where Watch() is a pure local append and Done(true) commits atomically
by diffing against the previously committed set.

Key changes:
- Watch() no longer locks the coordinator or touches shared state
- Done(false) is a true no-op (pending discarded, committed stays)
- Watches identified by content {GVR,Name,Namespace,Selector} not nodeID
- Single committed slice per instance replaces current+previous maps
- gvrRefCount enables O(1) orphan detection

builds on top of https://github.com/kubernetes-sigs/kro/pull/1146