### PR TITLE
fix(cel): handle `oneOf` string|number schemas in `UnstructuredToVal`

### DIFF
--- a/pkg/cel/unstructured/valunstructured.go
+++ b/pkg/cel/unstructured/valunstructured.go
@@ -193,11 +193,30 @@ func UnstructuredToVal(unstructured interface{}, schema common.Schema) ref.Val {
 	}
 
 	if schema.IsXPreserveUnknownFields() {
-		// Adjusted so KRO gives access to unknown fields best effort
+		// kro divergence: gives access to unknown fields best effort
+		return types.DefaultTypeAdapter.NativeToValue(unstructured)
+	}
+
+	// kro divergence: resource.Quantity in OpenAPI v3 has no top-level type,
+	// just oneOf: [{type: string}, {type: number}]. The x-kubernetes-int-or-string
+	// extension is absent. Detect this pattern and let NativeToValue handle it.
+	if schema.Type() == "" && isOneOfStringNumber(schema) {
 		return types.DefaultTypeAdapter.NativeToValue(unstructured)
 	}
 
 	return types.NewErr("invalid type, expected object, array, number, integer, boolean or string, or no type with x-kubernetes-int-or-string or x-kubernetes-preserve-unknown-fields is true, got %s", schema.Type())
+}
+
+// isOneOfStringNumber returns true if the schema has exactly oneOf with
+// "string" and "number" variants. This is how resource.Quantity appears
+// in OpenAPI v3 schemas discovered from the cluster.
+func isOneOfStringNumber(schema common.Schema) bool {
+	oneOf := schema.OneOf()
+	if len(oneOf) != 2 {
+		return false
+	}
+	has := map[string]bool{oneOf[0].Type(): true, oneOf[1].Type(): true}
+	return has["string"] && has["number"]
 }
 
 // unstructuredMapList represents an unstructured data instance of an OpenAPI array with x-kubernetes-list-type=map.

--- a/pkg/cel/unstructured/valunstructured_test.go
+++ b/pkg/cel/unstructured/valunstructured_test.go
@@ -28,8 +28,11 @@ import (
 	"github.com/google/cel-go/common/types/traits"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	rtschema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/cel/openapi"
 	"k8s.io/kube-openapi/pkg/validation/spec"
+
+	testk8s "github.com/kubernetes-sigs/kro/pkg/testutil/k8s"
 )
 
 func schema(typ string) *openapi.Schema {
@@ -1274,4 +1277,79 @@ func TestCELExpressionEvaluation(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, types.False, out)
 	})
+}
+
+func TestUnstructuredToVal_OneOfStringNumber(t *testing.T) {
+	resolver, _ := testk8s.NewFakeResolver()
+	rqSpec, err := resolver.ResolveSchema(rtschema.GroupVersionKind{Version: "v1", Kind: "ResourceQuota"})
+	require.NoError(t, err)
+
+	// Extract the Quantity schema from ResourceQuota.spec.hard.additionalProperties.
+	quantitySpec := rqSpec.Properties["spec"].Properties["hard"].AdditionalProperties.Schema
+	s := &openapi.Schema{Schema: quantitySpec}
+
+	tests := []struct {
+		name  string
+		input interface{}
+		want  ref.Val
+	}{
+		{"string quantity", "500m", types.String("500m")},
+		{"string quantity gi", "128Mi", types.String("128Mi")},
+		{"float64 from json", float64(1.5), types.Double(1.5)},
+		{"int64", int64(4), types.Int(4)},
+		{"whole number float", float64(100), types.Double(100)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val := UnstructuredToVal(tt.input, s)
+			assert.False(t, types.IsError(val), "should not error: %v", val)
+			assert.Equal(t, tt.want, val)
+		})
+	}
+}
+
+func TestCELExpressionEvaluation_ResourceQuotaQuantities(t *testing.T) {
+	resolver, _ := testk8s.NewFakeResolver()
+	rqSpec, err := resolver.ResolveSchema(rtschema.GroupVersionKind{Version: "v1", Kind: "ResourceQuota"})
+	require.NoError(t, err)
+	rqSchema := &openapi.Schema{Schema: rqSpec}
+
+	data := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name":      "team-alpha",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"hard": map[string]interface{}{
+				"requests.cpu":    "4",
+				"requests.memory": "8Gi",
+				"limits.cpu":      "8",
+				"limits.memory":   "16Gi",
+			},
+		},
+	}
+
+	vars := map[string]typedValue{
+		"rq": {value: data, schema: rqSchema},
+	}
+
+	tests := []struct {
+		name string
+		expr string
+		want ref.Val
+	}{
+		{"access name", "rq.metadata.name == 'team-alpha'", types.True},
+		{"access cpu quantity", "rq.spec.hard['requests.cpu'] == '4'", types.True},
+		{"access memory quantity", "rq.spec.hard['limits.memory'] == '16Gi'", types.True},
+		{"key exists", "'requests.cpu' in rq.spec.hard", types.True},
+		{"key missing", "'requests.gpu' in rq.spec.hard", types.False},
+		{"map size", "size(rq.spec.hard) == 4", types.True},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := evalCEL(t, tt.expr, vars)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, out)
+		})
+	}
 }

