### PR TITLE
refactor(runtime,instance): split large files and simplify state management

### DIFF
--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
@@ -60,78 +59,101 @@ func resourceRef(obj *unstructured.Unstructured) string {
 	return obj.GetNamespace() + "/" + obj.GetName()
 }
 
+// reconcileResult tracks state flowing through the reconcileNodes pipeline.
+type reconcileResult struct {
+	resources      []applyset.Resource
+	applier        *applyset.ApplySet
+	applyResult    *applyset.ApplyResult
+	supersetPatch  applyset.Metadata
+	batchMeta      applyset.Metadata
+	unresolvedErr  error
+	clusterMutated bool
+	pruneRetry     bool
+}
+
 // reconcileNodes orchestrates node processing, apply, prune, and state updates.
 func (c *Controller) reconcileNodes(rcx *ReconcileContext) error {
 	rcx.Log.V(2).Info("Reconciling resources")
 
-	applier := c.createApplySet(rcx)
+	r, err := c.buildApplyInputs(rcx)
+	if err != nil {
+		return err
+	}
+	if err := c.applyResources(rcx, r); err != nil {
+		return err
+	}
+	if err := c.pruneIfSafe(rcx, r); err != nil {
+		return err
+	}
+	return c.finalizeState(rcx, r)
+}
 
