### PR TITLE
feat(graph): gate omit() behind CELOmitFunction feature flag

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -24,6 +24,13 @@ const (
 	// enabled, every condition change is surfaced as an Event on the instance
 	// object, visible via `kubectl describe`.
 	InstanceConditionEvents featuregate.Feature = "InstanceConditionEvents"
+
+	// CELOmitFunction enables the omit() CEL function for conditional field
+	// omission in resource templates. When enabled, CEL expressions can return
+	// omit() to remove the containing field from the rendered object instead
+	// of writing a value. When disabled, any use of omit() in an RGD is
+	// rejected at build time.
+	CELOmitFunction featuregate.Feature = "CELOmitFunction"
 )
 
 // defaultKroFeatureGates consists of all known KRO-specific feature keys.
@@ -31,6 +38,7 @@ const (
 // its default state and maturity stage (Alpha, Beta, or GA).
 var defaultKroFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	InstanceConditionEvents: {Default: false, PreRelease: featuregate.Alpha},
+	CELOmitFunction:         {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // FeatureGate is the shared global MutableFeatureGate for KRO.

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -27,6 +27,8 @@ import (
 func TestDefaultFeatureGatesAreDisabled(t *testing.T) {
 	assert.False(t, FeatureGate.Enabled(InstanceConditionEvents),
 		"InstanceConditionEvents should be disabled by default (Alpha)")
+	assert.False(t, FeatureGate.Enabled(CELOmitFunction),
+		"CELOmitFunction should be disabled by default (Alpha)")
 }
 
 // TestEnableFeatureViaSet verifies that a feature can be enabled by calling
@@ -64,4 +66,5 @@ func TestKnownFeaturesContainsAllRegistered(t *testing.T) {
 	knownStr := strings.Join(known, " ")
 
 	assert.Contains(t, knownStr, string(InstanceConditionEvents))
+	assert.Contains(t, knownStr, string(CELOmitFunction))
 }

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kubernetes-sigs/kro/pkg/cel/ast"
 	celcache "github.com/kubernetes-sigs/kro/pkg/cel/cache"
 	"github.com/kubernetes-sigs/kro/pkg/cel/conversion"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/pkg/graph/crd"
 	"github.com/kubernetes-sigs/kro/pkg/graph/dag"
 	"github.com/kubernetes-sigs/kro/pkg/graph/fieldpath"
@@ -255,8 +256,12 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 	}
 
 	// Validate that omit() is not used on resource identity fields.
-	if err := validateIdentityFields(nodes, inspector, instanceNamespaced); err != nil {
-		return nil, err
+	// Only needed when omit() is enabled — if the gate is off, the builder
+	// already rejects any omit() usage in extractDependencies.
+	if features.FeatureGate.Enabled(features.CELOmitFunction) {
+		if err := validateIdentityFields(nodes, inspector, instanceNamespaced); err != nil {
+			return nil, err
+		}
 	}
 
 	// Collect all schemas for CEL validation:
@@ -889,6 +894,10 @@ func extractDependencies(inspector *ast.Inspector, expr *krocel.Expression, iter
 	inspectionResult, err := inspector.Inspect(expr.Original)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to inspect expression: %w", err)
+	}
+
+	if !features.FeatureGate.Enabled(features.CELOmitFunction) && inspectionResult.UsesOmit() {
+		return nil, nil, fmt.Errorf("omit() requires the CELOmitFunction feature gate to be enabled")
 	}
 
 	// Populate expression references

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -16,6 +16,7 @@ package graph
 
 import (
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/google/cel-go/cel"
@@ -35,11 +36,29 @@ import (
 	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 	"github.com/kubernetes-sigs/kro/pkg/cel/ast"
 	celcache "github.com/kubernetes-sigs/kro/pkg/cel/cache"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/pkg/graph/fieldpath"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
 	"github.com/kubernetes-sigs/kro/pkg/testutil/k8s"
 )
+
+func TestMain(m *testing.M) {
+	// Enable CELOmitFunction by default for all graph package tests.
+	// Tests that verify gate-off behavior disable it locally.
+	_ = features.FeatureGate.Set("CELOmitFunction=true")
+	os.Exit(m.Run())
+}
+
+// disableOmitFeatureGate disables the CELOmitFunction feature gate for the
+// duration of the test and restores it on cleanup.
+func disableOmitFeatureGate(t *testing.T) {
+	t.Helper()
+	require.NoError(t, features.FeatureGate.Set("CELOmitFunction=false"))
+	t.Cleanup(func() {
+		require.NoError(t, features.FeatureGate.Set("CELOmitFunction=true"))
+	})
+}
 
 var defaultRGDConfig = RGDConfig{MaxCollectionDimensionSize: 5}
 
@@ -4254,6 +4273,16 @@ func TestBuilderHelperCases(t *testing.T) {
 				deps, _, err := extractDependencies(inspector, expr("omit()"), nil)
 				require.NoError(t, err)
 				assert.Empty(t, deps)
+			},
+		},
+		{
+			name: "extractDependencies rejects omit when feature gate is disabled",
+			run: func(t *testing.T) {
+				disableOmitFeatureGate(t)
+				inspector := newUnitInspector(t, "schema")
+				_, _, err := extractDependencies(inspector, expr("omit()"), nil)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "CELOmitFunction feature gate")
 			},
 		},
 		{

--- a/test/integration/suites/core/setup_test.go
+++ b/test/integration/suites/core/setup_test.go
@@ -24,12 +24,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	ctrlinstance "github.com/kubernetes-sigs/kro/pkg/controller/instance"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
 var env *environment.Environment
 
 func TestCore(t *testing.T) {
+	// Enable alpha feature gates for integration test coverage.
+	if err := features.FeatureGate.Set("CELOmitFunction=true"); err != nil {
+		t.Fatalf("failed to enable CELOmitFunction feature gate: %v", err)
+	}
+
 	RegisterFailHandler(Fail)
 	BeforeSuite(func() {
 		var err error


### PR DESCRIPTION
`omit()` is new and not yet battle-tested. Shipping it behind an alpha
feature gate (default off) lets us iterate on semantics - especially
around identity-field validation — without committing to the behavior.

When the gate is off, extractDependencies rejects any CEL expression
that calls omit(), so the rejection happens early and the error is
clear. validateIdentityFields is only needed when omit() is live, so
it moves inside the gate check too.