--- a/pkg/testutil/k8s/discovery.go
+++ b/pkg/testutil/k8s/discovery.go
@@ -327,6 +327,33 @@ func NewFakeResolver() (*FakeResolver, *fake.FakeDiscovery) {
 			},
 		},
 		// v1 resources
+		{Version: "v1", Kind: "ResourceQuota"}: {
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					"metadata":   metadataSchema(),
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"hard": resourceListSchema(),
+							},
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"hard": resourceListSchema(),
+								"used": resourceListSchema(),
+							},
+						},
+					},
+				},
+			},
+		},
 		{Version: "v1", Kind: "Pod"}: {
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
@@ -550,6 +577,12 @@ func NewFakeResolver() (*FakeResolver, *fake.FakeDiscovery) {
 					Kind:       "ConfigMap",
 					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 				},
+				{
+					Name:       "resourcequotas",
+					Namespaced: true,
+					Kind:       "ResourceQuota",
+					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
 			},
 		},
 		// CRD
@@ -567,6 +600,34 @@ func NewFakeResolver() (*FakeResolver, *fake.FakeDiscovery) {
 	}
 
 	return &FakeResolver{schemas: schemas}, fakeDiscovery
+}
+
+// quantitySchema returns the OpenAPI v3 representation of resource.Quantity
+// as served by the Kubernetes API server: oneOf string|number with no
+// top-level type and no x-kubernetes-int-or-string extension.
+func quantitySchema() spec.Schema {
+	return spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			OneOf: []spec.Schema{
+				{SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+				{SchemaProps: spec.SchemaProps{Type: []string{"number"}}},
+			},
+		},
+	}
+}
+
+// resourceListSchema returns a map[string]Quantity schema (e.g. ResourceQuota.spec.hard).
+func resourceListSchema() spec.Schema {
+	qs := quantitySchema()
+	return spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: []string{"object"},
+			AdditionalProperties: &spec.SchemaOrBool{
+				Allows: true,
+				Schema: &qs,
+			},
+		},
+	}
 }
 
 // Helper to create AWS tags schema


### PR DESCRIPTION
`resource.Quantity` in OpenAPI v3 is represented as
`oneOf: [{type: string}, {type: number}]` with no top level type and no
`x-kubernetes-int-or-string` extension. This caused `UnstructuredToVal` to
error when evaluating CEL expressions against resources with `Quantity`
fields (e.g `ResourceQuota.spec.hard`)

Detect the `oneOf` string|number pattern and delegate to `NativeToValue`
Add `ResourceQuota` with `Quantity` schema to the fake resolver.