### PR TITLE
feat(helm): expose feature gates in chart values

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -121,6 +121,14 @@ spec:
             - --enable-controller-warmup
             {{- end }}
             {{- end }}
+            {{- if .Values.config.featureGates }}
+            {{- $gates := list }}
+            {{- range $k, $v := .Values.config.featureGates }}
+            {{- $gates = append $gates (printf "%s=%t" $k $v) }}
+            {{- end }}
+            - --feature-gates
+            - {{ join "," $gates | quote }}
+            {{- end }}
             {{- if $pprofEnabled }}
             - --pprof-bind-address
             - ":{{ $pprofPort }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -155,6 +155,12 @@ config:
     # The fixed delay between delayed instance requeues while waiting for cluster state to settle.
     # Set to 0 to disable delayed requeues.
     requeueInterval: 3s
+  # Feature gates for alpha/experimental features.
+  # Each key is a feature gate name, each value is a boolean.
+  # Example:
+  #   featureGates:
+  #     CELOmitFunction: true
+  featureGates: {}
 
 metrics:
   service:


### PR DESCRIPTION
Adds `config.featureGates` as a map in `values.yaml` rendered into a
single `--feature-gates flag` on the controller args. Empty by default,
so existing deployments are unaffected.