### PR TITLE
docs: Fix formatting in the verify installation step (getting started…

### DIFF
--- a/website/docs/docs/getting-started/01-Installation.md
+++ b/website/docs/docs/getting-started/01-Installation.md
@@ -122,10 +122,6 @@ kro-7d98bc6f46-jvjl5   1/1     Running   0          30s
 ```
   </TabItem>
   <TabItem value="kubectl" label="Raw manifest installation">
-Check the Helm release:
-
-```bash
-
 Check the kro pod is running:
 
 ```bash


### PR DESCRIPTION
I noticed a small typo/formatting issue in the getting started guide where "Check the Helm release:" is also shown in the raw manifests tab -> simply removed that :) 

<img width="659" height="441" alt="image" src="https://github.com/user-attachments/assets/54b01cd0-08a2-4026-a710-ca71e15685e7" />

Link: https://kro.run/docs/getting-started/Installation#verify-installation
