### PR TITLE
key typed env cache by schema structure instead of pointer address

### DIFF
--- a/pkg/cel/cache/cache_test.go
+++ b/pkg/cel/cache/cache_test.go
@@ -163,7 +163,33 @@ func TestBuilderCache_TypedEnvironmentWithProvider(t *testing.T) {
 		t.Errorf("expected create to not be called again, got %d calls", createCalls)
 	}
 
-	// Different schema pointer should produce different env
+	// Equivalent schema content with a different pointer should still hit cache.
+	schemaClone := &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: []string{"object"},
+			Properties: map[string]spec.Schema{
+				"name": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+			},
+		},
+	}
+	schemasClone := map[string]*spec.Schema{
+		"pod": schemaClone,
+	}
+	envClone, provClone, err := cache.TypedEnvironmentWithProvider(schemasClone, create)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if envClone != env1 {
+		t.Error("expected same env for equivalent schema content")
+	}
+	if provClone != prov1 {
+		t.Error("expected same provider for equivalent schema content")
+	}
+	if createCalls != 1 {
+		t.Errorf("expected create to not be called again, got %d calls", createCalls)
+	}
+
+	// Different schema content should produce different env.
 	schema2 := &spec.Schema{
 		SchemaProps: spec.SchemaProps{
 			Type: []string{"object"},
@@ -229,10 +255,16 @@ func TestBuilderCache_FieldTypeMap(t *testing.T) {
 }
 
 func TestMakeEnvCacheKey(t *testing.T) {
-	s1 := &spec.Schema{}
-	s2 := &spec.Schema{}
+	s1 := &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"object"}}}
+	s1Clone := &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type:        []string{"object"},
+			Description: "ignored for CEL typing",
+		},
+	}
+	s2 := &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}}}
 
-	// Same map should produce same key
+	// Same logical map should produce the same key regardless of iteration order.
 	m1 := map[string]*spec.Schema{"a": s1, "b": s2}
 	m2 := map[string]*spec.Schema{"b": s2, "a": s1}
 	k1 := MakeEnvCacheKey(m1)
@@ -241,11 +273,20 @@ func TestMakeEnvCacheKey(t *testing.T) {
 		t.Errorf("expected same key regardless of iteration order, got %q vs %q", k1, k2)
 	}
 
-	// Different schemas should produce different key
-	m3 := map[string]*spec.Schema{"a": s2, "b": s1}
+	// Equivalent schema content should produce the same key even with a different pointer.
+	mEquivalent := map[string]*spec.Schema{"a": s1Clone, "b": s2}
+	if k := MakeEnvCacheKey(mEquivalent); k != k1 {
+		t.Errorf("expected equivalent schema content to produce same key, got %q vs %q", k, k1)
+	}
+
+	// Different CEL-relevant schemas should produce a different key.
+	m3 := map[string]*spec.Schema{
+		"a": {SchemaProps: spec.SchemaProps{Type: []string{"integer"}}},
+		"b": s2,
+	}
 	k3 := MakeEnvCacheKey(m3)
 	if k1 == k3 {
-		t.Error("expected different key for swapped schema pointers")
+		t.Error("expected different key for different schema content")
 	}
 }
 

