### PR TITLE
fix(dynamic): skip parent instance events with unchanged generation

### DIFF
--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -68,6 +68,7 @@ import (
 	"golang.org/x/time/rate"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -77,6 +78,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/requeue"
 )
 
@@ -374,14 +376,14 @@ func (dc *DynamicController) Register(
 
 		// Register event handler directly on the parent informer.
 		parentHandler := cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				dc.enqueueFromInformer(parent, obj, EventAdd)
+			AddFunc: func(obj any) {
+				dc.enqueueFromInformer(parent, nil, obj, EventAdd)
 			},
-			UpdateFunc: func(_, newObj interface{}) {
-				dc.enqueueFromInformer(parent, newObj, EventUpdate)
+			UpdateFunc: func(oldObj, newObj any) {
+				dc.enqueueFromInformer(parent, oldObj, newObj, EventUpdate)
 			},
-			DeleteFunc: func(obj interface{}) {
-				dc.enqueueFromInformer(parent, obj, EventDelete)
+			DeleteFunc: func(obj any) {
+				dc.enqueueFromInformer(parent, nil, obj, EventDelete)
 			},
 		}
 		reg, err := inf.AddEventHandler(parentHandler)
@@ -423,18 +425,49 @@ func (dc *DynamicController) Register(
 }
 
 // enqueueFromInformer converts a raw informer callback into an enqueue call.
-func (dc *DynamicController) enqueueFromInformer(parentGVR schema.GroupVersionResource, obj interface{}, eventType EventType) {
-	mobj, err := meta.Accessor(obj)
+// For Update events it compares generations and skips if unchanged (unless
+// the reconcile-disabled label was just removed).
+func (dc *DynamicController) enqueueFromInformer(parentGVR schema.GroupVersionResource, oldObject, newObject any, eventType EventType) {
+	newMeta, err := meta.Accessor(newObject)
 	if err != nil {
 		dc.log.Error(err, "Failed to get meta for parent object")
 		return
 	}
+
+	// Generation-based skip only applies to updates where we have both old and new objects.
+	if eventType == EventUpdate && oldObject != nil {
+		oldMeta, err := meta.Accessor(oldObject)
+		if err != nil {
+			dc.log.Error(err, "Failed to get meta for old parent object")
+			return
+		}
+		if newMeta.GetGeneration() == oldMeta.GetGeneration() {
+			// Normally skip, but we should enqueue if the oldMeta had the reconcile disabled label, and the newMeta doesn't.
+			// This covers an edge case where the user only updates the reconcile label from disabled to enabled,
+			// which will trigger this func, but the generation won't change since it's a metadata-only update.
+			// We want to make sure this transition still triggers a reconciliation.
+			if !reconcileEnabledInUpdate(oldMeta, newMeta) {
+				dc.log.V(2).Info("Skipping update due to unchanged generation",
+					"name", newMeta.GetName(), "namespace", newMeta.GetNamespace(), "generation", newMeta.GetGeneration())
+				return
+			}
+		}
+	}
+
 	dc.enqueueParent(parentGVR, Event{
 		Type:      eventType,
 		GVR:       parentGVR,
-		Name:      mobj.GetName(),
-		Namespace: mobj.GetNamespace(),
+		Name:      newMeta.GetName(),
+		Namespace: newMeta.GetNamespace(),
 	})
+}
+
+func reconcileEnabledInUpdate(oldMeta, newMeta metav1.Object) bool {
+	oldLbls := oldMeta.GetLabels()
+	newLbls := newMeta.GetLabels()
+	oldIsDisabled := strings.EqualFold(oldLbls[metadata.InstanceReconcileLabel], "disabled")
+	newIsDisabled := strings.EqualFold(newLbls[metadata.InstanceReconcileLabel], "disabled")
+	return oldIsDisabled && !newIsDisabled
 }
 
 // Deregister removes a parent GVR handler and cleans up coordinator state.

--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -36,6 +36,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/requeue"
 )
 
@@ -560,6 +561,179 @@ func TestKeyFromGVR(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := keyFromGVR(tt.gvr)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEnqueueFromInformer_GenerationSkip(t *testing.T) {
+	parentGVR := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
+
+	makeObj := func(name, ns string, gen int64, labels map[string]string) *v1.PartialObjectMetadata {
+		obj := &v1.PartialObjectMetadata{}
+		obj.SetName(name)
+		obj.SetNamespace(ns)
+		obj.SetGeneration(gen)
+		obj.SetLabels(labels)
+		return obj
+	}
+
+	tests := []struct {
+		name        string
+		oldObj      *v1.PartialObjectMetadata
+		newObj      *v1.PartialObjectMetadata
+		expectQueue int
+	}{
+		{
+			name:        "generation changed — enqueues",
+			oldObj:      makeObj("a", "default", 1, nil),
+			newObj:      makeObj("a", "default", 2, nil),
+			expectQueue: 1,
+		},
+		{
+			name:        "same generation — skips",
+			oldObj:      makeObj("a", "default", 5, nil),
+			newObj:      makeObj("a", "default", 5, nil),
+			expectQueue: 0,
+		},
+		{
+			name:        "same generation but reconcile re-enabled — enqueues",
+			oldObj:      makeObj("a", "default", 5, map[string]string{metadata.InstanceReconcileLabel: "disabled"}),
+			newObj:      makeObj("a", "default", 5, nil),
+			expectQueue: 1,
+		},
+		{
+			name:        "same generation, reconcile stays disabled — skips",
+			oldObj:      makeObj("a", "default", 5, map[string]string{metadata.InstanceReconcileLabel: "disabled"}),
+			newObj:      makeObj("a", "default", 5, map[string]string{metadata.InstanceReconcileLabel: "disabled"}),
+			expectQueue: 0,
+		},
+		{
+			name:        "same generation, reconcile disabled on new only — skips",
+			oldObj:      makeObj("a", "default", 5, nil),
+			newObj:      makeObj("a", "default", 5, map[string]string{metadata.InstanceReconcileLabel: "disabled"}),
+			expectQueue: 0,
+		},
+		{
+			name:        "same generation, reconcile re-enabled case-insensitive — enqueues",
+			oldObj:      makeObj("a", "default", 5, map[string]string{metadata.InstanceReconcileLabel: "Disabled"}),
+			newObj:      makeObj("a", "default", 5, map[string]string{metadata.InstanceReconcileLabel: "true"}),
+			expectQueue: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, v1.AddMetaToScheme(scheme))
+			client := fake.NewSimpleMetadataClient(scheme)
+			mapper := meta.NewDefaultRESTMapper(scheme.PreferredVersionAllGroups())
+
+			dc := NewDynamicController(noopLogger(), testConfig(), client, mapper)
+			dc.enqueueFromInformer(parentGVR, tt.oldObj, tt.newObj, EventUpdate)
+			assert.Equal(t, tt.expectQueue, dc.queue.Len())
+		})
+	}
+}
+
+func TestEnqueueFromInformer_AddAndDelete(t *testing.T) {
+	// Add and Delete pass nil for oldObject — generation skip is bypassed,
+	// so these events should always enqueue.
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1.AddMetaToScheme(scheme))
+	client := fake.NewSimpleMetadataClient(scheme)
+	mapper := meta.NewDefaultRESTMapper(scheme.PreferredVersionAllGroups())
+
+	parentGVR := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
+	dc := NewDynamicController(noopLogger(), testConfig(), client, mapper)
+
+	obj := &v1.PartialObjectMetadata{}
+	obj.SetName("a")
+	obj.SetNamespace("default")
+	obj.SetGeneration(1)
+
+	// AddFunc passes nil as oldObject — should enqueue
+	dc.enqueueFromInformer(parentGVR, nil, obj, EventAdd)
+	assert.Equal(t, 1, dc.queue.Len(), "Add events should be enqueued")
+
+	// Drain
+	item, _ := dc.queue.Get()
+	dc.queue.Done(item)
+	dc.queue.Forget(item)
+
+	// DeleteFunc passes nil as oldObject — should enqueue
+	dc.enqueueFromInformer(parentGVR, nil, obj, EventDelete)
+	assert.Equal(t, 1, dc.queue.Len(), "Delete events should be enqueued")
+}
+
+func TestEnqueueFromInformer_NilNewObject(t *testing.T) {
+	// If newObject is nil, meta.Accessor fails and we return early.
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1.AddMetaToScheme(scheme))
+	client := fake.NewSimpleMetadataClient(scheme)
+	mapper := meta.NewDefaultRESTMapper(scheme.PreferredVersionAllGroups())
+
+	parentGVR := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
+	dc := NewDynamicController(noopLogger(), testConfig(), client, mapper)
+
+	dc.enqueueFromInformer(parentGVR, nil, nil, EventDelete)
+	assert.Equal(t, 0, dc.queue.Len(), "nil newObject should cause early return")
+}
+
+func TestReconcileEnabledInUpdate(t *testing.T) {
+	makeObj := func(labels map[string]string) *v1.PartialObjectMetadata {
+		obj := &v1.PartialObjectMetadata{}
+		obj.SetLabels(labels)
+		return obj
+	}
+
+	tests := []struct {
+		name   string
+		old    map[string]string
+		new    map[string]string
+		expect bool
+	}{
+		{
+			name:   "disabled -> enabled (label removed)",
+			old:    map[string]string{metadata.InstanceReconcileLabel: "disabled"},
+			new:    nil,
+			expect: true,
+		},
+		{
+			name:   "disabled -> enabled (label changed)",
+			old:    map[string]string{metadata.InstanceReconcileLabel: "disabled"},
+			new:    map[string]string{metadata.InstanceReconcileLabel: "enabled"},
+			expect: true,
+		},
+		{
+			name:   "disabled -> disabled",
+			old:    map[string]string{metadata.InstanceReconcileLabel: "disabled"},
+			new:    map[string]string{metadata.InstanceReconcileLabel: "disabled"},
+			expect: false,
+		},
+		{
+			name:   "enabled -> disabled",
+			old:    nil,
+			new:    map[string]string{metadata.InstanceReconcileLabel: "disabled"},
+			expect: false,
+		},
+		{
+			name:   "no labels on either",
+			old:    nil,
+			new:    nil,
+			expect: false,
+		},
+		{
+			name:   "case insensitive disabled",
+			old:    map[string]string{metadata.InstanceReconcileLabel: "DISABLED"},
+			new:    map[string]string{metadata.InstanceReconcileLabel: "true"},
+			expect: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := reconcileEnabledInUpdate(makeObj(tt.old), makeObj(tt.new))
+			assert.Equal(t, tt.expect, result)
 		})
 	}
 }


### PR DESCRIPTION
Add back generation-based filtering to enqueueFromInformer so that parent update events where only metadata (e.g. status, labels) changed do not trigger unnecessary reconciliations. An exception is made when the reconcile-disabled label is removed, ensuring that re-enabling reconciliation still triggers a sync even without a spec change.

Tests cover generation skip, reconcile label transitions (including case-insensitive matching), and nil-object safety paths.