### PR TITLE
harden `BuilderCache` stores and cache iterator environments

### DIFF
--- a/pkg/cel/cache/builder_cache.go
+++ b/pkg/cel/cache/builder_cache.go
@@ -53,7 +53,9 @@ func (c *BuilderCache) SchemaDeclType(schema *spec.Schema, create func(*spec.Sch
 	builderCacheMissesTotal.WithLabelValues("decl_type").Inc()
 	declType := create(schema)
 	if declType != nil {
-		c.declTypes.Store(schema, declType)
+		if actual, loaded := c.declTypes.LoadOrStore(schema, declType); loaded {
+			return actual.(*apiservercel.DeclType)
+		}
 		builderCacheSize.WithLabelValues("decl_type").Inc()
 	}
 	return declType
@@ -70,7 +72,9 @@ func (c *BuilderCache) MaybeAssignTypeName(schema *spec.Schema, declType *apiser
 	}
 	builderCacheMissesTotal.WithLabelValues("named_type").Inc()
 	named := declType.MaybeAssignTypeName(typeName)
-	c.namedTypes.Store(key, named)
+	if actual, loaded := c.namedTypes.LoadOrStore(key, named); loaded {
+		return actual.(*apiservercel.DeclType)
+	}
 	builderCacheSize.WithLabelValues("named_type").Inc()
 	return named
 }
@@ -90,9 +94,14 @@ func (c *BuilderCache) TypedEnvironmentWithProvider(schemas map[string]*spec.Sch
 		builderCacheMissesTotal.WithLabelValues("typed_env").Inc()
 		env, provider, err := create()
 		if err != nil {
+			builderCacheErrorsTotal.WithLabelValues("typed_env").Inc()
 			return nil, nil, err
 		}
-		c.typedEnvs.Store(key, &TypedEnvEntry{Env: env, Provider: provider})
+		entry := &TypedEnvEntry{Env: env, Provider: provider}
+		if actual, loaded := c.typedEnvs.LoadOrStore(key, entry); loaded {
+			cached := actual.(*TypedEnvEntry)
+			return cached.Env, cached.Provider, nil
+		}
 		builderCacheSize.WithLabelValues("typed_env").Inc()
 		return env, provider, nil
 	}
@@ -108,7 +117,9 @@ func (c *BuilderCache) FieldTypeMap(t *apiservercel.DeclType, create func() map[
 	}
 	builderCacheMissesTotal.WithLabelValues("field_type_map").Inc()
 	m := create()
-	c.fieldTypeMaps.Store(t, m)
+	if actual, loaded := c.fieldTypeMaps.LoadOrStore(t, m); loaded {
+		return actual.(map[string]*apiservercel.DeclType)
+	}
 	builderCacheSize.WithLabelValues("field_type_map").Inc()
 	return m
 }

--- a/pkg/cel/cache/cache_test.go
+++ b/pkg/cel/cache/cache_test.go
@@ -410,7 +410,7 @@ func TestSessionCache_ExtendWithTypedVar(t *testing.T) {
 	}
 }
 
