### PR TITLE
fix(metadata): skip instance-namespace label for cluster-scoped instances

### DIFF
--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -485,7 +485,7 @@ func (c *Controller) applyDecoratorLabels(
 
 	// Merge tool labels from labeler. On conflict (duplicate keys), log and use
 	// instance labels only - this avoids panic from nil dereference.
-	instanceLabeler := metadata.NewInstanceLabeler(rcx.Instance)
+	instanceLabeler := metadata.NewInstanceLabeler(rcx.Instance, c.rgd.Instance.Meta.Namespaced)
 	nodeLabeler := metadata.NewNodeLabeler()
 	merged, err := instanceLabeler.Merge(nodeLabeler)
 	if err != nil {

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -165,16 +165,19 @@ func NewResourceGraphDefinitionLabeler(rgMeta metav1.Object) GenericLabeler {
 // and name of the instance that was reconciled to create the resource.
 // It also includes the instance's GVK to allow child
 // resource handlers to filter events by parent instance type.
-func NewInstanceLabeler(instance *unstructured.Unstructured) GenericLabeler {
+func NewInstanceLabeler(instance *unstructured.Unstructured, namespaced bool) GenericLabeler {
 	gvk := instance.GroupVersionKind()
-	return map[string]string{
-		InstanceIDLabel:        string(instance.GetUID()),
-		InstanceLabel:          instance.GetName(),
-		InstanceNamespaceLabel: instance.GetNamespace(),
-		InstanceGroupLabel:     gvk.Group,
-		InstanceVersionLabel:   gvk.Version,
-		InstanceKindLabel:      gvk.Kind,
+	labels := map[string]string{
+		InstanceIDLabel:      string(instance.GetUID()),
+		InstanceLabel:        instance.GetName(),
+		InstanceGroupLabel:   gvk.Group,
+		InstanceVersionLabel: gvk.Version,
+		InstanceKindLabel:    gvk.Kind,
 	}
+	if namespaced {
+		labels[InstanceNamespaceLabel] = instance.GetNamespace()
+	}
+	return labels
 }
 
 // NewNodeLabeler returns a new labeler for child resources

--- a/pkg/metadata/labels_test.go
+++ b/pkg/metadata/labels_test.go
@@ -256,7 +256,7 @@ func TestNewInstanceLabeler(t *testing.T) {
 			Kind:    kind,
 		})
 
-		labeler := NewInstanceLabeler(obj)
+		labeler := NewInstanceLabeler(obj, true)
 		assert.Equal(t, GenericLabeler{
 			InstanceLabel:          name,
 			InstanceNamespaceLabel: namespace,
@@ -264,6 +264,32 @@ func TestNewInstanceLabeler(t *testing.T) {
 			InstanceGroupLabel:     group,
 			InstanceVersionLabel:   version,
 			InstanceKindLabel:      kind,
+		}, labeler)
+	})
+
+	t.Run("NewInstanceLabeler_ClusterScoped", func(t *testing.T) {
+		name := "instance-name"
+		uid := types.UID("instance-uid")
+		group := "apps.example.com"
+		version := "v1"
+		kind := "MyApp"
+
+		obj := &unstructured.Unstructured{}
+		obj.SetName(name)
+		obj.SetUID(uid)
+		obj.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   group,
+			Version: version,
+			Kind:    kind,
+		})
+
+		labeler := NewInstanceLabeler(obj, false)
+		assert.Equal(t, GenericLabeler{
+			InstanceLabel:        name,
+			InstanceIDLabel:      string(uid),
+			InstanceGroupLabel:   group,
+			InstanceVersionLabel: version,
+			InstanceKindLabel:    kind,
 		}, labeler)
 	})
 }

--- a/test/integration/suites/core/instance_cluster_scoped_test.go
+++ b/test/integration/suites/core/instance_cluster_scoped_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
 )
 
@@ -221,6 +222,10 @@ var _ = Describe("ClusterScopedInstance", func() {
 			g.Expect(policyCM.Data["setting"]).To(Equal("enabled"))
 		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
+		By("verifying cluster-scoped instance child does NOT have instance-namespace label")
+		Expect(policyCM.GetLabels()).ToNot(HaveKey(metadata.InstanceNamespaceLabel),
+			"cluster-scoped instance child should not have instance-namespace label")
+
 		By("verifying collection resources were created in the target namespace")
 		for _, val := range []string{"dev", "staging"} {
 			cm := &corev1.ConfigMap{}
@@ -232,6 +237,18 @@ var _ = Describe("ClusterScopedInstance", func() {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(cm.Data["env"]).To(Equal(val))
 			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+		}
+
+		By("verifying collection children also lack instance-namespace label")
+		for _, val := range []string{"dev", "staging"} {
+			cm := &corev1.ConfigMap{}
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      fmt.Sprintf("%s-env-%s", instanceName, val),
+				Namespace: namespace,
+			}, cm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cm.GetLabels()).ToNot(HaveKey(metadata.InstanceNamespaceLabel),
+				"cluster-scoped instance collection child should not have instance-namespace label")
 		}
 
 		By("deleting the cluster-scoped instance")


### PR DESCRIPTION
Cluster-scoped instances have no namespace, so stamping an empty kro.run/instance-namespace label on child resources is misleading. Make `NewInstanceLabeler` scope-aware: only set the label when the instance CRD is namespace-scoped.