--- a/pkg/cel/cache/keys.go
+++ b/pkg/cel/cache/keys.go
@@ -15,10 +15,11 @@
 package cache
 
 import (
+	"encoding/hex"
+	"encoding/json"
+	"hash/fnv"
 	"sort"
-	"strconv"
 	"strings"
-	"unsafe"
 
 	"github.com/google/cel-go/cel"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -84,9 +85,25 @@ func MakeIteratorVarsKey(vars map[string]*cel.Type) string {
 	return b.String()
 }
 
+type envSchemaKey struct {
+	Type                  []string                 `json:"type,omitempty"`
+	Format                string                   `json:"format,omitempty"`
+	Required              []string                 `json:"required,omitempty"`
+	XIntOrString          bool                     `json:"xIntOrString,omitempty"`
+	PreserveUnknownFields bool                     `json:"preserveUnknownFields,omitempty"`
+	Properties            map[string]*envSchemaKey `json:"properties,omitempty"`
+	Items                 *envSchemaKey            `json:"items,omitempty"`
+	AdditionalProperties  *envAdditionalPropsKey   `json:"additionalProperties,omitempty"`
+}
+
+type envAdditionalPropsKey struct {
+	Allows bool          `json:"allows,omitempty"`
+	Schema *envSchemaKey `json:"schema,omitempty"`
+}
+
 // MakeEnvCacheKey builds a canonical string key from a schema map.
-// Schemas are sorted by name for determinism, and each entry encodes
-// the schema pointer address to distinguish different schema objects.
+// Schemas are keyed by their CEL-relevant structural shape rather than
+// by pointer identity so equivalent schema sets reuse the same typed env.
 func MakeEnvCacheKey(schemas map[string]*spec.Schema) string {
 	names := make([]string, 0, len(schemas))
 	for name := range schemas {
@@ -94,15 +111,64 @@ func MakeEnvCacheKey(schemas map[string]*spec.Schema) string {
 	}
 	sort.Strings(names)
 
-	var b strings.Builder
-	for i, name := range names {
-		if i > 0 {
-			b.WriteByte(';')
-		}
-		b.WriteString(name)
-		b.WriteByte(':')
-		b.WriteString("0x")
-		b.WriteString(strconv.FormatUint(uint64(uintptr(unsafe.Pointer(schemas[name]))), 16))
+	h := fnv.New128a()
+	normalized := make(map[string]*envSchemaKey, len(schemas))
+	for _, name := range names {
+		normalized[name] = makeEnvSchemaKey(schemas[name])
 	}
-	return b.String()
+
+	data, err := json.Marshal(normalized)
+	if err == nil {
+		_, _ = h.Write(data)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func makeEnvSchemaKey(schema *spec.Schema) *envSchemaKey {
+	if schema == nil {
+		return nil
+	}
+
+	key := &envSchemaKey{
+		Type:                  append([]string(nil), schema.Type...),
+		Format:                schema.Format,
+		Required:              append([]string(nil), schema.Required...),
+		XIntOrString:          extensionBool(schema.Extensions, "x-kubernetes-int-or-string"),
+		PreserveUnknownFields: extensionBool(schema.Extensions, "x-kubernetes-preserve-unknown-fields"),
+	}
+	sort.Strings(key.Type)
+	sort.Strings(key.Required)
+
+	if len(schema.Properties) > 0 {
+		key.Properties = make(map[string]*envSchemaKey, len(schema.Properties))
+		for name, child := range schema.Properties {
+			childCopy := child
+			key.Properties[name] = makeEnvSchemaKey(&childCopy)
+		}
+	}
+
+	if schema.Items != nil && schema.Items.Schema != nil {
+		key.Items = makeEnvSchemaKey(schema.Items.Schema)
+	}
+
+	if schema.AdditionalProperties != nil {
+		key.AdditionalProperties = &envAdditionalPropsKey{
+			Allows: schema.AdditionalProperties.Allows,
+			Schema: makeEnvSchemaKey(schema.AdditionalProperties.Schema),
+		}
+	}
+
+	return key
+}
+
+func extensionBool(ext spec.Extensions, key string) bool {
+	if ext == nil {
+		return false
+	}
+	v, ok := ext[key]
+	if !ok {
+		return false
+	}
+	b, ok := v.(bool)
+	return ok && b
 }


### PR DESCRIPTION
Need merge post #1190 

`MakeEnvCacheKey` used `unsafe.Pointer` addresses to distinguish
schemas. This made the cache fragile to how schemas are constructed
upstream - any code path that produces a fresh `*spec.Schema` for
the same logical schema (re fetch, copy, rebuild) defeats the cache.

Replace with a canonical FNV hash of CEL-relevant schema fields
(type, format, required, properties, items, additionalProperties).
Fields irrelevant to CEL typing are excluded so cosmetic differences
don't cause misses

Orthogonal to `schema.Cache` (PR 1190) which fixes pointer instability
on `SchemaDeclType` within a single build. DeclType lookups are keyed
by `*spec.Schema` pointer and need stable pointers from a different
mechanism. Content-based keying doesn't help there.