### PR TITLE
feat(graph): reject omit() on required resource metadata fields

### DIFF
--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -254,6 +254,11 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 		return nil, fmt.Errorf("failed to get topological order: %w", err)
 	}
 
+	// Validate that omit() is not used on resource identity fields.
+	if err := validateIdentityFields(nodes, inspector, instanceNamespaced); err != nil {
+		return nil, err
+	}
+
 	// Collect all schemas for CEL validation:
 	// - Resource schemas (wrapped as lists for collections)
 	// - Instance spec schema as "schema" variable (extracted from CRD, without status)
@@ -1185,11 +1190,8 @@ func validateAndCompileTemplates(
 	// NOTE: omit() is allowed in template expressions. Restricted-context
 	// rejection (includeWhen, readyWhen, forEach) is handled by the compiler
 	// in inspectExpressionRestricted and validateAndCompileForEach.
-	//
-	// TODO: Add validation that required resource fields (e.g. metadata.name)
-	// cannot evaluate to null or omit(). Currently nothing prevents a user
-	// from writing `metadata.name: ${omit()}`, which produces an invalid
-	// resource at apply time.
+	// Identity-field rejection (metadata.name, metadata.namespace) is handled
+	// by validateIdentityFields earlier in the build pipeline.
 	compileEnv := env
 	if len(iteratorTypes) > 0 {
 		opts := make([]cel.EnvOption, 0, len(iteratorTypes))

--- a/pkg/graph/validation.go
+++ b/pkg/graph/validation.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/cel/ast"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 )
 
@@ -299,6 +300,48 @@ func validateTemplateConstraints(
 	}
 
 	return nil
+}
+
+// validateIdentityFields checks that omit() is not used on resource identity
+// fields. These fields are special to kro's ownership model — omitting them
+// silently breaks SSA ownership and resource tracking, unlike schema-required
+// fields which fail loudly on server-side apply.
+//
+// Identity fields:
+//   - metadata.name: always required for any Kubernetes resource
+//   - metadata.namespace: required when the instance is cluster-scoped and the
+//     resource itself is namespaced (no instance namespace to inherit)
+func validateIdentityFields(nodes map[string]*Node, inspector *ast.Inspector, isInstanceNamespaced bool) error {
+	for _, node := range nodes {
+		for _, v := range node.Variables {
+			if !isRequiredIdentityField(v.Path, node.Meta.Namespaced, isInstanceNamespaced) {
+				continue
+			}
+			result, err := inspector.Inspect(v.Expression.Original)
+			if err != nil {
+				return fmt.Errorf("resource %q: failed to inspect expression at path %q: %w", node.Meta.ID, v.Path, err)
+			}
+			if result.UsesOmit() {
+				return fmt.Errorf("resource %q: omit() cannot be used at path %q — the field is required and must resolve to a concrete value", node.Meta.ID, v.Path)
+			}
+		}
+	}
+	return nil
+}
+
+// isRequiredIdentityField reports whether the given field path is a resource
+// identity field that must resolve to a concrete value. metadata.name is always
+// required. metadata.namespace is required only when the resource is namespaced
+// and the instance is cluster-scoped (no namespace to inherit).
+func isRequiredIdentityField(path string, resourceNamespaced, instanceNamespaced bool) bool {
+	switch path {
+	case MetadataNamePath:
+		return true
+	case MetadataNamespacePath:
+		return resourceNamespaced && !instanceNamespaced
+	default:
+		return false
+	}
 }
 
 // validateNoKROOwnedLabels enforces that the resource template doesn't define any label with

--- a/pkg/graph/validation_test.go
+++ b/pkg/graph/validation_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
+	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 )
 
 func TestValidateRGResourceNames(t *testing.T) {
@@ -890,6 +891,104 @@ func TestValidateTemplateConstraints(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateTemplateConstraints(tt.resource, tt.object, tt.namespaced, tt.instanceNamespaced)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestValidateIdentityFields(t *testing.T) {
+	inspector := newUnitInspector(t, "schema")
+
+	makeNode := func(id, path, expression string, namespaced bool) *Node {
+		return &Node{
+			Meta: NodeMeta{ID: id, Namespaced: namespaced},
+			Variables: []*variable.ResourceField{
+				{
+					FieldDescriptor: variable.FieldDescriptor{
+						Path:       path,
+						Expression: expr(expression),
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                 string
+		nodes                map[string]*Node
+		isInstanceNamespaced bool
+		wantErr              string
+	}{
+		{
+			name: "omit on metadata.name is rejected",
+			nodes: map[string]*Node{
+				"cm": makeNode("cm", MetadataNamePath, "omit()", true),
+			},
+			isInstanceNamespaced: true,
+			wantErr:              "omit() cannot be used at path \"metadata.name\"",
+		},
+		{
+			name: "conditional omit on metadata.name is rejected",
+			nodes: map[string]*Node{
+				"cm": makeNode("cm", MetadataNamePath, `schema.spec.name != "" ? schema.spec.name : omit()`, true),
+			},
+			isInstanceNamespaced: true,
+			wantErr:              "omit() cannot be used at path \"metadata.name\"",
+		},
+		{
+			name: "omit on metadata.namespace rejected for namespaced resource with cluster-scoped instance",
+			nodes: map[string]*Node{
+				"cm": makeNode("cm", MetadataNamespacePath, "omit()", true),
+			},
+			isInstanceNamespaced: false,
+			wantErr:              "omit() cannot be used at path \"metadata.namespace\"",
+		},
+		{
+			name: "omit on metadata.namespace allowed for namespaced instance",
+			nodes: map[string]*Node{
+				"cm": makeNode("cm", MetadataNamespacePath, "omit()", true),
+			},
+			isInstanceNamespaced: true,
+		},
+		{
+			name: "omit on metadata.namespace allowed for cluster-scoped resource",
+			nodes: map[string]*Node{
+				"crb": makeNode("crb", MetadataNamespacePath, "omit()", false),
+			},
+			isInstanceNamespaced: false,
+		},
+		{
+			name: "omit on non-required field is allowed",
+			nodes: map[string]*Node{
+				"cm": makeNode("cm", "spec.someField", "omit()", true),
+			},
+			isInstanceNamespaced: true,
+		},
+		{
+			name: "omit on metadata.name rejected for cluster-scoped instance",
+			nodes: map[string]*Node{
+				"cm": makeNode("cm", MetadataNamePath, "omit()", true),
+			},
+			isInstanceNamespaced: false,
+			wantErr:              "omit() cannot be used at path \"metadata.name\"",
+		},
+		{
+			name: "non-omit expression on metadata.name is allowed",
+			nodes: map[string]*Node{
+				"cm": makeNode("cm", MetadataNamePath, `"my-resource"`, true),
+			},
+			isInstanceNamespaced: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateIdentityFields(tt.nodes, inspector, tt.isInstanceNamespaced)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 				return

--- a/test/integration/suites/core/omit_test.go
+++ b/test/integration/suites/core/omit_test.go
@@ -217,6 +217,29 @@ var _ = Describe("Omit", func() {
 		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 	})
 
+	It("should reject omit() on metadata.name for a regular resource", func(ctx SpecContext) {
+		rgd := generator.NewResourceGraphDefinition("test-omit-name",
+			generator.WithSchema(
+				"TestOmitName", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+				},
+				nil,
+			),
+			generator.WithResource("configmap", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${omit()}",
+				},
+			}, nil, nil),
+		)
+
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		expectRGDInactiveWithError(ctx, rgd, "omit() cannot be used at path \"metadata.name\"")
+		Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+	})
+
 	It("should omit array elements when omit() is triggered", func(ctx SpecContext) {
 		rgd := generator.NewResourceGraphDefinition("test-omit-array",
 			generator.WithSchema(


### PR DESCRIPTION
Reject omit() on metadata.name (always) and metadata.namespace (when
the instance CRD is cluster-scoped and the resource is namespaced).

Adds validateNoOmitOnRequiredFields as a dedicated validation pass
that runs after dependency extraction, where node metadata and the
instance scope are available.