### PR TITLE
make instance requeue interval configurable

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -73,6 +73,7 @@ func main() {
 		rateLimit     int
 		burstLimit    int
 		// reconciler parameters
+		instanceRequeueInterval time.Duration
 		resyncPeriod            int
 		queueMaxRetries         int
 		gracefulShutdownTimeout time.Duration
@@ -126,6 +127,8 @@ func main() {
 		"Burst size of events for the dynamic controller rate limiter.")
 
 	// reconciler parameters
+	flag.DurationVar(&instanceRequeueInterval, "instance-requeue-interval", 3*time.Second,
+		"Fixed delay between delayed instance requeues while waiting for cluster state to settle.")
 	flag.IntVar(&resyncPeriod, "dynamic-controller-default-resync-period", 36000,
 		"interval at which the controller will re list resources even with no changes, in seconds.")
 	flag.IntVar(&queueMaxRetries, "dynamic-controller-default-queue-max-retries", 20,
@@ -232,6 +235,7 @@ func main() {
 		allowCRDDeletion,
 		dc,
 		resourceGraphDefinitionGraphBuilder,
+		instanceRequeueInterval,
 		resourceGraphDefinitionConcurrentReconciles,
 		graph.RGDConfig{
 			MaxCollectionSize:          rgdMaxCollectionSize,

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -71,6 +71,8 @@ spec:
               value: {{ .Values.config.dynamicControllerDefaultQueueMaxRetries | quote }}
             - name: KRO_GRACEFUL_SHUTDOWN_TIMEOUT
               value: {{ .Values.config.gracefulShutdownTimeout | quote }}
+            - name: KRO_INSTANCE_REQUEUE_INTERVAL
+              value: {{ .Values.config.instance.requeueInterval | quote }}
             - name: KRO_CLIENT_QPS
               value: {{ .Values.config.clientQps | quote }}
             - name: KRO_CLIENT_BURST
@@ -95,6 +97,8 @@ spec:
             - "$(KRO_LOG_LEVEL)"
             - --graceful-shutdown-timeout
             - "$(KRO_GRACEFUL_SHUTDOWN_TIMEOUT)"
+            - --instance-requeue-interval
+            - "$(KRO_INSTANCE_REQUEUE_INTERVAL)"
             - --dynamic-controller-default-resync-period
             - "$(KRO_DYNAMIC_CONTROLLER_DEFAULT_RESYNC_PERIOD)"
             - --dynamic-controller-default-queue-max-retries

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -151,6 +151,10 @@ config:
     maxCollectionSize: 1000
     # Maximum size of collection dimension per forEach defined in ResourceGraphDefinitions
     maxCollectionDimensionSize: 10
+  instance:
+    # The fixed delay between delayed instance requeues while waiting for cluster state to settle.
+    # Set to 0 to disable delayed requeues.
+    requeueInterval: 3s
 
 metrics:
   service:

--- a/pkg/controller/instance/context.go
+++ b/pkg/controller/instance/context.go
@@ -86,6 +86,9 @@ func NewReconcileContext(
 }
 
 func (rcx *ReconcileContext) delayedRequeue(err error) error {
+	if rcx.Config.DefaultRequeueDuration == 0 {
+		return requeue.None(err)
+	}
 	return requeue.NeededAfter(err, rcx.Config.DefaultRequeueDuration)
 }
 

--- a/pkg/controller/instance/context_test.go
+++ b/pkg/controller/instance/context_test.go
@@ -41,6 +41,11 @@ func TestContextHelpersAndStateTransitions(t *testing.T) {
 	require.ErrorAs(t, delayed, &retryAfter)
 	assert.Equal(t, 2*time.Second, retryAfter.Duration())
 
+	rcx.Config.DefaultRequeueDuration = 0
+	noRequeue := rcx.delayedRequeue(errors.New("do not retry"))
+	var noRequeueErr *requeue.NoRequeue
+	require.ErrorAs(t, noRequeue, &noRequeueErr)
+
 	clusterScoped := newClusterScopedInstanceObject("cluster-demo")
 	_, clusterRCX, raw := newControllerAndContext(t, clusterScoped, newTestGraph())
 	_, err := clusterRCX.InstanceClient().Get(context.Background(), clusterScoped.GetName(), metav1.GetOptions{})

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -44,8 +44,9 @@ const FieldManagerForLabeler = "kro.run/labeller"
 // ReconcileConfig holds configuration parameters for the reconciliation process.
 // It allows the customization of various aspects of the controller's behavior.
 type ReconcileConfig struct {
-	// DefaultRequeueDuration is the default duration to wait before requeuing a
-	// a reconciliation if no specific requeue time is set.
+	// DefaultRequeueDuration is the fixed delay used when the instance
+	// reconciler needs to retry after transient cluster state changes.
+	// Set to 0 to disable delayed requeues.
 	DefaultRequeueDuration time.Duration
 	// DeletionGraceTimeDuration is the duration to wait after initializing a resource
 	// deletion before considering it failed

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -59,6 +59,7 @@ type ResourceGraphDefinitionReconciler struct {
 	metadataLabeler         metadata.Labeler
 	rgBuilder               resourceGraphBuilder
 	dynamicController       *dynamiccontroller.DynamicController
+	instanceRequeueInterval time.Duration
 	maxConcurrentReconciles int
 	rgdConfig               graph.RGDConfig
 }
@@ -68,6 +69,7 @@ func NewResourceGraphDefinitionReconciler(
 	allowCRDDeletion bool,
 	dynamicController *dynamiccontroller.DynamicController,
 	builder *graph.Builder,
+	instanceRequeueInterval time.Duration,
 	maxConcurrentReconciles int,
 	rgdConfig graph.RGDConfig,
 ) *ResourceGraphDefinitionReconciler {
@@ -78,6 +80,7 @@ func NewResourceGraphDefinitionReconciler(
 		allowCRDDeletion:        allowCRDDeletion,
 		crdManager:              crdWrapper,
 		dynamicController:       dynamicController,
+		instanceRequeueInterval: instanceRequeueInterval,
 		metadataLabeler:         metadata.NewKROMetaLabeler(),
 		rgBuilder:               builder,
 		maxConcurrentReconciles: maxConcurrentReconciles,

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile.go
@@ -100,7 +100,7 @@ func (r *ResourceGraphDefinitionReconciler) setupMicroController(
 	return instancectrl.NewController(
 		instanceLogger,
 		instancectrl.ReconcileConfig{
-			DefaultRequeueDuration:    3 * time.Second,
+			DefaultRequeueDuration:    r.instanceRequeueInterval,
 			DeletionGraceTimeDuration: 30 * time.Second,
 			DeletionPolicy:            "Delete",
 			RGDConfig:                 r.rgdConfig,

--- a/pkg/controller/resourcegraphdefinition/controller_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_test.go
@@ -471,6 +471,7 @@ func TestNewResourceGraphDefinitionReconciler(t *testing.T) {
 		true,
 		nil,
 		nil,
+		9*time.Second,
 		7,
 		graph.RGDConfig{MaxCollectionSize: 32},
 	)
@@ -478,9 +479,25 @@ func TestNewResourceGraphDefinitionReconciler(t *testing.T) {
 	require.NotNil(t, r)
 	assert.True(t, r.allowCRDDeletion)
 	assert.NotNil(t, r.crdManager)
+	assert.Equal(t, 9*time.Second, r.instanceRequeueInterval)
 	assert.Equal(t, 7, r.maxConcurrentReconciles)
 	assert.Equal(t, graph.RGDConfig{MaxCollectionSize: 32}, r.rgdConfig)
 	assert.Equal(t, metadata.NewKROMetaLabeler().Labels(), r.metadataLabeler.Labels())
+}
+
+func TestNewResourceGraphDefinitionReconcilerPreservesZeroInstanceRequeueInterval(t *testing.T) {
+	r := NewResourceGraphDefinitionReconciler(
+		newKROFakeSet(),
+		true,
+		nil,
+		nil,
+		0,
+		7,
+		graph.RGDConfig{},
+	)
+
+	require.NotNil(t, r)
+	assert.Zero(t, r.instanceRequeueInterval)
 }
 
 func TestFindRGDsForCRD(t *testing.T) {
@@ -626,7 +643,7 @@ func TestSetupWithManager(t *testing.T) {
 				addErr:            tt.addErr,
 			}
 
-			reconciler := NewResourceGraphDefinitionReconciler(fakeSet, true, newRunningDynamicController(t), nil, 3, graph.RGDConfig{})
+			reconciler := NewResourceGraphDefinitionReconciler(fakeSet, true, newRunningDynamicController(t), nil, 5*time.Second, 3, graph.RGDConfig{})
 			reconciler.rgBuilder = newTestBuilder()
 			reconciler.crdManager = &stubCRDManager{}
 			err := reconciler.SetupWithManager(mgr)

--- a/test/integration/environment/setup.go
+++ b/test/integration/environment/setup.go
@@ -174,6 +174,7 @@ func (e *Environment) setupController() error {
 		e.ControllerConfig.AllowCRDDeletion,
 		dc,
 		e.GraphBuilder,
+		e.ControllerConfig.ReconcileConfig.DefaultRequeueDuration,
 		40,
 		graph.RGDConfig{
 			MaxCollectionSize:          1000,

--- a/test/integration/suites/ackekscluster/suite_test.go
+++ b/test/integration/suites/ackekscluster/suite_test.go
@@ -47,7 +47,7 @@ func TestEKSCluster(t *testing.T) {
 				AllowCRDDeletion: true,
 				LogWriter:        GinkgoWriter,
 				ReconcileConfig: ctrlinstance.ReconcileConfig{
-					DefaultRequeueDuration: 15 * time.Second,
+					DefaultRequeueDuration: 3 * time.Second,
 				},
 			},
 		)

--- a/test/integration/suites/deploymentservice/suite_test.go
+++ b/test/integration/suites/deploymentservice/suite_test.go
@@ -47,7 +47,7 @@ func TestDeploymentservice(t *testing.T) {
 			environment.ControllerConfig{
 				AllowCRDDeletion: true,
 				ReconcileConfig: ctrlinstance.ReconcileConfig{
-					DefaultRequeueDuration: 15 * time.Second,
+					DefaultRequeueDuration: 3 * time.Second,
 				},
 			},
 		)

--- a/test/integration/suites/networkingstack/suite_test.go
+++ b/test/integration/suites/networkingstack/suite_test.go
@@ -45,7 +45,7 @@ func TestNetworkingStack(t *testing.T) {
 			environment.ControllerConfig{
 				AllowCRDDeletion: true,
 				ReconcileConfig: ctrlinstance.ReconcileConfig{
-					DefaultRequeueDuration: 15 * time.Second,
+					DefaultRequeueDuration: 3 * time.Second,
 				},
 			},
 		)

--- a/website/docs/docs/advanced/03-controller-tuning.md
+++ b/website/docs/docs/advanced/03-controller-tuning.md
@@ -89,6 +89,14 @@ More workers increase throughput but also increase concurrent API server load.
 
 The resync period triggers reconciliation for all resources periodically, even without changes. This catches any drift that might have been missed.
 
+### Instance Requeues
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `config.instance.requeueInterval` | `3s` | Fixed delay for delayed instance requeues when kro is waiting for resources, readiness, or deletion to settle. Set to `0` to disable delayed requeues |
+
+This setting is also available as the `--instance-requeue-interval` flag.
+
 ### Rate Limiting
 
 The queue uses a combined rate limiter with two strategies:


### PR DESCRIPTION
The delayed requeue duration used when the instance reconciler waits
for cluster state to settle was hardcoded to 3s. Extract it into an
`--instance-requeue-interval` flag (default unchanged) and thread it
from main through the RGD controller into `instance.ReconcileConfig`

Setting the interval to 0 disables delayed requeues entirely -
delayedRequeue returns `requeue.None` instead of `requeue.NeededAfter`
Helm values use `config.instance.requeueInterval` rather than a flat
key to avoid a breaking rename when more instance knobs are added