-func TestSessionCache_ConcurrentAccess(t *testing.T) {
+func TestSessionCache_ParseCheckAndCompile_ConcurrentAccess(t *testing.T) {
 	cache := NewSessionCache()
 
 	env, err := cel.NewEnv(cel.Variable("x", cel.IntType))

--- a/pkg/cel/cache/keys.go
+++ b/pkg/cel/cache/keys.go
@@ -49,11 +49,39 @@ type extendedEnvCacheKey struct {
 	schema    *spec.Schema
 }
 
+// iteratorEnvCacheKey keys iterator-extended environments by (parent, varsKey).
+// varsKey is a canonical string encoding the iterator variable declarations.
+type iteratorEnvCacheKey struct {
+	parentEnv *cel.Env
+	varsKey   string
+}
+
 // TypedEnvEntry holds a cached (env, provider) pair.
 // Provider is stored as any to avoid importing pkg/cel (DeclTypeProvider).
 type TypedEnvEntry struct {
 	Env      *cel.Env
 	Provider any
+}
+
+// MakeIteratorVarsKey builds a canonical string key from iterator variable
+// names and their CEL type strings. Sorted by name for determinism.
+func MakeIteratorVarsKey(vars map[string]*cel.Type) string {
+	names := make([]string, 0, len(vars))
+	for name := range vars {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	for i, name := range names {
+		if i > 0 {
+			b.WriteByte(';')
+		}
+		b.WriteString(name)
+		b.WriteByte(':')
+		b.WriteString(vars[name].String())
+	}
+	return b.String()
 }
 
 // MakeEnvCacheKey builds a canonical string key from a schema map.

--- a/pkg/cel/cache/metrics.go
+++ b/pkg/cel/cache/metrics.go
@@ -44,6 +44,14 @@ var (
 		[]string{"cache_type"},
 	)
 
+	builderCacheErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cel_cache_builder_errors_total",
+			Help: "Total number of builder cache creation failures on miss",
+		},
+		[]string{"cache_type"},
+	)
+
 	// SessionCache metrics — short-lived, per-RGD-build cache.
 
 	sessionCacheHitsTotal = prometheus.NewCounterVec(
@@ -73,6 +81,7 @@ func init() {
 		builderCacheHitsTotal,
 		builderCacheMissesTotal,
 		builderCacheSize,
+		builderCacheErrorsTotal,
 		sessionCacheHitsTotal,
 		sessionCacheMissesTotal,
 		sessionCacheASTReuseTotal,

--- a/pkg/cel/cache/session_cache.go
+++ b/pkg/cel/cache/session_cache.go
@@ -34,6 +34,7 @@ type SessionCache struct {
 	checkedASTs  sync.Map // key: ProgramCacheKey, value: *cel.Ast
 	programs     sync.Map // key: ProgramCacheKey, value: *ProgramCacheEntry
 	extendedEnvs sync.Map // key: extendedEnvCacheKey, value: *cel.Env
+	iteratorEnvs sync.Map // key: iteratorEnvCacheKey, value: *cel.Env
 }
 
 // NewSessionCache returns a fresh SessionCache instance.
@@ -49,11 +50,9 @@ func (c *SessionCache) ParseAndCheck(env *cel.Env, expr string) (*cel.Ast, error
 	// Check if we already have a full program cached — reuse its AST.
 	if v, ok := c.programs.Load(key); ok {
 		sessionCacheHitsTotal.WithLabelValues("checked_ast").Inc()
-		entry := v.(*ProgramCacheEntry)
-		return entry.Ast, nil
+		return v.(*ProgramCacheEntry).Ast, nil
 	}
 
-	// Check the AST-only cache.
 	if v, ok := c.checkedASTs.Load(key); ok {
 		sessionCacheHitsTotal.WithLabelValues("checked_ast").Inc()
 		return v.(*cel.Ast), nil
@@ -77,9 +76,8 @@ func (c *SessionCache) ParseAndCheck(env *cel.Env, expr string) (*cel.Ast, error
 
 // ParseCheckAndCompile returns a cached compiled program and checked AST
 // for the given expression and environment. On cache miss, it parses,
-// type-checks, and compiles the expression, then stores the result.
-// If a checked AST was previously cached by ParseAndCheck, it is reused
-// to skip the parse and check phases.
+// type-checks, and compiles the expression. If a checked AST was
+// previously cached by ParseAndCheck, it is reused to skip parse+check.
 func (c *SessionCache) ParseCheckAndCompile(env *cel.Env, expr string) (cel.Program, *cel.Ast, error) {
 	key := ProgramCacheKey{Expr: expr, Env: env}
 	if v, ok := c.programs.Load(key); ok {
@@ -96,15 +94,10 @@ func (c *SessionCache) ParseCheckAndCompile(env *cel.Env, expr string) (cel.Prog
 		sessionCacheASTReuseTotal.Inc()
 		checkedAST = v.(*cel.Ast)
 	} else {
-		parsedAST, issues := env.Parse(expr)
-		if issues != nil && issues.Err() != nil {
-			return nil, nil, issues.Err()
-		}
-
-		var checkIssues *cel.Issues
-		checkedAST, checkIssues = env.Check(parsedAST)
-		if checkIssues != nil && checkIssues.Err() != nil {
-			return nil, nil, checkIssues.Err()
+		var err error
+		checkedAST, err = c.ParseAndCheck(env, expr)
+		if err != nil {
+			return nil, nil, err
 		}
 	}
 
@@ -117,10 +110,9 @@ func (c *SessionCache) ParseCheckAndCompile(env *cel.Env, expr string) (cel.Prog
 	return program, checkedAST, nil
 }
 
-// ExtendWithTypedVar returns a cached environment that extends the parent
+// ExtendWithTypedVar returns a cached environment extending the parent
 // with a single typed variable declaration derived from the given schema.
 // On cache miss, the create callback is called to build the extended env.
-// The callback pattern avoids importing pkg/cel (for DeclTypeProvider etc.).
 func (c *SessionCache) ExtendWithTypedVar(parent *cel.Env, varName string, schema *spec.Schema, create func() (*cel.Env, error)) (*cel.Env, error) {
 	key := extendedEnvCacheKey{parentEnv: parent, varName: varName, schema: schema}
 	if v, ok := c.extendedEnvs.Load(key); ok {
@@ -136,5 +128,26 @@ func (c *SessionCache) ExtendWithTypedVar(parent *cel.Env, varName string, schem
 	}
 
 	c.extendedEnvs.Store(key, extended)
+	return extended, nil
+}
+
+// ExtendWithVariables returns a cached environment that extends the parent
+// with variable declarations. The key is the parent env pointer plus a
+// canonical string built from the variable names and type strings.
+func (c *SessionCache) ExtendWithVariables(parent *cel.Env, varsKey string, create func() (*cel.Env, error)) (*cel.Env, error) {
+	key := iteratorEnvCacheKey{parentEnv: parent, varsKey: varsKey}
+	if v, ok := c.iteratorEnvs.Load(key); ok {
+		sessionCacheHitsTotal.WithLabelValues("iterator_env").Inc()
+		return v.(*cel.Env), nil
+	}
+
+	sessionCacheMissesTotal.WithLabelValues("iterator_env").Inc()
+
+	extended, err := create()
+	if err != nil {
+		return nil, err
+	}
+
+	c.iteratorEnvs.Store(key, extended)
 	return extended, nil
 }

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -1194,12 +1194,15 @@ func validateAndCompileTemplates(
 	// by validateIdentityFields earlier in the build pipeline.
 	compileEnv := env
 	if len(iteratorTypes) > 0 {
-		opts := make([]cel.EnvOption, 0, len(iteratorTypes))
-		for name, typ := range iteratorTypes {
-			opts = append(opts, cel.Variable(name, typ))
-		}
+		varsKey := celcache.MakeIteratorVarsKey(iteratorTypes)
 		var err error
-		compileEnv, err = env.Extend(opts...)
+		compileEnv, err = sessionCache.ExtendWithVariables(env, varsKey, func() (*cel.Env, error) {
+			opts := make([]cel.EnvOption, 0, len(iteratorTypes))
+			for name, typ := range iteratorTypes {
+				opts = append(opts, cel.Variable(name, typ))
+			}
+			return env.Extend(opts...)
+		})
 		if err != nil {
 			return fmt.Errorf("failed to extend CEL environment with iterator types: %w", err)
 		}

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -3956,7 +3956,7 @@ func TestBuildStatusSchema(t *testing.T) {
 			"replicas": {SchemaProps: spec.SchemaProps{Type: []string{"integer"}}},
 		}),
 	})
-	sessionCache := celcache.NewSessionCache()
+	statusSessionCache := celcache.NewSessionCache()
 	env, provider := newTypedEnvWithProvider(t, map[string]*spec.Schema{"resource": resourceSchema})
 	inspector := newUnitInspector(t, "resource")
 	tests := []struct {
@@ -3974,7 +3974,7 @@ func TestBuildStatusSchema(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			statusSchema, fieldDescriptors, _, err := buildStatusSchema(sessionCache, &krov1alpha1.Schema{
+			statusSchema, fieldDescriptors, _, err := buildStatusSchema(statusSessionCache, &krov1alpha1.Schema{
 				Status: rawExt(tt.statusRaw),
 			}, []string{"resource"}, inspector, env, provider)
 			if tt.wantErr != "" {


### PR DESCRIPTION
`BuilderCache` methods used plain `Store` on miss, so concurrent callers
could overwrite an entry another goroutine just stored - producing
duplicate objects for the same key. Switch all four methods to
`LoadOrStore` so the first writer wins.

`forEach` iterator environments were built fresh via `env.Extend()` on
every build. Add `ExtendWithVariables` to `SessionCache` keyed by
`(parent, varsKey)` where `varsKey` is a canonical encoding of iterator
variable names and types. This deduplicates within a single RGD build
when multiple nodes share the same forEach signature.