### PR TITLE
fix(test): use unique labels to avoid cross-namespace collisions

### DIFF
--- a/test/integration/suites/core/externalref_test.go
+++ b/test/integration/suites/core/externalref_test.go
@@ -422,7 +422,7 @@ var _ = Describe("ExternalRef", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "config-alpha",
 				Namespace: namespace,
-				Labels:    map[string]string{"team": "alpha"},
+				Labels:    map[string]string{"empty-selector-test": "alpha"},
 			},
 			Data: map[string]string{"key": "value1"},
 		}
@@ -430,7 +430,7 @@ var _ = Describe("ExternalRef", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "config-beta",
 				Namespace: namespace,
-				Labels:    map[string]string{"team": "beta"},
+				Labels:    map[string]string{"empty-selector-test": "beta"},
 			},
 			Data: map[string]string{"key": "value2"},
 		}

--- a/test/integration/suites/core/externalref_watch_test.go
+++ b/test/integration/suites/core/externalref_watch_test.go
@@ -275,7 +275,7 @@ var _ = Describe("ExternalRef Watch", func() {
 				Metadata: krov1alpha1.ExternalRefMetadata{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"team": "alpha",
+							"watch-test": "reactive",
 						},
 					},
 				},
@@ -294,13 +294,13 @@ var _ = Describe("ExternalRef Watch", func() {
 			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
 		}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
-		By("creating first ConfigMap with label team=alpha")
+		By("creating first ConfigMap with label watch-test=reactive")
 		cm1 := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "alpha-config-1",
 				Namespace: namespace,
 				Labels: map[string]string{
-					"team": "alpha",
+					"watch-test": "reactive",
 				},
 			},
 			Data: map[string]string{"key": "value1"},
@@ -336,13 +336,13 @@ var _ = Describe("ExternalRef Watch", func() {
 			g.Expect(configCount).To(Equal("1"))
 		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
-		By("creating a second ConfigMap with label team=alpha")
+		By("creating a second ConfigMap with label watch-test=reactive")
 		cm2 := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "alpha-config-2",
 				Namespace: namespace,
 				Labels: map[string]string{
-					"team": "alpha",
+					"watch-test": "reactive",
 				},
 			},
 			Data: map[string]string{"key": "value2"},


### PR DESCRIPTION
After https://github.com/kubernetes-sigs/kro/commit/7345ec4952ff11d30a6ca019011bb4fb8543526b changed external collections with no namespace to list
across all namespaces, tests using common labels like `team: alpha` can
collide when stale ConfigMaps from a previous test's namespace haven't
been deleted yet.

Give each test a unique label key so cross-namespace LIST results are
never polluted by other tests:
- watch test: `watch-test: reactive`
- empty-selector test: `empty-selector-test: alpha/beta`