### PR TITLE
perf: removes the lock convoy during large RGD bursts

### DIFF
--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -345,9 +345,6 @@ func (dc *DynamicController) Register(
 	parent schema.GroupVersionResource,
 	instanceHandler Handler,
 ) error {
-	dc.mu.Lock()
-	defer dc.mu.Unlock()
-
 	ctx := dc.ctx.Load()
 	if ctx == nil {
 		return fmt.Errorf("dynamic controller not started")
@@ -356,8 +353,12 @@ func (dc *DynamicController) Register(
 	// Store handler.
 	dc.handlers.Store(parent, instanceHandler)
 
+	dc.mu.Lock()
+	_, exists := dc.parentWatches[parent]
+	dc.mu.Unlock()
+
 	// Create parent watch if it doesn't exist.
-	if _, exists := dc.parentWatches[parent]; !exists {
+	if !exists {
 		// Retain the shared informer for the parent and wait for cache sync.
 		if err := dc.watches.EnsureParentWatch(parent); err != nil {
 			dc.handlers.Delete(parent)
@@ -374,33 +375,41 @@ func (dc *DynamicController) Register(
 			return fmt.Errorf("add parent handler %s: informer not found after EnsureWatch", parent)
 		}
 
-		// Register event handler directly on the parent informer.
-		parentHandler := cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj any) {
-				dc.enqueueFromInformer(parent, nil, obj, EventAdd)
-			},
-			UpdateFunc: func(oldObj, newObj any) {
-				dc.enqueueFromInformer(parent, oldObj, newObj, EventUpdate)
-			},
-			DeleteFunc: func(obj any) {
-				dc.enqueueFromInformer(parent, nil, obj, EventDelete)
-			},
-		}
-		reg, err := inf.AddEventHandler(parentHandler)
-		if err != nil {
+		dc.mu.Lock()
+		if _, exists := dc.parentWatches[parent]; exists {
+			dc.mu.Unlock()
 			dc.watches.ReleaseParentWatch(parent)
-			if !dc.coordinator.HasRequestsForGVR(parent) {
-				dc.watches.StopWatch(parent)
+		} else {
+			// Register event handler directly on the parent informer.
+			parentHandler := cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj any) {
+					dc.enqueueFromInformer(parent, nil, obj, EventAdd)
+				},
+				UpdateFunc: func(oldObj, newObj any) {
+					dc.enqueueFromInformer(parent, oldObj, newObj, EventUpdate)
+				},
+				DeleteFunc: func(obj any) {
+					dc.enqueueFromInformer(parent, nil, obj, EventDelete)
+				},
 			}
-			dc.handlers.Delete(parent)
-			return fmt.Errorf("add parent handler %s: %w", parent, err)
-		}
-		dc.parentWatches[parent] = reg
+			reg, err := inf.AddEventHandler(parentHandler)
+			if err != nil {
+				dc.mu.Unlock()
+				dc.watches.ReleaseParentWatch(parent)
+				if !dc.coordinator.HasRequestsForGVR(parent) {
+					dc.watches.StopWatch(parent)
+				}
+				dc.handlers.Delete(parent)
+				return fmt.Errorf("add parent handler %s: %w", parent, err)
+			}
+			dc.parentWatches[parent] = reg
+			dc.mu.Unlock()
 
-		gvrCount.Inc()
-		handlerAttachTotal.WithLabelValues("parent").Inc()
-		handlerCount.WithLabelValues("parent").Inc()
-		dc.log.V(1).Info("Attached parent watch", "gvr", parent)
+			gvrCount.Inc()
+			handlerAttachTotal.WithLabelValues("parent").Inc()
+			handlerCount.WithLabelValues("parent").Inc()
+			dc.log.V(1).Info("Attached parent watch", "gvr", parent)
+		}
 	}
 
 	// Enqueue existing instances from parent cache.


### PR DESCRIPTION
removes the lock convoy during large RGD bursts where parent registration could
wait on informer startup and cache sync while holding `dc.mu` and inflate
reconcile latency across unrelated GVRs.

before this change:

<img width="715" height="308" alt="Screenshot 2026-03-21 at 12 38 45 AM" src="https://github.com/user-attachments/assets/5afb0e90-ab4b-45de-8fab-5328ee03ba34" />
<img width="719" height="305" alt="Screenshot 2026-03-21 at 12 40 34 AM" src="https://github.com/user-attachments/assets/e256051d-3ae7-485e-a6e0-c841a8ce0a4c" />
<img width="719" height="304" alt="Screenshot 2026-03-21 at 12 41 55 AM" src="https://github.com/user-attachments/assets/f804b9f8-6f2b-4865-9ed8-bc139454b31e" />



After this change:

<img width="728" height="319" alt="Screenshot 2026-03-21 at 12 39 26 AM" src="https://github.com/user-attachments/assets/ded84db6-15af-4c67-b5e6-c8a231fdb37c" />

<img width="718" height="306" alt="Screenshot 2026-03-21 at 12 40 04 AM" src="https://github.com/user-attachments/assets/78374f99-a236-4ab5-b2ad-84b7b96b52be" />

<img width="717" height="304" alt="Screenshot 2026-03-21 at 12 42 59 AM" src="https://github.com/user-attachments/assets/9dc9904b-ab8a-4a59-8b4e-1fe07a75cdf3" />