-	// ---------------------------------------------------------
-	// 1. Process nodes (build applyset inputs)
-	// ---------------------------------------------------------
-	var firstUnresolvedErr error
+// buildApplyInputs processes all nodes and projects applyset metadata.
+func (c *Controller) buildApplyInputs(rcx *ReconcileContext) (*reconcileResult, error) {
+	r := &reconcileResult{
+		applier: c.createApplySet(rcx),
+	}
+
 	resources, err := c.processNodes(rcx)
 	if err != nil {
 		if !runtime.IsDataPending(err) {
-			return err
+			return nil, err
 		}
-		firstUnresolvedErr = err
+		r.unresolvedErr = err
 	}
-	prune := firstUnresolvedErr == nil
+	r.resources = resources
 
-	// ---------------------------------------------------------
-	// 2. Project applyset metadata and patch parent
-	// ---------------------------------------------------------
-	supersetPatch, err := applier.Project(resources)
+	r.supersetPatch, err = r.applier.Project(resources)
 	if err != nil {
-		return rcx.delayedRequeue(fmt.Errorf("project failed: %w", err))
+		return nil, rcx.delayedRequeue(fmt.Errorf("project failed: %w", err))
 	}
 
-	if err := c.patchInstanceWithApplySetMetadata(rcx, supersetPatch); err != nil {
-		return rcx.delayedRequeue(fmt.Errorf("failed to patch instance with applyset labels: %w", err))
+	if err := c.patchInstanceWithApplySetMetadata(rcx, r.supersetPatch); err != nil {
+		return nil, rcx.delayedRequeue(fmt.Errorf("failed to patch instance with applyset labels: %w", err))
 	}
 
-	// ---------------------------------------------------------
-	// 3. Apply desired resources
-	// ---------------------------------------------------------
-	result, batchMeta, err := applier.Apply(rcx.Ctx, resources, applyset.ApplyMode{})
+	return r, nil
+}
+
+// applyResources submits the desired resources to the cluster.
+func (c *Controller) applyResources(rcx *ReconcileContext, r *reconcileResult) error {
+	result, batchMeta, err := r.applier.Apply(rcx.Ctx, r.resources, applyset.ApplyMode{})
 	if err != nil {
 		return rcx.delayedRequeue(fmt.Errorf("apply failed: %w", err))
 	}
+	r.applyResult = result
+	r.batchMeta = batchMeta
+	r.clusterMutated = result.HasClusterMutation()
+	return nil
+}
 
-	// clusterMutated tracks any cluster-side change from apply and/or prune.
-	// NOTE: it must start from apply results and only ever be OR-ed with
-	// prune outcomes. Be careful overwrriting this later, as we may drop the
-	// "apply changed the cluster" signal and skip the requeue needed for CEL
-	// refresh.
-	clusterMutated := result.HasClusterMutation()
-
-	// ---------------------------------------------------------
-	// 4. Prune orphans (when desired is fully resolved)
-	// ---------------------------------------------------------
-	pruneNeedsRetry := false
-	//
-	// Prune is intentionally gated by two independent conditions:
-	//   1) prune == true  -> all desired objects were resolvable (no ErrDataPending)
-	//   2) result.Errors() == nil -> apply had no per resource errors
-	//
-	// The split is deliberate: "unresolved desired" is not an apply error, but
-	// pruning in that case would delete still-managed objects because they were
-	// omitted from the apply set. Keeping both checks visible prevents  regressions
-	// where one gate gets removed and prune becomes unsafe.
-	if prune && result.Errors() == nil {
-		pruned, needsRetry, err := c.pruneOrphans(rcx, applier, result, supersetPatch, batchMeta)
-		if err != nil {
-			return err
-		}
-		clusterMutated = clusterMutated || pruned
-		pruneNeedsRetry = pruneNeedsRetry || needsRetry
+// pruneIfSafe deletes orphaned resources when the desired set is fully resolved
+// and apply had no per-resource errors.
+//
+// Prune is intentionally gated by two independent conditions:
+//  1. unresolvedErr == nil -> all desired objects were resolvable (no ErrDataPending)
+//  2. applyResult.Errors() == nil -> apply had no per resource errors
+//
+// The split is deliberate: "unresolved desired" is not an apply error, but
+// pruning in that case would delete still-managed objects because they were
+// omitted from the apply set.
+func (c *Controller) pruneIfSafe(rcx *ReconcileContext, r *reconcileResult) error {
+	if r.unresolvedErr != nil || r.applyResult.Errors() != nil {
+		return nil
 	}
+	pruned, needsRetry, err := c.pruneOrphans(rcx, r.applier, r.applyResult, r.supersetPatch, r.batchMeta)
+	if err != nil {
+		return err
+	}
+	r.clusterMutated = r.clusterMutated || pruned
+	r.pruneRetry = needsRetry
+	return nil
+}
 
-	// ---------------------------------------------------------
-	// 5. Process results and update node state
-	// ---------------------------------------------------------
-	if err := c.processApplyResults(rcx, result); err != nil {
+// finalizeState processes apply results, updates node states, and determines
+// whether the controller needs to requeue.
+func (c *Controller) finalizeState(rcx *ReconcileContext, r *reconcileResult) error {
+	if err := c.processApplyResults(rcx, r.applyResult); err != nil {
 		return rcx.delayedRequeue(err)
 	}
 
@@ -140,13 +162,13 @@ func (c *Controller) reconcileNodes(rcx *ReconcileContext) error {
 	// before the controller checks it.
 	rcx.StateManager.Update()
 
-	if firstUnresolvedErr != nil {
-		return rcx.delayedRequeue(fmt.Errorf("waiting for unresolved resource: %w", firstUnresolvedErr))
+	if r.unresolvedErr != nil {
+		return rcx.delayedRequeue(fmt.Errorf("waiting for unresolved resource: %w", r.unresolvedErr))
 	}
-	if pruneNeedsRetry {
+	if r.pruneRetry {
 		return rcx.delayedRequeue(fmt.Errorf("prune encountered UID conflicts; retrying"))
 	}
-	if clusterMutated {
+	if r.clusterMutated {
 		return rcx.delayedRequeue(fmt.Errorf("cluster mutated"))
 	}
 
@@ -233,6 +255,9 @@ func (c *Controller) createApplySet(rcx *ReconcileContext) *applyset.ApplySet {
 // marker when data is pending), reads existing cluster state where required,
 // and updates runtime observations so other nodes can become resolvable/ready/
 // includable. It produces the applyset.Resource entries for that node.
+//
+// processNode is the single registration point for node state — all process*Node
+// methods return NodeState values, and this method writes them to the StateManager.
 func (c *Controller) processNode(
 	rcx *ReconcileContext,
 	node *runtime.Node,
@@ -240,18 +265,17 @@ func (c *Controller) processNode(
 	id := node.Spec.Meta.ID
 	rcx.Log.V(3).Info("Preparing resource", "id", id)
 
-	state := rcx.StateManager.NewNodeState(id)
-
 	ignored, err := node.IsIgnored()
 	if err != nil {
 		if runtime.IsDataPending(err) {
+			rcx.StateManager.SetNodeState(id, inProgressState())
 			return nil, fmt.Errorf("gvr %q: %w", node.Spec.Meta.GVR.String(), err)
 		}
-		state.SetError(err)
+		rcx.StateManager.SetNodeState(id, errorState(err))
 		return nil, err
 	}
 	if ignored {
-		state.SetSkipped()
+		rcx.StateManager.SetNodeState(id, skippedState())
 		rcx.Log.V(2).Info("Skipping resource", "id", id, "reason", "ignored")
 		return []applyset.Resource{{
 			ID:        id,
@@ -265,55 +289,47 @@ func (c *Controller) processNode(
 			// Skip prune when any resource is unresolved to avoid deleting
 			// previously managed resources that are still pending resolution.
 			// Returning the unresolved ID signals the caller to disable prune.
+			rcx.StateManager.SetNodeState(id, inProgressState())
 			return nil, fmt.Errorf("gvr %q: %w", node.Spec.Meta.GVR.String(), err)
 		}
-		state.SetError(err)
+		rcx.StateManager.SetNodeState(id, errorState(err))
 		return nil, err
 	}
 
+	var resources []applyset.Resource
+	var nodeState NodeState
+
 	switch node.Spec.Meta.Type {
 	case graph.NodeTypeExternal:
-		if err := c.processExternalRefNode(rcx, node, state, desired); err != nil {
-			return nil, err
-		}
-		return nil, nil
+		nodeState, err = c.processExternalRefNode(rcx, node, desired)
 	case graph.NodeTypeExternalCollection:
-		if err := c.processExternalCollectionNode(rcx, node, state, desired); err != nil {
-			return nil, err
-		}
-		return nil, nil
+		nodeState, err = c.processExternalCollectionNode(rcx, node, desired)
 	case graph.NodeTypeCollection:
-		resources, err := c.processCollectionNode(rcx, node, state, desired)
-		if err != nil {
-			return nil, err
-		}
-		return resources, nil
+		resources, nodeState, err = c.processCollectionNode(rcx, node, desired)
 	case graph.NodeTypeResource:
-		resources, err := c.processRegularNode(rcx, node, state, desired)
-		if err != nil {
-			return nil, err
-		}
-		return resources, nil
+		resources, nodeState, err = c.processRegularNode(rcx, node, desired)
 	case graph.NodeTypeInstance:
 		panic("instance node should not be processed for apply")
 	default:
 		panic(fmt.Sprintf("unknown node type: %v", node.Spec.Meta.Type))
 	}
+
+	rcx.StateManager.SetNodeState(id, nodeState)
+	return resources, err
 }
 
 // processRegularNode builds applyset inputs for a single-resource node.
+// Returns the resources to apply and the resulting node state.
 func (c *Controller) processRegularNode(
 	rcx *ReconcileContext,
 	node *runtime.Node,
-	state *NodeState,
 	desiredList []*unstructured.Unstructured,
-) ([]applyset.Resource, error) {
+) ([]applyset.Resource, NodeState, error) {
 	id := node.Spec.Meta.ID
 	nodeMeta := node.Spec.Meta
 
 	if len(desiredList) == 0 {
-		state.SetReady()
-		return nil, nil
+		return nil, readyState(), nil
 	}
 	desired := desiredList[0]
 
@@ -327,18 +343,16 @@ func (c *Controller) processRegularNode(
 		err = nil
 	}
 	if err != nil {
-		state.SetError(fmt.Errorf("failed to get current state for %s/%s: %w", desired.GetNamespace(), desired.GetName(), err))
-		return nil, state.Err
+		return nil, errorState(fmt.Errorf("failed to get current state for %s/%s: %w", desired.GetNamespace(), desired.GetName(), err)), err
 	}
 
 	if current != nil && current.GetDeletionTimestamp() != nil {
-		state.SetDeleting()
 		rcx.Log.V(1).Info("Resource is terminating; waiting for deletion to complete",
 			"id", id,
 			"namespace", current.GetNamespace(),
 			"name", current.GetName(),
 		)
-		return nil, newResourceDeletingError(id, current)
+		return nil, deletingState(), newResourceDeletingError(id, current)
 	}
 
 	if current != nil {
@@ -354,126 +368,7 @@ func (c *Controller) processRegularNode(
 		Current: current,
 	}
 
-	return []applyset.Resource{resource}, nil
-}
-
-// processCollectionNode builds applyset inputs for a collection node and
-// aligns observed items to desired items.
-func (c *Controller) processCollectionNode(
-	rcx *ReconcileContext,
-	node *runtime.Node,
-	state *NodeState,
-	expandedResources []*unstructured.Unstructured,
-) ([]applyset.Resource, error) {
-	id := node.Spec.Meta.ID
-	nodeMeta := node.Spec.Meta
-	gvr := nodeMeta.GVR
-
-	collectionSize := len(expandedResources)
-
-	// LIST all existing collection items with single call (more efficient than N GETs)
-	existingItems, err := c.listCollectionItems(rcx, gvr, id)
-	if err != nil {
-		state.SetError(fmt.Errorf("failed to list collection items: %w", err))
-		return nil, state.Err
-	}
-
-	// Empty collection: observed is set (possibly with orphans to prune), mark ready.
-	if collectionSize == 0 {
-		node.SetObserved(existingItems)
-		state.SetReady()
-		return nil, nil
-	}
-
-	// Build lookup map for current items keyed by namespace/name.
-	existingByKey := make(map[string]*unstructured.Unstructured, len(existingItems))
-	for _, current := range existingItems {
-		key := current.GetNamespace() + "/" + current.GetName()
-		existingByKey[key] = current
-	}
-
-	// Register a single collection watch for the forEach node. The selector
-	// matches all items owned by this instance + node, which is the same
-	// selector listCollectionItems uses to LIST them.
-	selector := labels.SelectorFromSet(labels.Set{
-		metadata.InstanceIDLabel: string(rcx.Instance.GetUID()),
-		metadata.NodeIDLabel:     id,
-	})
-	requestCollectionWatch(rcx, id, gvr, rcx.Instance.GetNamespace(), selector)
-
-	for _, expandedResource := range expandedResources {
-		key := expandedResource.GetNamespace() + "/" + expandedResource.GetName()
-		current := existingByKey[key]
-		if current != nil && current.GetDeletionTimestamp() != nil {
-			state.SetDeleting()
-			rcx.Log.V(1).Info("Collection resource is terminating; waiting for deletion to complete",
-				"id", id,
-				"namespace", current.GetNamespace(),
-				"name", current.GetName(),
-			)
-			return nil, newResourceDeletingError(id, current)
-		}
-	}
-
-	// Pass unordered observed items to runtime; it will align them to desired
-	// order by identity.
-	node.SetObserved(existingItems)
-
-	// Build resources list for apply
-	resources := make([]applyset.Resource, 0, collectionSize)
-	for i, expandedResource := range expandedResources {
-		// Apply decorator labels with collection info
-		collectionInfo := &CollectionInfo{Index: i, Size: collectionSize}
-		c.applyDecoratorLabels(rcx, expandedResource, id, collectionInfo)
-
-		// Look up current revision from LIST results
-		key := expandedResource.GetNamespace() + "/" + expandedResource.GetName()
-		current := existingByKey[key]
-
-		expandedID := fmt.Sprintf("%s-%d", id, i)
-		resources = append(resources, applyset.Resource{
-			ID:      expandedID,
-			Object:  expandedResource,
-			Current: current,
-		})
-	}
-
-	return resources, nil
-}
-
-// listCollectionItems returns existing collection items.
-// Uses a single LIST with label selector instead of N individual GETs.
-func (c *Controller) listCollectionItems(
-	rcx *ReconcileContext,
-	gvr schema.GroupVersionResource,
-	nodeID string,
-) ([]*unstructured.Unstructured, error) {
-	// Filter by both instance UID and node ID for precise matching
-	instanceUID := string(rcx.Instance.GetUID())
-	selector := fmt.Sprintf("%s=%s,%s=%s",
-		metadata.InstanceIDLabel, instanceUID,
-		metadata.NodeIDLabel, nodeID,
-	)
-
-	// List across all namespaces - collection items may span namespaces
-	list, err := rcx.Client.Resource(gvr).List(rcx.Ctx, metav1.ListOptions{
-		LabelSelector: selector,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	items := make([]*unstructured.Unstructured, len(list.Items))
-	for i := range list.Items {
-		items[i] = &list.Items[i]
-	}
-	return items, nil
-}
-
-// CollectionInfo holds collection item metadata for decorator.
-type CollectionInfo struct {
-	Index int
-	Size  int
+	return []applyset.Resource{resource}, inProgressState(), nil
 }
 
 // applyDecoratorLabels merges tool labels and adds node/collection identifiers.
@@ -537,58 +432,6 @@ func (c *Controller) patchInstanceWithApplySetMetadata(rcx *ReconcileContext, me
 		},
 	)
 	return err
-}
-
-// processExternalRefNode reads an external ref object and updates node state.
-func (c *Controller) processExternalRefNode(
-	rcx *ReconcileContext,
-	node *runtime.Node,
-	state *NodeState,
-	desiredList []*unstructured.Unstructured,
-) error {
-	id := node.Spec.Meta.ID
-	if len(desiredList) == 0 {
-		state.SetSkipped()
-		return nil
-	}
-	desired := desiredList[0]
-
-	// Register watch BEFORE reading the external resource.
-	requestWatch(rcx, id, node.Spec.Meta.GVR, desired.GetName(), desired.GetNamespace())
-
-	// External refs are read-only: fetch and push into runtime for dependency/readiness.
-	ri := resourceClientFor(rcx, node.Spec.Meta, desired.GetNamespace())
-	actual, err := ri.Get(rcx.Ctx, desired.GetName(), metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			state.SetWaitingForReadiness(fmt.Errorf("waiting for external reference %q: %w", id, err))
-			return nil
-		}
-		state.SetError(fmt.Errorf("external ref get %s %s/%s: %w",
-			desired.GroupVersionKind().String(), desired.GetNamespace(), desired.GetName(), err))
-		return state.Err
-	}
-
-	rcx.Log.V(2).Info("External reference resolved",
-		"id", id,
-		"gvk", desired.GroupVersionKind().String(),
-		"namespace", actual.GetNamespace(),
-		"name", actual.GetName(),
-	)
-
-	node.SetObserved([]*unstructured.Unstructured{actual})
-
-	if err := node.CheckReadiness(); err != nil {
-		if errors.Is(err, runtime.ErrWaitingForReadiness) {
-			state.SetWaitingForReadiness(fmt.Errorf("waiting for external reference %q: %w", id, err))
-			return nil
-		}
-		state.SetError(err)
-		return err
-	}
-	state.SetReady()
-
-	return nil
 }
 
 // processApplyResults updates runtime observations and node states from apply results.
@@ -658,54 +501,6 @@ func (c *Controller) processApplyResults(
 	return nil
 }
 
-// updateCollectionFromApplyResults maps per-item apply results back to the
-// collection node and refreshes the observed list in runtime.
-func (c *Controller) updateCollectionFromApplyResults(
-	_ *ReconcileContext,
-	node *runtime.Node,
-	state *NodeState,
-	byID map[string]applyset.ApplyResultItem,
-) error {
-	nodeID := node.Spec.Meta.ID
-	// Re-evaluate desired for collections when processing apply results:
-	// - Any non-pending error is a real failure (bad expression, missing field, etc.),
-	//   so we mark ERROR and stop.
-	// - An empty resolved collection (len==0) is correct by design and is treated
-	//   as SYNCED/ready because there is nothing to apply.
-	// - Otherwise we expect item-level apply results and proceed to reconcile them.
-	desiredItems, err := node.GetDesired()
-	if err != nil {
-		if runtime.IsDataPending(err) {
-			return nil
-		}
-		state.SetError(err)
-		return err
-	}
-	if len(desiredItems) == 0 {
-		state.SetReady()
-		return nil
-	}
-
-	observedItems := make([]*unstructured.Unstructured, 0, len(desiredItems))
-
-	for i := range desiredItems {
-		expandedID := fmt.Sprintf("%s-%d", nodeID, i)
-		if item, ok := byID[expandedID]; ok {
-			if item.Error != nil {
-				state.SetError(fmt.Errorf("collection item %d: %w", i, item.Error))
-				return nil
-			}
-			if item.Observed != nil {
-				observedItems = append(observedItems, item.Observed)
-			}
-		}
-	}
-
-	node.SetObserved(observedItems)
-	setStateFromReadiness(node, state)
-	return nil
-}
-
 // setStateFromReadiness evaluates node readiness and updates the node state
 // to synced, waiting, or error.
 func setStateFromReadiness(node *runtime.Node, state *NodeState) {
@@ -718,96 +513,6 @@ func setStateFromReadiness(node *runtime.Node, state *NodeState) {
 		return
 	}
 	state.SetReady()
-}
-
-// processExternalCollectionNode reads external resources matching a label selector
-// and updates node state. The selector is extracted from the resolved template
-// (desired), which was resolved by the standard template pipeline.
-func (c *Controller) processExternalCollectionNode(
-	rcx *ReconcileContext,
-	node *runtime.Node,
-	state *NodeState,
-	desired []*unstructured.Unstructured,
-) error {
-	id := node.Spec.Meta.ID
-	nodeMeta := node.Spec.Meta
-
-	if len(desired) == 0 {
-		state.SetSkipped()
-		return nil
-	}
-
-	// Extract the resolved selector from the template and convert to labels.Selector.
-	// A missing selector means "select everything" (unfiltered list).
-	var selector labels.Selector
-	selectorRaw, found, err := unstructured.NestedMap(desired[0].Object, "metadata", "selector")
-	if err != nil || !found {
-		selector = labels.Everything()
-	} else {
-		ls := &metav1.LabelSelector{}
-		if err := apimachineryruntime.DefaultUnstructuredConverter.FromUnstructured(selectorRaw, ls); err != nil {
-			state.SetError(fmt.Errorf("failed to convert selector for %s: %w", id, err))
-			return state.Err
-		}
-		selector, err = metav1.LabelSelectorAsSelector(ls)
-		if err != nil {
-			state.SetError(fmt.Errorf("invalid label selector for %s: %w", id, err))
-			return state.Err
-		}
-	}
-
-	// Get namespace from the resolved template. For cluster-scoped resources,
-	// use empty namespace so the LIST is not scoped to a single namespace.
-	ns := desired[0].GetNamespace()
-	if !nodeMeta.Namespaced {
-		ns = ""
-	} else if ns == "" {
-		// if no namespace is specified, use the namespace of the instance.
-		ns = rcx.Instance.GetNamespace()
-	}
-
-	// Register collection watch with the coordinator.
-	requestCollectionWatch(rcx, id, nodeMeta.GVR, ns, selector)
-
-	// LIST external resources matching the selector.
-	var list *unstructured.UnstructuredList
-	if ns != "" {
-		list, err = rcx.Client.Resource(nodeMeta.GVR).Namespace(ns).List(rcx.Ctx, metav1.ListOptions{
-			LabelSelector: selector.String(),
-		})
-	} else {
-		list, err = rcx.Client.Resource(nodeMeta.GVR).List(rcx.Ctx, metav1.ListOptions{
-			LabelSelector: selector.String(),
-		})
-	}
-	if err != nil {
-		state.SetError(fmt.Errorf("failed to list external collection %s: %w", id, err))
-		return state.Err
-	}
-
-	items := make([]*unstructured.Unstructured, len(list.Items))
-	for i := range list.Items {
-		items[i] = &list.Items[i]
-	}
-
-	node.SetObserved(items)
-
-	if err := node.CheckReadiness(); err != nil {
-		if errors.Is(err, runtime.ErrWaitingForReadiness) {
-			state.SetWaitingForReadiness(fmt.Errorf("waiting for external collection %q: %w", id, err))
-			return nil
-		}
-		state.SetError(err)
-		return err
-	}
-	state.SetReady()
-
-	rcx.Log.V(2).Info("External collection resolved",
-		"id", id,
-		"gvr", nodeMeta.GVR.String(),
-		"count", len(items),
-	)
-	return nil
 }
 
 // requestWatch registers a scalar watch request with the coordinator.

--- a/pkg/controller/instance/resources_collection.go
+++ b/pkg/controller/instance/resources_collection.go
@@ -1,0 +1,187 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
+	"github.com/kubernetes-sigs/kro/pkg/runtime"
+)
+
+// CollectionInfo holds collection item metadata for decorator.
+type CollectionInfo struct {
+	Index int
+	Size  int
+}
+
+// processCollectionNode builds applyset inputs for a collection node and
+// aligns observed items to desired items. Returns resources, node state, and error.
+func (c *Controller) processCollectionNode(
+	rcx *ReconcileContext,
+	node *runtime.Node,
+	expandedResources []*unstructured.Unstructured,
+) ([]applyset.Resource, NodeState, error) {
+	id := node.Spec.Meta.ID
+	nodeMeta := node.Spec.Meta
+	gvr := nodeMeta.GVR
+
+	collectionSize := len(expandedResources)
+
+	// LIST all existing collection items with single call (more efficient than N GETs)
+	existingItems, err := c.listCollectionItems(rcx, gvr, id)
+	if err != nil {
+		listErr := fmt.Errorf("failed to list collection items: %w", err)
+		return nil, errorState(listErr), listErr
+	}
+
+	// Empty collection: observed is set (possibly with orphans to prune), mark ready.
+	if collectionSize == 0 {
+		node.SetObserved(existingItems)
+		return nil, readyState(), nil
+	}
+
+	// Build lookup map for current items keyed by namespace/name.
+	existingByKey := make(map[string]*unstructured.Unstructured, len(existingItems))
+	for _, current := range existingItems {
+		key := current.GetNamespace() + "/" + current.GetName()
+		existingByKey[key] = current
+	}
+
+	// Register a single collection watch for the forEach node. The selector
+	// matches all items owned by this instance + node, which is the same
+	// selector listCollectionItems uses to LIST them.
+	selector := labels.SelectorFromSet(labels.Set{
+		metadata.InstanceIDLabel: string(rcx.Instance.GetUID()),
+		metadata.NodeIDLabel:     id,
+	})
+	requestCollectionWatch(rcx, id, gvr, rcx.Instance.GetNamespace(), selector)
+
+	for _, expandedResource := range expandedResources {
+		key := expandedResource.GetNamespace() + "/" + expandedResource.GetName()
+		current := existingByKey[key]
+		if current != nil && current.GetDeletionTimestamp() != nil {
+			rcx.Log.V(1).Info("Collection resource is terminating; waiting for deletion to complete",
+				"id", id,
+				"namespace", current.GetNamespace(),
+				"name", current.GetName(),
+			)
+			return nil, deletingState(), newResourceDeletingError(id, current)
+		}
+	}
+
+	// Pass unordered observed items to runtime; it will align them to desired
+	// order by identity.
+	node.SetObserved(existingItems)
+
+	// Build resources list for apply
+	resources := make([]applyset.Resource, 0, collectionSize)
+	for i, expandedResource := range expandedResources {
+		// Apply decorator labels with collection info
+		collectionInfo := &CollectionInfo{Index: i, Size: collectionSize}
+		c.applyDecoratorLabels(rcx, expandedResource, id, collectionInfo)
+
+		// Look up current revision from LIST results
+		key := expandedResource.GetNamespace() + "/" + expandedResource.GetName()
+		current := existingByKey[key]
+
+		expandedID := fmt.Sprintf("%s-%d", id, i)
+		resources = append(resources, applyset.Resource{
+			ID:      expandedID,
+			Object:  expandedResource,
+			Current: current,
+		})
+	}
+
+	return resources, inProgressState(), nil
+}
+
+// listCollectionItems returns existing collection items.
+// Uses a single LIST with label selector instead of N individual GETs.
+func (c *Controller) listCollectionItems(
+	rcx *ReconcileContext,
+	gvr schema.GroupVersionResource,
+	nodeID string,
+) ([]*unstructured.Unstructured, error) {
+	// Filter by both instance UID and node ID for precise matching
+	instanceUID := string(rcx.Instance.GetUID())
+	selector := fmt.Sprintf("%s=%s,%s=%s",
+		metadata.InstanceIDLabel, instanceUID,
+		metadata.NodeIDLabel, nodeID,
+	)
+
+	// List across all namespaces - collection items may span namespaces
+	list, err := rcx.Client.Resource(gvr).List(rcx.Ctx, metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]*unstructured.Unstructured, len(list.Items))
+	for i := range list.Items {
+		items[i] = &list.Items[i]
+	}
+	return items, nil
+}
+
+// updateCollectionFromApplyResults maps per-item apply results back to the
+// collection node and refreshes the observed list in runtime.
+// This operates on already-registered node states from processApplyResults.
+func (c *Controller) updateCollectionFromApplyResults(
+	_ *ReconcileContext,
+	node *runtime.Node,
+	state *NodeState,
+	byID map[string]applyset.ApplyResultItem,
+) error {
+	nodeID := node.Spec.Meta.ID
+	desiredItems, err := node.GetDesired()
+	if err != nil {
+		if runtime.IsDataPending(err) {
+			return nil
+		}
+		state.SetError(err)
+		return err
+	}
+	if len(desiredItems) == 0 {
+		state.SetReady()
+		return nil
+	}
+
+	observedItems := make([]*unstructured.Unstructured, 0, len(desiredItems))
+
+	for i := range desiredItems {
+		expandedID := fmt.Sprintf("%s-%d", nodeID, i)
+		if item, ok := byID[expandedID]; ok {
+			if item.Error != nil {
+				state.SetError(fmt.Errorf("collection item %d: %w", i, item.Error))
+				return nil
+			}
+			if item.Observed != nil {
+				observedItems = append(observedItems, item.Observed)
+			}
+		}
+	}
+
+	node.SetObserved(observedItems)
+	setStateFromReadiness(node, state)
+	return nil
+}

--- a/pkg/controller/instance/resources_external.go
+++ b/pkg/controller/instance/resources_external.go
@@ -1,0 +1,159 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"errors"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kubernetes-sigs/kro/pkg/runtime"
+)
+
+// processExternalRefNode reads an external ref object and updates node state.
+// Returns the resulting NodeState; the caller registers it.
+func (c *Controller) processExternalRefNode(
+	rcx *ReconcileContext,
+	node *runtime.Node,
+	desiredList []*unstructured.Unstructured,
+) (NodeState, error) {
+	id := node.Spec.Meta.ID
+	if len(desiredList) == 0 {
+		return skippedState(), nil
+	}
+	desired := desiredList[0]
+
+	// Register watch BEFORE reading the external resource.
+	requestWatch(rcx, id, node.Spec.Meta.GVR, desired.GetName(), desired.GetNamespace())
+
+	// External refs are read-only: fetch and push into runtime for dependency/readiness.
+	ri := resourceClientFor(rcx, node.Spec.Meta, desired.GetNamespace())
+	actual, err := ri.Get(rcx.Ctx, desired.GetName(), metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return waitingForReadinessState(fmt.Errorf("waiting for external reference %q: %w", id, err)), nil
+		}
+		fetchErr := fmt.Errorf("external ref get %s %s/%s: %w",
+			desired.GroupVersionKind().String(), desired.GetNamespace(), desired.GetName(), err)
+		return errorState(fetchErr), fetchErr
+	}
+
+	rcx.Log.V(2).Info("External reference resolved",
+		"id", id,
+		"gvk", desired.GroupVersionKind().String(),
+		"namespace", actual.GetNamespace(),
+		"name", actual.GetName(),
+	)
+
+	node.SetObserved([]*unstructured.Unstructured{actual})
+
+	if err := node.CheckReadiness(); err != nil {
+		if errors.Is(err, runtime.ErrWaitingForReadiness) {
+			return waitingForReadinessState(fmt.Errorf("waiting for external reference %q: %w", id, err)), nil
+		}
+		return errorState(err), err
+	}
+	return readyState(), nil
+}
+
+// processExternalCollectionNode reads external resources matching a label selector
+// and returns node state. The selector is extracted from the resolved template
+// (desired), which was resolved by the standard template pipeline.
+func (c *Controller) processExternalCollectionNode(
+	rcx *ReconcileContext,
+	node *runtime.Node,
+	desired []*unstructured.Unstructured,
+) (NodeState, error) {
+	id := node.Spec.Meta.ID
+	nodeMeta := node.Spec.Meta
+
+	if len(desired) == 0 {
+		return skippedState(), nil
+	}
+
+	// Extract the resolved selector from the template and convert to labels.Selector.
+	// A missing selector means "select everything" (unfiltered list).
+	var selector labels.Selector
+	selectorRaw, found, err := unstructured.NestedMap(desired[0].Object, "metadata", "selector")
+	if err != nil || !found {
+		selector = labels.Everything()
+	} else {
+		ls := &metav1.LabelSelector{}
+		if err := apimachineryruntime.DefaultUnstructuredConverter.FromUnstructured(selectorRaw, ls); err != nil {
+			convErr := fmt.Errorf("failed to convert selector for %s: %w", id, err)
+			return errorState(convErr), convErr
+		}
+		selector, err = metav1.LabelSelectorAsSelector(ls)
+		if err != nil {
+			selErr := fmt.Errorf("invalid label selector for %s: %w", id, err)
+			return errorState(selErr), selErr
+		}
+	}
+
+	// Get namespace from the resolved template. For cluster-scoped resources,
+	// use empty namespace so the LIST is not scoped to a single namespace.
+	ns := desired[0].GetNamespace()
+	if !nodeMeta.Namespaced {
+		ns = ""
+	} else if ns == "" {
+		// if no namespace is specified, use the namespace of the instance.
+		ns = rcx.Instance.GetNamespace()
+	}
+
+	// Register collection watch with the coordinator.
+	requestCollectionWatch(rcx, id, nodeMeta.GVR, ns, selector)
+
+	// LIST external resources matching the selector.
+	var list *unstructured.UnstructuredList
+	if ns != "" {
+		list, err = rcx.Client.Resource(nodeMeta.GVR).Namespace(ns).List(rcx.Ctx, metav1.ListOptions{
+			LabelSelector: selector.String(),
+		})
+	} else {
+		list, err = rcx.Client.Resource(nodeMeta.GVR).List(rcx.Ctx, metav1.ListOptions{
+			LabelSelector: selector.String(),
+		})
+	}
+	if err != nil {
+		listErr := fmt.Errorf("failed to list external collection %s: %w", id, err)
+		return errorState(listErr), listErr
+	}
+
+	items := make([]*unstructured.Unstructured, len(list.Items))
+	for i := range list.Items {
+		items[i] = &list.Items[i]
+	}
+
+	node.SetObserved(items)
+
+	if err := node.CheckReadiness(); err != nil {
+		if errors.Is(err, runtime.ErrWaitingForReadiness) {
+			return waitingForReadinessState(fmt.Errorf("waiting for external collection %q: %w", id, err)), nil
+		}
+		return errorState(err), err
+	}
+
+	rcx.Log.V(2).Info("External collection resolved",
+		"id", id,
+		"gvr", nodeMeta.GVR.String(),
+		"count", len(items),
+	)
+	return readyState(), nil
+}

--- a/pkg/controller/instance/resources_test.go
+++ b/pkg/controller/instance/resources_test.go
@@ -423,22 +423,22 @@ func TestCollectionAndExternalCollectionProcessing(t *testing.T) {
 	collectionRuntimeNode := rcx.Runtime.Nodes()[0]
 	desired, err := collectionRuntimeNode.GetDesired()
 	require.NoError(t, err)
-	resources, err := controller.processCollectionNode(rcx, collectionRuntimeNode, rcx.StateManager.NewNodeState("configs"), desired)
+	resources, nodeState, err := controller.processCollectionNode(rcx, collectionRuntimeNode, desired)
 	require.NoError(t, err)
 	require.Len(t, resources, 2)
 	assert.Equal(t, "one", resources[0].Object.GetName())
 	assert.NotNil(t, resources[0].Current)
 	assert.Equal(t, "0", resources[0].Object.GetLabels()[metadata.CollectionIndexLabel])
 	assert.Equal(t, "2", resources[0].Object.GetLabels()[metadata.CollectionSizeLabel])
+	_ = nodeState // state registered by caller
 
-	err = controller.processExternalCollectionNode(
+	extState, err := controller.processExternalCollectionNode(
 		rcx,
 		rcx.Runtime.Nodes()[1],
-		rcx.StateManager.NewNodeState("external-configs"),
 		[]*unstructured.Unstructured{externalCollection.Template.DeepCopy()},
 	)
 	require.NoError(t, err)
-	assert.Equal(t, v1alpha1.NodeStateSynced, rcx.StateManager.NodeStates["external-configs"].State)
+	assert.Equal(t, v1alpha1.NodeStateSynced, extState.State)
 }
 
 func TestProcessExternalRefNodePaths(t *testing.T) {
@@ -494,8 +494,7 @@ func TestProcessExternalRefNodePaths(t *testing.T) {
 				})
 			}
 
-			state := rcx.StateManager.NewNodeState(tt.name)
-			err := controller.processExternalRefNode(rcx, rcx.Runtime.Nodes()[0], state, tt.desired)
+			state, err := controller.processExternalRefNode(rcx, rcx.Runtime.Nodes()[0], tt.desired)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -523,8 +522,7 @@ func TestProcessExternalRefNodeWaitsForReadiness(t *testing.T) {
 	}
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(node), newConfigMapObject("demo", "default"))
-	state := rcx.StateManager.NewNodeState("external")
-	err := controller.processExternalRefNode(rcx, rcx.Runtime.Nodes()[0], state, []*unstructured.Unstructured{newConfigMapObject("demo", "default")})
+	state, err := controller.processExternalRefNode(rcx, rcx.Runtime.Nodes()[0], []*unstructured.Unstructured{newConfigMapObject("demo", "default")})
 	require.NoError(t, err)
 	assert.Equal(t, v1alpha1.NodeStateWaitingForReadiness, state.State)
 }
@@ -622,8 +620,7 @@ func TestProcessExternalCollectionNodePaths(t *testing.T) {
 				})
 			}
 
-			state := rcx.StateManager.NewNodeState(tt.name)
-			err := controller.processExternalCollectionNode(rcx, rcx.Runtime.Nodes()[0], state, tt.desired)
+			state, err := controller.processExternalCollectionNode(rcx, rcx.Runtime.Nodes()[0], tt.desired)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)

--- a/pkg/controller/instance/state.go
+++ b/pkg/controller/instance/state.go
@@ -21,11 +21,39 @@ import (
 )
 
 // NodeState holds the current reconciliation state for a node.
-// Prefer mutating this struct via its helper methods.
 type NodeState struct {
 	State v1alpha1.NodeState
 	Err   error
 }
+
+// Value constructors for NodeState — prefer these over mutating pointers.
+
+func inProgressState() NodeState {
+	return NodeState{State: v1alpha1.NodeStateInProgress}
+}
+
+func errorState(err error) NodeState {
+	return NodeState{State: v1alpha1.NodeStateError, Err: err}
+}
+
+func skippedState() NodeState {
+	return NodeState{State: v1alpha1.NodeStateSkipped}
+}
+
+func readyState() NodeState {
+	return NodeState{State: v1alpha1.NodeStateSynced}
+}
+
+func deletingState() NodeState {
+	return NodeState{State: v1alpha1.NodeStateDeleting}
+}
+
+func waitingForReadinessState(err error) NodeState {
+	return NodeState{State: v1alpha1.NodeStateWaitingForReadiness, Err: err}
+}
+
+// Pointer mutation methods — retained for processApplyResults and deletion paths
+// that update state on existing registered nodes.
 
 // SetInProgress marks the node as in progress and clears any error.
 func (st *NodeState) SetInProgress() {
@@ -33,16 +61,16 @@ func (st *NodeState) SetInProgress() {
 	st.Err = nil
 }
 
-// SetError marks the node as failed and records err.
-func (st *NodeState) SetError(err error) {
-	st.State = v1alpha1.NodeStateError
-	st.Err = err
-}
-
 // SetSkipped marks the node as intentionally skipped and clears any error.
 func (st *NodeState) SetSkipped() {
 	st.State = v1alpha1.NodeStateSkipped
 	st.Err = nil
+}
+
+// SetError marks the node as failed and records err.
+func (st *NodeState) SetError(err error) {
+	st.State = v1alpha1.NodeStateError
+	st.Err = err
 }
 
 // SetReady marks the node as ready/synced and clears any error.
@@ -86,13 +114,20 @@ func newStateManager() *StateManager {
 	}
 }
 
-// NewNodeState initializes and registers node state.
-// Callers should prefer this over allocating NodeState directly.
+// NewNodeState initializes and registers node state as InProgress.
+// Returns a pointer for processApplyResults and deletion paths that
+// update state on already-registered nodes.
 func (s *StateManager) NewNodeState(id string) *NodeState {
-	st := &NodeState{}
-	st.SetInProgress()
+	st := &NodeState{State: v1alpha1.NodeStateInProgress}
 	s.NodeStates[id] = st
 	return st
+}
+
+// SetNodeState registers a node state by value. This is the preferred
+// registration method for processNode — it makes the caller the single
+// point where state is written.
+func (s *StateManager) SetNodeState(id string, state NodeState) {
+	s.NodeStates[id] = &state
 }
 
 // NodeErrors aggregates errors across all node states.

--- a/pkg/runtime/eval.go
+++ b/pkg/runtime/eval.go
@@ -22,27 +22,12 @@ import (
 
 // evalExprAny evaluates an expression using its pre-compiled Program and caches the result.
 func evalExprAny(expr *expressionEvaluationState, ctx map[string]any) (any, error) {
-	if expr.Resolved {
-		return expr.ResolvedValue, nil
-	}
-
-	val, err := expr.Expression.Eval(filterContext(ctx, expr.Expression.References))
-	if err != nil {
-		return nil, err
-	}
-
-	expr.Resolved = true
-	expr.ResolvedValue = val
-	return val, nil
+	return expr.EvalCached(ctx)
 }
 
 // evalBoolExpr evaluates an expression that should return bool.
 func evalBoolExpr(expr *expressionEvaluationState, ctx map[string]any) (bool, error) {
-	if expr.Resolved {
-		return expr.ResolvedValue.(bool), nil
-	}
-
-	val, err := expr.Expression.Eval(filterContext(ctx, expr.Expression.References))
+	val, err := expr.EvalCached(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -53,19 +38,12 @@ func evalBoolExpr(expr *expressionEvaluationState, ctx map[string]any) (bool, er
 	if !ok {
 		return false, fmt.Errorf("expression %q did not return bool", expr.Expression.UserExpression())
 	}
-
-	expr.Resolved = true
-	expr.ResolvedValue = result
 	return result, nil
 }
 
 // evalListExpr evaluates an expression that should return a list.
 func evalListExpr(expr *expressionEvaluationState, ctx map[string]any) ([]any, error) {
-	if expr.Resolved {
-		return expr.ResolvedValue.([]any), nil
-	}
-
-	val, err := expr.Expression.Eval(filterContext(ctx, expr.Expression.References))
+	val, err := expr.EvalCached(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -76,9 +54,6 @@ func evalListExpr(expr *expressionEvaluationState, ctx map[string]any) ([]any, e
 	if !ok {
 		return nil, fmt.Errorf("expression %q did not return a list", expr.Expression.UserExpression())
 	}
-
-	expr.Resolved = true
-	expr.ResolvedValue = result
 	return result, nil
 }
 

--- a/pkg/runtime/node.go
+++ b/pkg/runtime/node.go
@@ -22,10 +22,8 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apiserver/pkg/cel/openapi"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
-	celunstructured "github.com/kubernetes-sigs/kro/pkg/cel/unstructured"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 	"github.com/kubernetes-sigs/kro/pkg/runtime/resolver"
@@ -60,6 +58,19 @@ var identityPaths = []string{
 	"metadata.name",
 	"metadata.namespace",
 }
+
+// resolveMode controls how template resolution behaves.
+type resolveMode int
+
+const (
+	// resolveFull evaluates all vars, fails on pending, caches result.
+	// Used by GetDesired for normal reconciliation.
+	resolveFull resolveMode = iota
+
+	// resolveIdentity evaluates identity paths only, no dep readiness check, no cache.
+	// Used by GetDesiredIdentity for deletion/observation.
+	resolveIdentity
+)
 
 // IsIgnored reports whether this node should be skipped entirely.
 // It is true when:
@@ -156,12 +167,27 @@ func (n *Node) IsIgnored() (bool, error) {
 //   - External: resolves template (for name/namespace CEL), caller reads instead of applies
 //
 // Note: The caller should call IsIgnored() before GetDesired() for resource nodes.
-func (n *Node) GetDesired() (result []*unstructured.Unstructured, err error) {
+func (n *Node) GetDesired() ([]*unstructured.Unstructured, error) {
 	// Return cached result if available.
 	if n.desired != nil {
 		return n.desired, nil
 	}
+	return n.resolve(resolveFull)
+}
 
+// GetDesiredIdentity resolves only identity-related fields (metadata.name & namespace)
+// and skips readiness gating. It is used for deletion/observation when we only need
+// stable identities and want to avoid being blocked by unrelated template fields.
+//
+// NOTE: This method does not cache its result in n.desired; callers in non-deletion
+// paths should continue using GetDesired().
+func (n *Node) GetDesiredIdentity() ([]*unstructured.Unstructured, error) {
+	return n.resolve(resolveIdentity)
+}
+
+// resolve is the unified resolution method. The mode controls which vars are
+// resolved, whether to tolerate pending dependencies, and whether to cache.
+func (n *Node) resolve(mode resolveMode) (result []*unstructured.Unstructured, err error) {
 	startTime := time.Now()
 	defer func() {
 		duration := time.Since(startTime)
@@ -172,9 +198,8 @@ func (n *Node) GetDesired() (result []*unstructured.Unstructured, err error) {
 		}
 	}()
 
-	// For resource types, block until all dependencies are ready.
-	// This enforces readyWhen semantics: dependents wait for parents.
-	if n.Spec.Meta.Type != graph.NodeTypeInstance {
+	// Full and partial modes check dep readiness (partial skips for instance nodes).
+	if mode == resolveFull && n.Spec.Meta.Type != graph.NodeTypeInstance {
 		for depID, dep := range n.deps {
 			if depID == graph.InstanceNodeID {
 				continue
@@ -189,106 +214,50 @@ func (n *Node) GetDesired() (result []*unstructured.Unstructured, err error) {
 		}
 	}
 
+	// Select vars based on mode.
+	vars := n.templateVars
+	if mode == resolveIdentity {
+		vars = n.templateVarsForPaths(identityPaths)
+	}
+
 	switch n.Spec.Meta.Type {
 	case graph.NodeTypeInstance:
+		if mode == resolveIdentity {
+			panic("GetDesiredIdentity called for instance node")
+		}
 		result, err = n.softResolve()
 	case graph.NodeTypeCollection:
-		result, err = n.hardResolveCollection(n.templateVars, true)
-	case graph.NodeTypeResource, graph.NodeTypeExternal:
-		// External refs resolve like resources (for name/namespace CEL),
-		// but the caller reads instead of applies.
-		result, err = n.hardResolveSingleResource(n.templateVars)
-	case graph.NodeTypeExternalCollection:
-		// Resolve the template to evaluate CEL expressions in
-		// metadata (name, namespace, selector). The caller extracts
-		// the resolved selector for LIST operations.
-		result, err = n.hardResolveSingleResource(n.templateVars)
-	default:
-		panic(fmt.Sprintf("unknown node type: %v", n.Spec.Meta.Type))
-	}
-
-	if err == nil {
-		if n.Spec.Meta.Type != graph.NodeTypeInstance {
-			if err = n.normalizeNamespaces(result); err != nil {
-				return nil, err
-			}
-		}
-		n.desired = result
-	}
-	return result, err
-}
-
-// GetDesiredIdentity resolves only identity-related fields (metadata.name & namespace)
-// and skips readiness gating. It is used for deletion/observation when we only need
-// stable identities and want to avoid being blocked by unrelated template fields.
-//
-// NOTE: This method does not cache its result in n.desired; callers in non-deletion
-// paths should continue using GetDesired().
-func (n *Node) GetDesiredIdentity() (result []*unstructured.Unstructured, err error) {
-	startTime := time.Now()
-	defer func() {
-		duration := time.Since(startTime)
-		nodeEvalDuration.Observe(duration.Seconds())
-		nodeEvalTotal.Inc()
-		if err != nil {
-			nodeEvalErrorsTotal.Inc()
-		}
-	}()
-
-	vars := n.templateVarsForPaths(identityPaths)
-	switch n.Spec.Meta.Type {
-	case graph.NodeTypeCollection:
-		result, err = n.hardResolveCollection(vars, false)
-		if err != nil {
-			return nil, err
-		}
-		if err := n.normalizeNamespaces(result); err != nil {
-			return nil, err
-		}
-		return result, nil
+		setIndexLabel := mode == resolveFull
+		result, err = n.hardResolveCollection(vars, setIndexLabel)
 	case graph.NodeTypeResource, graph.NodeTypeExternal:
 		result, err = n.hardResolveSingleResource(vars)
-		if err != nil {
-			return nil, err
-		}
-		if err := n.normalizeNamespaces(result); err != nil {
-			return nil, err
-		}
-		return result, nil
 	case graph.NodeTypeExternalCollection:
-		// External collections have no identity to resolve; they use selectors.
-		return nil, nil
-	case graph.NodeTypeInstance:
-		panic("GetDesiredIdentity called for instance node")
+		if mode == resolveIdentity {
+			// External collections have no identity to resolve; they use selectors.
+			return nil, nil
+		}
+		result, err = n.hardResolveSingleResource(vars)
 	default:
 		panic(fmt.Sprintf("unknown node type: %v", n.Spec.Meta.Type))
 	}
-}
 
-// normalizeNamespaces inherits the instance namespace onto namespaced children
-// that don't specify one. Cluster-scoped instances must resolve an explicit
-// namespace for namespaced children, otherwise reconciliation cannot safely
-// address them.
-func (n *Node) normalizeNamespaces(objs []*unstructured.Unstructured) error {
-	if !n.Spec.Meta.Namespaced {
-		return nil
+	if err != nil {
+		return nil, err
 	}
-	ns := n.deps[graph.InstanceNodeID].observed[0].GetNamespace()
-	for _, obj := range objs {
-		if obj.GetNamespace() != "" {
-			continue
-		}
-		if ns == "" {
-			return fmt.Errorf(
-				"node %q is namespaced and must resolve metadata.namespace when the instance is cluster-scoped",
-				n.Spec.Meta.ID,
-			)
-		}
-		if obj.GetNamespace() == "" {
-			obj.SetNamespace(ns)
+
+	// Normalize namespaces (not for instance nodes).
+	if n.Spec.Meta.Type != graph.NodeTypeInstance {
+		if err = n.normalizeNamespaces(result); err != nil {
+			return nil, err
 		}
 	}
-	return nil
+
+	// Cache result for full and partial modes (not identity).
+	if mode != resolveIdentity {
+		n.desired = result
+	}
+
+	return result, nil
 }
 
 // DeleteTargets returns the ordered list of objects this node should delete now.
@@ -318,247 +287,6 @@ func (n *Node) DeleteTargets() ([]*unstructured.Unstructured, error) {
 	}
 }
 
-func (n *Node) hardResolveSingleResource(vars []*variable.ResourceField) ([]*unstructured.Unstructured, error) {
-	baseExprs, _ := n.exprSetsForVars(vars)
-	values, _, err := n.evaluateExprsFiltered(baseExprs, false)
-	if err != nil {
-		return nil, fmt.Errorf("node %q: %w", n.Spec.Meta.ID, err)
-	}
-
-	desired := n.Spec.Template.DeepCopy()
-	res := resolver.NewResolver(desired.Object, values)
-	summary := res.Resolve(toFieldDescriptors(vars))
-	if len(summary.Errors) > 0 {
-		return nil, fmt.Errorf("node %q: resolve errors: %v", n.Spec.Meta.ID, summary.Errors)
-	}
-
-	return []*unstructured.Unstructured{desired}, nil
-}
-
-func (n *Node) hardResolveCollection(vars []*variable.ResourceField, setIndexLabel bool) ([]*unstructured.Unstructured, error) {
-	baseExprs, iterExprs := n.exprSetsForVars(vars)
-	baseValues, _, err := n.evaluateExprsFiltered(baseExprs, false)
-	if err != nil {
-		if !IsDataPending(err) {
-			err = fmt.Errorf("node %q base eval: %w", n.Spec.Meta.ID, err)
-		}
-		return nil, err
-	}
-
-	items, err := n.evaluateForEach()
-	if err != nil {
-		return nil, err
-	}
-
-	collectionSize.Observe(float64(len(items)))
-
-	if len(items) == 0 {
-		// Resolved empty collection: return non-nil empty slice to distinguish
-		// from unresolved (n.desired == nil).
-		return []*unstructured.Unstructured{}, nil
-	}
-
-	// Build a map from expression string to expressionEvaluationState for iteration expressions.
-	iterExprStates := make(map[string]*expressionEvaluationState, len(n.templateExprs))
-	for _, expr := range n.templateExprs {
-		if expr.Kind.IsIteration() {
-			iterExprStates[expr.Expression.Original] = expr
-		}
-	}
-
-	// Only build context for dependencies referenced by iteration expressions.
-	iterNeeded := make(map[string]struct{})
-	for exprStr := range iterExprs {
-		if state, ok := iterExprStates[exprStr]; ok {
-			for _, ref := range state.Expression.References {
-				iterNeeded[ref] = struct{}{}
-			}
-		}
-	}
-	baseCtx := n.buildContext(slices.Collect(maps.Keys(iterNeeded))...)
-
-	expanded := make([]*unstructured.Unstructured, 0, len(items))
-	for idx, iterCtx := range items {
-		values := make(map[string]any, len(baseValues)+len(iterExprs))
-		maps.Copy(values, baseValues)
-
-		// Merge iterator values into context.
-		ctx := make(map[string]any, len(baseCtx)+len(iterCtx))
-		maps.Copy(ctx, baseCtx)
-		maps.Copy(ctx, iterCtx)
-
-		// Evaluate iteration expressions (not cached - different context per iteration).
-		for exprStr := range iterExprs {
-			exprState := iterExprStates[exprStr]
-			val, err := exprState.Expression.Eval(ctx)
-			if err != nil {
-				if isCELDataPending(err) {
-					return nil, ErrDataPending
-				}
-				return nil, fmt.Errorf("collection iteration eval %q: %w", exprStr, err)
-			}
-			values[exprStr] = val
-		}
-
-		desired := n.Spec.Template.DeepCopy()
-		res := resolver.NewResolver(desired.Object, values)
-		summary := res.Resolve(toFieldDescriptors(vars))
-		if len(summary.Errors) > 0 {
-			return nil, fmt.Errorf("node %q collection resolve: resolve errors: %v", n.Spec.Meta.ID, summary.Errors)
-		}
-		if setIndexLabel {
-			setCollectionIndexLabel(desired, idx)
-		}
-		expanded = append(expanded, desired)
-	}
-
-	if err := validateUniqueIdentities(expanded); err != nil {
-		return nil, fmt.Errorf("node %q identity collision: %w", n.Spec.Meta.ID, err)
-	}
-
-	return expanded, nil
-}
-
-// softResolve evaluates expressions using best-effort partial resolution.
-// It ignores ErrDataPending (returns partial result) but propagates fatal errors.
-// Used for instance status where we populate as many fields as possible.
-//
-// Only fields where ALL expressions are resolved will be included in the result.
-// This prevents template strings like "${expr}" from leaking into the status.
-func (n *Node) softResolve() ([]*unstructured.Unstructured, error) {
-	values, _, err := n.evaluateExprsFiltered(nil, true) // soft: continue on pending
-	if err != nil {
-		return nil, err
-	}
-
-	// Filter to only fully-resolvable fields (expression value available)
-	var resolvable []variable.FieldDescriptor
-	for _, v := range n.templateVars {
-		if _, ok := values[v.Expression.Original]; ok {
-			resolvable = append(resolvable, v.FieldDescriptor)
-		}
-	}
-
-	// Resolve on template copy, then copy resolved values to empty desired
-	template := n.Spec.Template.DeepCopy()
-	templateRes := resolver.NewResolver(template.Object, values)
-	summary := templateRes.Resolve(resolvable)
-
-	// Resolution errors on filtered fields indicate bugs (template/path mismatch)
-	if len(summary.Errors) > 0 {
-		return nil, fmt.Errorf("failed to resolve status fields: %v", summary.Errors)
-	}
-
-	// Build desired with only successfully resolved fields
-	desired := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"status": map[string]interface{}{},
-		},
-	}
-	destRes := resolver.NewResolver(desired.Object, nil)
-	for _, result := range summary.Results {
-		if result.Resolved {
-			if err := destRes.UpsertValueAtPath(result.Path, result.Replaced); err != nil {
-				return nil, fmt.Errorf("failed to set status field %s: %w", result.Path, err)
-			}
-		}
-	}
-
-	return []*unstructured.Unstructured{desired}, nil
-}
-
-// evaluateExprsFiltered evaluates non-iteration expressions and returns the values map.
-// If exprs is nil, all expressions are evaluated. If exprs is empty, returns empty values.
-// If continueOnPending is true, it skips expressions that return ErrDataPending.
-// Returns (values, hasPending, error).
-func (n *Node) evaluateExprsFiltered(exprs map[string]struct{}, continueOnPending bool) (map[string]any, bool, error) {
-	if exprs != nil && len(exprs) == 0 {
-		return map[string]any{}, false, nil
-	}
-
-	// Compute the union of referenced dependencies across all expressions to
-	// evaluate, so buildContext only wraps needed deps with schema-aware values.
-	needed := n.neededDeps(exprs)
-	ctx := n.buildContext(needed...)
-
-	capacity := len(n.templateExprs)
-	if exprs != nil {
-		capacity = len(exprs)
-	}
-	values := make(map[string]any, capacity)
-	var hasPending bool
-	for _, expr := range n.templateExprs {
-		if expr.Kind.IsIteration() {
-			continue
-		}
-		if exprs != nil {
-			if _, ok := exprs[expr.Expression.Original]; !ok {
-				continue
-			}
-		}
-		if !expr.Resolved {
-			val, err := evalExprAny(expr, ctx)
-			if err != nil {
-				if isCELDataPending(err) {
-					hasPending = true
-					if continueOnPending {
-						continue
-					}
-					return nil, true, fmt.Errorf("failed to evaluate expression: %w (%w)", err, ErrDataPending)
-				}
-				return nil, false, err
-			}
-			expr.Resolved = true
-			expr.ResolvedValue = val
-		}
-		values[expr.Expression.Original] = expr.ResolvedValue
-	}
-	return values, hasPending, nil
-}
-
-func (n *Node) templateVarsForPaths(paths []string) []*variable.ResourceField {
-	if len(paths) == 0 {
-		return n.templateVars
-	}
-
-	pathSet := make(map[string]struct{}, len(paths))
-	for _, p := range paths {
-		pathSet[p] = struct{}{}
-	}
-
-	result := make([]*variable.ResourceField, 0, len(n.templateVars))
-	for _, v := range n.templateVars {
-		if _, ok := pathSet[v.Path]; ok {
-			result = append(result, v)
-		}
-	}
-	return result
-}
-
-func (n *Node) exprSetsForVars(
-	vars []*variable.ResourceField,
-) (map[string]struct{}, map[string]struct{}) {
-	baseExprs := make(map[string]struct{})
-	iterExprs := make(map[string]struct{})
-	if len(vars) == 0 {
-		return baseExprs, iterExprs
-	}
-
-	exprKinds := make(map[string]variable.ResourceVariableKind, len(n.templateExprs))
-	for _, expr := range n.templateExprs {
-		exprKinds[expr.Expression.Original] = expr.Kind
-	}
-
-	for _, v := range vars {
-		if kind, ok := exprKinds[v.Expression.Original]; ok && kind.IsIteration() {
-			iterExprs[v.Expression.Original] = struct{}{}
-		} else {
-			baseExprs[v.Expression.Original] = struct{}{}
-		}
-	}
-	return baseExprs, iterExprs
-}
-
 // upsertToTemplate applies values by upserting at paths, creating parent fields if needed.
 // Use for instance status where paths like status.foo may not exist yet.
 func (n *Node) upsertToTemplate(base *unstructured.Unstructured, values map[string]any) *unstructured.Unstructured {
@@ -584,248 +312,4 @@ func (n *Node) SetObserved(observed []*unstructured.Unstructured) {
 	default:
 		n.observed = observed
 	}
-}
-
-// CheckReadiness evaluates readyWhen expressions using observed state.
-// Ignored nodes are treated as ready for dependency gating purposes.
-func (n *Node) CheckReadiness() error {
-	nodeReadyCheckTotal.Inc()
-
-	// Ignored nodes are satisfied for dependency gating - dependents shouldn't block.
-	ignored, err := n.IsIgnored()
-	if err != nil {
-		return fmt.Errorf("is ignore check failed: %w", err)
-	}
-	if ignored {
-		return nil
-	}
-
-	err = n.checkObservedReadiness()
-	if err != nil && errors.Is(err, ErrWaitingForReadiness) {
-		nodeNotReadyTotal.Inc()
-	}
-
-	return err
-}
-
-// checkObservedReadiness evaluates readiness from the node's own observed and
-// desired state. Callers that need ignore semantics must handle them first.
-func (n *Node) checkObservedReadiness() error {
-	if n.Spec.Meta.Type == graph.NodeTypeCollection || n.Spec.Meta.Type == graph.NodeTypeExternalCollection {
-		return n.checkCollectionReadiness()
-	}
-	return n.checkSingleResourceReadiness()
-}
-
-func (n *Node) checkSingleResourceReadiness() error {
-	if len(n.observed) == 0 {
-		return fmt.Errorf("node %q: no observed state: %w", n.Spec.Meta.ID, ErrWaitingForReadiness)
-	}
-	if len(n.readyWhenExprs) == 0 {
-		return nil
-	}
-
-	nodeID := n.Spec.Meta.ID
-	ctx := map[string]any{nodeID: n.observed[0].Object}
-
-	for _, expr := range n.readyWhenExprs {
-		result, err := evalBoolExpr(expr, ctx)
-		if err != nil {
-			if isCELDataPending(err) {
-				return fmt.Errorf("node %q: failed to evaluate readyWhen expression: %q (%w)", n.Spec.Meta.ID, expr.Expression.UserExpression(), ErrWaitingForReadiness)
-			}
-			return fmt.Errorf("node %q: failed to evaluate readyWhen expression: %q (%w)", n.Spec.Meta.ID, expr.Expression.UserExpression(), err)
-		}
-		if !result {
-			return fmt.Errorf("readyWhen condition evaluated to false: %q (%w)", expr.Expression.UserExpression(), ErrWaitingForReadiness)
-		}
-	}
-	return nil
-}
-
-func (n *Node) checkCollectionReadiness() error {
-	if n.Spec.Meta.Type == graph.NodeTypeExternalCollection {
-		// External collections: desired carries the selector template, not actual
-		// desired resources. Skip count-based readiness checks.
-		if len(n.readyWhenExprs) == 0 || len(n.observed) == 0 {
-			return nil
-		}
-	} else {
-		// Use nil check (not len==0) to distinguish "not computed" from "empty collection".
-		if n.desired == nil {
-			return fmt.Errorf("node %q: collection not computed (%w)", n.Spec.Meta.ID, ErrWaitingForReadiness)
-		}
-		if len(n.desired) == 0 {
-			return nil
-		}
-		if len(n.observed) < len(n.desired) {
-			return fmt.Errorf("node %q: collection not ready: observed %d but desired %d (%w)", n.Spec.Meta.ID, len(n.observed), len(n.desired), ErrWaitingForReadiness)
-		}
-		if len(n.readyWhenExprs) == 0 {
-			return nil
-		}
-	}
-
-	// Collection readyWhen uses "each" (single item) only.
-	// Each item has different context, so we evaluate directly (not cached).
-	for i, obj := range n.observed {
-		ctx := map[string]any{graph.EachVarName: obj.Object}
-		for _, expr := range n.readyWhenExprs {
-			// readyWhen for collections must NOT be cached - each item has different "each" context.
-			// Use Expression.Eval directly instead of evalBoolExpr.
-			val, err := expr.Expression.Eval(ctx)
-			if err != nil {
-				if isCELDataPending(err) {
-					return fmt.Errorf("node %q: failed to evaluate readyWhen %q (item %d) (%w)", n.Spec.Meta.ID, expr.Expression.UserExpression(), i, ErrWaitingForReadiness)
-				}
-				return fmt.Errorf("node %q: failed to evaluate readyWhen %q (item %d): %w", n.Spec.Meta.ID, expr.Expression.UserExpression(), i, err)
-			}
-			result, ok := val.(bool)
-			if !ok {
-				return fmt.Errorf("readyWhen %q did not return bool", expr.Expression.UserExpression())
-			}
-			if !result {
-				return fmt.Errorf("readyWhen condition evaluated to false: %q (%w)", expr.Expression.UserExpression(), ErrWaitingForReadiness)
-			}
-		}
-	}
-
-	return nil
-}
-
-// evaluateForEach evaluates forEach dimensions and returns iterator contexts.
-func (n *Node) evaluateForEach() ([]map[string]any, error) {
-	if len(n.Spec.ForEach) == 0 {
-		return nil, nil
-	}
-
-	// Only build context for dependencies referenced by forEach expressions.
-	needed := make(map[string]struct{})
-	for _, expr := range n.forEachExprs {
-		for _, ref := range expr.Expression.References {
-			needed[ref] = struct{}{}
-		}
-	}
-	ctx := n.buildContext(slices.Collect(maps.Keys(needed))...)
-
-	dimensions := make([]evaluatedDimension, len(n.Spec.ForEach))
-	for i, dim := range n.Spec.ForEach {
-		values, err := evalListExpr(n.forEachExprs[i], ctx)
-		if err != nil {
-			if isCELDataPending(err) {
-				return nil, ErrDataPending
-			}
-			return nil, fmt.Errorf("forEach %q: %w", dim.Name, err)
-		}
-		if len(values) == 0 {
-			return nil, nil
-		}
-		dimensions[i] = evaluatedDimension{name: dim.Name, values: values}
-	}
-
-	product, err := cartesianProduct(dimensions, n.rgdConfig.MaxCollectionSize)
-	if err != nil {
-		return nil, err
-	}
-
-	return product, nil
-}
-
-// buildContext builds the CEL activation context from node dependencies.
-// If only is provided, only those dependency IDs are included in the context.
-// If only is empty/nil, all dependencies are included.
-//
-// When a dependency has a resourceSchema, its observed objects are wrapped using
-// Kubernetes' UnstructuredToVal for schema-aware type conversion. This ensures
-// CEL runtime values match their compile-time types (e.g., Secret data as bytes).
-func (n *Node) buildContext(only ...string) map[string]any {
-	ctx := make(map[string]any)
-	for depID, dep := range n.deps {
-		// Use nil check (not len==0) to include empty collections in context.
-		if dep.observed == nil {
-			continue
-		}
-		if len(only) > 0 && !slices.Contains(only, depID) {
-			continue
-		}
-		if dep.Spec.Meta.Type == graph.NodeTypeCollection || dep.Spec.Meta.Type == graph.NodeTypeExternalCollection {
-			items := make([]any, len(dep.observed))
-			for i, obj := range dep.observed {
-				items[i] = wrapWithSchema(obj.Object, dep.resourceSchema)
-			}
-			ctx[depID] = items
-		} else {
-			obj := dep.observed[0].Object
-			// For schema (instance), strip status - users should only access spec/metadata.
-			// The instance's resourceSchema already excludes status (set by builder via
-			// getSchemaWithoutStatus), so the schema and data stay aligned.
-			if depID == graph.InstanceNodeID {
-				obj = withStatusOmitted(obj)
-			}
-			ctx[depID] = wrapWithSchema(obj, dep.resourceSchema)
-		}
-	}
-	return ctx
-}
-
-// wrapWithSchema wraps an unstructured object with schema-aware CEL value
-// conversion. If the schema is nil, the raw object is returned. Otherwise,
-// returns a schemaMap that delegates to UnstructuredToVal for typed properties
-// and falls back to NativeToValue for preserve-unknown fields.
-func wrapWithSchema(obj map[string]interface{}, schema *spec.Schema) any {
-	if schema == nil {
-		return obj
-	}
-	return celunstructured.UnstructuredToVal(obj, &openapi.Schema{Schema: schema})
-}
-
-// withStatusOmitted returns a shallow copy of obj with the "status" key removed.
-// This prevents CEL expressions from accessing instance status fields.
-func withStatusOmitted(obj map[string]any) map[string]any {
-	result := make(map[string]any, len(obj))
-	for k, v := range obj {
-		if k != "status" {
-			result[k] = v
-		}
-	}
-	return result
-}
-
-// neededDeps computes the union of referenced dependency IDs across the
-// expressions in the given set. If exprs is nil, all non-iteration template
-// expressions are included. This allows buildContext to only wrap needed deps.
-func (n *Node) neededDeps(exprs map[string]struct{}) []string {
-	needed := make(map[string]struct{})
-	for _, expr := range n.templateExprs {
-		if expr.Kind.IsIteration() {
-			continue
-		}
-		if exprs != nil {
-			if _, ok := exprs[expr.Expression.Original]; !ok {
-				continue
-			}
-		}
-		for _, ref := range expr.Expression.References {
-			needed[ref] = struct{}{}
-		}
-	}
-	return slices.Collect(maps.Keys(needed))
-}
-
-// contextDependencyIDs returns CEL variable names grouped by type.
-// - singles: dependencies that are single resources (declared as dyn)
-// - collections: dependencies that are collections (declared as list(dyn))
-// - iterators: forEach loop variable names from iterCtx (declared as list(dyn))
-func (n *Node) contextDependencyIDs(iterCtx map[string]any) (singles, collections, iterators []string) {
-	for depID, dep := range n.deps {
-		if dep.Spec.Meta.Type == graph.NodeTypeCollection || dep.Spec.Meta.Type == graph.NodeTypeExternalCollection {
-			collections = append(collections, depID)
-		} else {
-			singles = append(singles, depID)
-		}
-	}
-	for name := range iterCtx {
-		iterators = append(iterators, name)
-	}
-	return
 }

--- a/pkg/runtime/node_context.go
+++ b/pkg/runtime/node_context.go
@@ -1,0 +1,125 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"maps"
+	"slices"
+
+	"k8s.io/apiserver/pkg/cel/openapi"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+
+	celunstructured "github.com/kubernetes-sigs/kro/pkg/cel/unstructured"
+	"github.com/kubernetes-sigs/kro/pkg/graph"
+)
+
+// buildContext builds the CEL activation context from node dependencies.
+// If only is provided, only those dependency IDs are included in the context.
+// If only is empty/nil, all dependencies are included.
+//
+// When a dependency has a resourceSchema, its observed objects are wrapped using
+// Kubernetes' UnstructuredToVal for schema-aware type conversion. This ensures
+// CEL runtime values match their compile-time types (e.g., Secret data as bytes).
+func (n *Node) buildContext(only ...string) map[string]any {
+	ctx := make(map[string]any)
+	for depID, dep := range n.deps {
+		// Use nil check (not len==0) to include empty collections in context.
+		if dep.observed == nil {
+			continue
+		}
+		if len(only) > 0 && !slices.Contains(only, depID) {
+			continue
+		}
+		if dep.Spec.Meta.Type == graph.NodeTypeCollection || dep.Spec.Meta.Type == graph.NodeTypeExternalCollection {
+			items := make([]any, len(dep.observed))
+			for i, obj := range dep.observed {
+				items[i] = wrapWithSchema(obj.Object, dep.resourceSchema)
+			}
+			ctx[depID] = items
+		} else {
+			obj := dep.observed[0].Object
+			// For schema (instance), strip status - users should only access spec/metadata.
+			// The instance's resourceSchema already excludes status (set by builder via
+			// getSchemaWithoutStatus), so the schema and data stay aligned.
+			if depID == graph.InstanceNodeID {
+				obj = withStatusOmitted(obj)
+			}
+			ctx[depID] = wrapWithSchema(obj, dep.resourceSchema)
+		}
+	}
+	return ctx
+}
+
+// wrapWithSchema wraps an unstructured object with schema-aware CEL value
+// conversion. If the schema is nil, the raw object is returned. Otherwise,
+// returns a schemaMap that delegates to UnstructuredToVal for typed properties
+// and falls back to NativeToValue for preserve-unknown fields.
+func wrapWithSchema(obj map[string]interface{}, schema *spec.Schema) any {
+	if schema == nil {
+		return obj
+	}
+	return celunstructured.UnstructuredToVal(obj, &openapi.Schema{Schema: schema})
+}
+
+// withStatusOmitted returns a shallow copy of obj with the "status" key removed.
+// This prevents CEL expressions from accessing instance status fields.
+func withStatusOmitted(obj map[string]any) map[string]any {
+	result := make(map[string]any, len(obj))
+	for k, v := range obj {
+		if k != "status" {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+// neededDeps computes the union of referenced dependency IDs across the
+// expressions in the given set. If exprs is nil, all non-iteration template
+// expressions are included. This allows buildContext to only wrap needed deps.
+func (n *Node) neededDeps(exprs map[string]struct{}) []string {
+	needed := make(map[string]struct{})
+	for _, expr := range n.templateExprs {
+		if expr.Kind.IsIteration() {
+			continue
+		}
+		if exprs != nil {
+			if _, ok := exprs[expr.Expression.Original]; !ok {
+				continue
+			}
+		}
+		for _, ref := range expr.Expression.References {
+			needed[ref] = struct{}{}
+		}
+	}
+	return slices.Collect(maps.Keys(needed))
+}
+
+// contextDependencyIDs returns CEL variable names grouped by type.
+// - singles: dependencies that are single resources (declared as dyn)
+// - collections: dependencies that are collections (declared as list(dyn))
+// - iterators: forEach loop variable names from iterCtx (declared as list(dyn))
+func (n *Node) contextDependencyIDs(iterCtx map[string]any) (singles, collections, iterators []string) {
+	for depID, dep := range n.deps {
+		if dep.Spec.Meta.Type == graph.NodeTypeCollection || dep.Spec.Meta.Type == graph.NodeTypeExternalCollection {
+			collections = append(collections, depID)
+		} else {
+			singles = append(singles, depID)
+		}
+	}
+	for name := range iterCtx {
+		iterators = append(iterators, name)
+	}
+	return
+}

--- a/pkg/runtime/node_readiness.go
+++ b/pkg/runtime/node_readiness.go
@@ -1,0 +1,129 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kubernetes-sigs/kro/pkg/graph"
+)
+
+// CheckReadiness evaluates readyWhen expressions using observed state.
+// Ignored nodes are treated as ready for dependency gating purposes.
+func (n *Node) CheckReadiness() error {
+	nodeReadyCheckTotal.Inc()
+
+	// Ignored nodes are satisfied for dependency gating - dependents shouldn't block.
+	ignored, err := n.IsIgnored()
+	if err != nil {
+		return fmt.Errorf("is ignore check failed: %w", err)
+	}
+	if ignored {
+		return nil
+	}
+
+	err = n.checkObservedReadiness()
+	if err != nil && errors.Is(err, ErrWaitingForReadiness) {
+		nodeNotReadyTotal.Inc()
+	}
+
+	return err
+}
+
+// checkObservedReadiness evaluates readiness from the node's own observed and
+// desired state. Callers that need ignore semantics must handle them first.
+func (n *Node) checkObservedReadiness() error {
+	if n.Spec.Meta.Type == graph.NodeTypeCollection || n.Spec.Meta.Type == graph.NodeTypeExternalCollection {
+		return n.checkCollectionReadiness()
+	}
+	return n.checkSingleResourceReadiness()
+}
+
+func (n *Node) checkSingleResourceReadiness() error {
+	if len(n.observed) == 0 {
+		return fmt.Errorf("node %q: no observed state: %w", n.Spec.Meta.ID, ErrWaitingForReadiness)
+	}
+	if len(n.readyWhenExprs) == 0 {
+		return nil
+	}
+
+	nodeID := n.Spec.Meta.ID
+	ctx := map[string]any{nodeID: n.observed[0].Object}
+
+	for _, expr := range n.readyWhenExprs {
+		result, err := evalBoolExpr(expr, ctx)
+		if err != nil {
+			if isCELDataPending(err) {
+				return fmt.Errorf("node %q: failed to evaluate readyWhen expression: %q (%w)", n.Spec.Meta.ID, expr.Expression.UserExpression(), ErrWaitingForReadiness)
+			}
+			return fmt.Errorf("node %q: failed to evaluate readyWhen expression: %q (%w)", n.Spec.Meta.ID, expr.Expression.UserExpression(), err)
+		}
+		if !result {
+			return fmt.Errorf("readyWhen condition evaluated to false: %q (%w)", expr.Expression.UserExpression(), ErrWaitingForReadiness)
+		}
+	}
+	return nil
+}
+
+func (n *Node) checkCollectionReadiness() error {
+	if n.Spec.Meta.Type == graph.NodeTypeExternalCollection {
+		// External collections: desired carries the selector template, not actual
+		// desired resources. Skip count-based readiness checks.
+		if len(n.readyWhenExprs) == 0 || len(n.observed) == 0 {
+			return nil
+		}
+	} else {
+		// Use nil check (not len==0) to distinguish "not computed" from "empty collection".
+		if n.desired == nil {
+			return fmt.Errorf("node %q: collection not computed (%w)", n.Spec.Meta.ID, ErrWaitingForReadiness)
+		}
+		if len(n.desired) == 0 {
+			return nil
+		}
+		if len(n.observed) < len(n.desired) {
+			return fmt.Errorf("node %q: collection not ready: observed %d but desired %d (%w)", n.Spec.Meta.ID, len(n.observed), len(n.desired), ErrWaitingForReadiness)
+		}
+		if len(n.readyWhenExprs) == 0 {
+			return nil
+		}
+	}
+
+	// Collection readyWhen uses "each" (single item) only.
+	// Each item has different context, so we evaluate directly (not cached).
+	for i, obj := range n.observed {
+		ctx := map[string]any{graph.EachVarName: obj.Object}
+		for _, expr := range n.readyWhenExprs {
+			// readyWhen for collections must NOT be cached - each item has different "each" context.
+			// Use Expression.Eval directly instead of evalBoolExpr.
+			val, err := expr.Expression.Eval(ctx)
+			if err != nil {
+				if isCELDataPending(err) {
+					return fmt.Errorf("node %q: failed to evaluate readyWhen %q (item %d) (%w)", n.Spec.Meta.ID, expr.Expression.UserExpression(), i, ErrWaitingForReadiness)
+				}
+				return fmt.Errorf("node %q: failed to evaluate readyWhen %q (item %d): %w", n.Spec.Meta.ID, expr.Expression.UserExpression(), i, err)
+			}
+			result, ok := val.(bool)
+			if !ok {
+				return fmt.Errorf("readyWhen %q did not return bool", expr.Expression.UserExpression())
+			}
+			if !result {
+				return fmt.Errorf("readyWhen condition evaluated to false: %q (%w)", expr.Expression.UserExpression(), ErrWaitingForReadiness)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/runtime/node_resolve.go
+++ b/pkg/runtime/node_resolve.go
@@ -1,0 +1,328 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kubernetes-sigs/kro/pkg/graph"
+	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
+	"github.com/kubernetes-sigs/kro/pkg/runtime/resolver"
+)
+
+func (n *Node) hardResolveSingleResource(vars []*variable.ResourceField) ([]*unstructured.Unstructured, error) {
+	baseExprs, _ := n.exprSetsForVars(vars)
+	values, _, err := n.evaluateExprsFiltered(baseExprs, false)
+	if err != nil {
+		return nil, fmt.Errorf("node %q: %w", n.Spec.Meta.ID, err)
+	}
+
+	desired := n.Spec.Template.DeepCopy()
+	res := resolver.NewResolver(desired.Object, values)
+	summary := res.Resolve(toFieldDescriptors(vars))
+	if len(summary.Errors) > 0 {
+		return nil, fmt.Errorf("node %q: resolve errors: %v", n.Spec.Meta.ID, summary.Errors)
+	}
+
+	return []*unstructured.Unstructured{desired}, nil
+}
+
+func (n *Node) hardResolveCollection(vars []*variable.ResourceField, setIndexLabel bool) ([]*unstructured.Unstructured, error) {
+	baseExprs, iterExprs := n.exprSetsForVars(vars)
+	baseValues, _, err := n.evaluateExprsFiltered(baseExprs, false)
+	if err != nil {
+		if !IsDataPending(err) {
+			err = fmt.Errorf("node %q base eval: %w", n.Spec.Meta.ID, err)
+		}
+		return nil, err
+	}
+
+	items, err := n.evaluateForEach()
+	if err != nil {
+		return nil, err
+	}
+
+	collectionSize.Observe(float64(len(items)))
+
+	if len(items) == 0 {
+		// Resolved empty collection: return non-nil empty slice to distinguish
+		// from unresolved (n.desired == nil).
+		return []*unstructured.Unstructured{}, nil
+	}
+
+	// Build a map from expression string to expressionEvaluationState for iteration expressions.
+	iterExprStates := make(map[string]*expressionEvaluationState, len(n.templateExprs))
+	for _, expr := range n.templateExprs {
+		if expr.Kind.IsIteration() {
+			iterExprStates[expr.Expression.Original] = expr
+		}
+	}
+
+	// Only build context for dependencies referenced by iteration expressions.
+	iterNeeded := make(map[string]struct{})
+	for exprStr := range iterExprs {
+		if state, ok := iterExprStates[exprStr]; ok {
+			for _, ref := range state.Expression.References {
+				iterNeeded[ref] = struct{}{}
+			}
+		}
+	}
+	baseCtx := n.buildContext(slices.Collect(maps.Keys(iterNeeded))...)
+
+	expanded := make([]*unstructured.Unstructured, 0, len(items))
+	for idx, iterCtx := range items {
+		values := make(map[string]any, len(baseValues)+len(iterExprs))
+		maps.Copy(values, baseValues)
+
+		// Merge iterator values into context.
+		ctx := make(map[string]any, len(baseCtx)+len(iterCtx))
+		maps.Copy(ctx, baseCtx)
+		maps.Copy(ctx, iterCtx)
+
+		// Evaluate iteration expressions (not cached - different context per iteration).
+		for exprStr := range iterExprs {
+			exprState := iterExprStates[exprStr]
+			val, err := exprState.Expression.Eval(ctx)
+			if err != nil {
+				if isCELDataPending(err) {
+					return nil, ErrDataPending
+				}
+				return nil, fmt.Errorf("collection iteration eval %q: %w", exprStr, err)
+			}
+			values[exprStr] = val
+		}
+
+		desired := n.Spec.Template.DeepCopy()
+		res := resolver.NewResolver(desired.Object, values)
+		summary := res.Resolve(toFieldDescriptors(vars))
+		if len(summary.Errors) > 0 {
+			return nil, fmt.Errorf("node %q collection resolve: resolve errors: %v", n.Spec.Meta.ID, summary.Errors)
+		}
+		if setIndexLabel {
+			setCollectionIndexLabel(desired, idx)
+		}
+		expanded = append(expanded, desired)
+	}
+
+	if err := validateUniqueIdentities(expanded); err != nil {
+		return nil, fmt.Errorf("node %q identity collision: %w", n.Spec.Meta.ID, err)
+	}
+
+	return expanded, nil
+}
+
+// softResolve evaluates expressions using best-effort partial resolution.
+// It ignores ErrDataPending (returns partial result) but propagates fatal errors.
+// Used for instance status where we populate as many fields as possible.
+//
+// Only fields where ALL expressions are resolved will be included in the result.
+// This prevents template strings like "${expr}" from leaking into the status.
+func (n *Node) softResolve() ([]*unstructured.Unstructured, error) {
+	values, _, err := n.evaluateExprsFiltered(nil, true) // soft: continue on pending
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter to only fully-resolvable fields (expression value available)
+	var resolvable []variable.FieldDescriptor
+	for _, v := range n.templateVars {
+		if _, ok := values[v.Expression.Original]; ok {
+			resolvable = append(resolvable, v.FieldDescriptor)
+		}
+	}
+
+	// Resolve on template copy, then copy resolved values to empty desired
+	template := n.Spec.Template.DeepCopy()
+	templateRes := resolver.NewResolver(template.Object, values)
+	summary := templateRes.Resolve(resolvable)
+
+	// Resolution errors on filtered fields indicate bugs (template/path mismatch)
+	if len(summary.Errors) > 0 {
+		return nil, fmt.Errorf("failed to resolve status fields: %v", summary.Errors)
+	}
+
+	// Build desired with only successfully resolved fields
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"status": map[string]interface{}{},
+		},
+	}
+	destRes := resolver.NewResolver(desired.Object, nil)
+	for _, result := range summary.Results {
+		if result.Resolved {
+			if err := destRes.UpsertValueAtPath(result.Path, result.Replaced); err != nil {
+				return nil, fmt.Errorf("failed to set status field %s: %w", result.Path, err)
+			}
+		}
+	}
+
+	return []*unstructured.Unstructured{desired}, nil
+}
+
+// evaluateExprsFiltered evaluates non-iteration expressions and returns the values map.
+// If exprs is nil, all expressions are evaluated. If exprs is empty, returns empty values.
+// If continueOnPending is true, it skips expressions that return ErrDataPending.
+// Returns (values, hasPending, error).
+func (n *Node) evaluateExprsFiltered(exprs map[string]struct{}, continueOnPending bool) (map[string]any, bool, error) {
+	if exprs != nil && len(exprs) == 0 {
+		return map[string]any{}, false, nil
+	}
+
+	// Compute the union of referenced dependencies across all expressions to
+	// evaluate, so buildContext only wraps needed deps with schema-aware values.
+	needed := n.neededDeps(exprs)
+	ctx := n.buildContext(needed...)
+
+	capacity := len(n.templateExprs)
+	if exprs != nil {
+		capacity = len(exprs)
+	}
+	values := make(map[string]any, capacity)
+	var hasPending bool
+	for _, expr := range n.templateExprs {
+		if expr.Kind.IsIteration() {
+			continue
+		}
+		if exprs != nil {
+			if _, ok := exprs[expr.Expression.Original]; !ok {
+				continue
+			}
+		}
+		val, err := expr.EvalCached(ctx)
+		if err != nil {
+			if isCELDataPending(err) {
+				hasPending = true
+				if continueOnPending {
+					continue
+				}
+				return nil, true, fmt.Errorf("failed to evaluate expression: %w (%w)", err, ErrDataPending)
+			}
+			return nil, false, err
+		}
+		values[expr.Expression.Original] = val
+	}
+	return values, hasPending, nil
+}
+
+// evaluateForEach evaluates forEach dimensions and returns iterator contexts.
+func (n *Node) evaluateForEach() ([]map[string]any, error) {
+	if len(n.Spec.ForEach) == 0 {
+		return nil, nil
+	}
+
+	// Only build context for dependencies referenced by forEach expressions.
+	needed := make(map[string]struct{})
+	for _, expr := range n.forEachExprs {
+		for _, ref := range expr.Expression.References {
+			needed[ref] = struct{}{}
+		}
+	}
+	ctx := n.buildContext(slices.Collect(maps.Keys(needed))...)
+
+	dimensions := make([]evaluatedDimension, len(n.Spec.ForEach))
+	for i, dim := range n.Spec.ForEach {
+		values, err := evalListExpr(n.forEachExprs[i], ctx)
+		if err != nil {
+			if isCELDataPending(err) {
+				return nil, ErrDataPending
+			}
+			return nil, fmt.Errorf("forEach %q: %w", dim.Name, err)
+		}
+		if len(values) == 0 {
+			return nil, nil
+		}
+		dimensions[i] = evaluatedDimension{name: dim.Name, values: values}
+	}
+
+	product, err := cartesianProduct(dimensions, n.rgdConfig.MaxCollectionSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return product, nil
+}
+
+func (n *Node) templateVarsForPaths(paths []string) []*variable.ResourceField {
+	if len(paths) == 0 {
+		return n.templateVars
+	}
+
+	pathSet := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		pathSet[p] = struct{}{}
+	}
+
+	result := make([]*variable.ResourceField, 0, len(n.templateVars))
+	for _, v := range n.templateVars {
+		if _, ok := pathSet[v.Path]; ok {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+func (n *Node) exprSetsForVars(
+	vars []*variable.ResourceField,
+) (map[string]struct{}, map[string]struct{}) {
+	baseExprs := make(map[string]struct{})
+	iterExprs := make(map[string]struct{})
+	if len(vars) == 0 {
+		return baseExprs, iterExprs
+	}
+
+	exprKinds := make(map[string]variable.ResourceVariableKind, len(n.templateExprs))
+	for _, expr := range n.templateExprs {
+		exprKinds[expr.Expression.Original] = expr.Kind
+	}
+
+	for _, v := range vars {
+		if kind, ok := exprKinds[v.Expression.Original]; ok && kind.IsIteration() {
+			iterExprs[v.Expression.Original] = struct{}{}
+		} else {
+			baseExprs[v.Expression.Original] = struct{}{}
+		}
+	}
+	return baseExprs, iterExprs
+}
+
+// normalizeNamespaces inherits the instance namespace onto namespaced children
+// that don't specify one. Cluster-scoped instances must resolve an explicit
+// namespace for namespaced children, otherwise reconciliation cannot safely
+// address them.
+func (n *Node) normalizeNamespaces(objs []*unstructured.Unstructured) error {
+	if !n.Spec.Meta.Namespaced {
+		return nil
+	}
+	ns := n.deps[graph.InstanceNodeID].observed[0].GetNamespace()
+	for _, obj := range objs {
+		if obj.GetNamespace() != "" {
+			continue
+		}
+		if ns == "" {
+			return fmt.Errorf(
+				"node %q is namespaced and must resolve metadata.namespace when the instance is cluster-scoped",
+				n.Spec.Meta.ID,
+			)
+		}
+		if obj.GetNamespace() == "" {
+			obj.SetNamespace(ns)
+		}
+	}
+	return nil
+}

--- a/pkg/runtime/node_test.go
+++ b/pkg/runtime/node_test.go
@@ -1955,14 +1955,14 @@ func TestEvalBoolExpr(t *testing.T) {
 			wantResolved: true,
 		},
 		{
-			name: "returns false for null values without caching",
+			name: "returns false for null values and caches the result",
 			expr: &expressionEvaluationState{
 				Expression: mustCompileTestExpr("null"),
 				Kind:       variable.ResourceVariableKindIncludeWhen,
 			},
 			ctx:          map[string]any{},
 			want:         false,
-			wantResolved: false,
+			wantResolved: true,
 		},
 		{
 			name: "errors when expression is not bool",

--- a/pkg/runtime/state.go
+++ b/pkg/runtime/state.go
@@ -45,3 +45,19 @@ type expressionEvaluationState struct {
 	// ResolvedValue holds the cached result. Nil until Resolved=true.
 	ResolvedValue any
 }
+
+// EvalCached evaluates the expression with caching. If the expression was
+// already evaluated, the cached value is returned. Otherwise the expression
+// is evaluated against the filtered context, and the result is cached.
+func (e *expressionEvaluationState) EvalCached(ctx map[string]any) (any, error) {
+	if e.Resolved {
+		return e.ResolvedValue, nil
+	}
+	val, err := e.Expression.Eval(filterContext(ctx, e.Expression.References))
+	if err != nil {
+		return nil, err
+	}
+	e.Resolved = true
+	e.ResolvedValue = val
+	return val, nil
+}


### PR DESCRIPTION
Reduce cognitive load in the instance controller (~7K LOC) and node runtime (~3.1K LOC) through six incremental refactors:

1. Split resources.go by node type — external ref/collection processing moved to resources_external.go, collection processing moved to resources_collection.go. Zero behavioral change.

2. Split node.go by concern — context building to node_context.go, readiness checks to node_readiness.go, resolution logic to node_resolve.go. Zero behavioral change.

3. Consolidate expression caching — add EvalCached() on expressionEvaluationState, making evalBoolExpr/evalListExpr thin type-assertion wrappers and eliminating duplicated cache-check-and-set across 4 locations.

4. Make resolution mode explicit — add resolveMode enum and unify GetDesired/GetDesiredIdentity into a shared resolve(mode) method that encodes which vars to resolve, whether to check dep readiness, and whether to cache results.

5. Return NodeState as values — process*Node methods return ([]Resource, NodeState, error) instead of mutating shared *NodeState pointers. processNode becomes the single state registration point via SetNodeState.

6. Extract reconcileNodes pipeline — replace 90-line method with reconcileResult struct flowing through buildApplyInputs, applyResources, pruneIfSafe, and finalizeState phases.

All changes are internal (no public API changes).