### PR TITLE
  refactor(apis): add condition prune mechanism for upgrades

### DIFF
--- a/api/internal.kro.run/v1alpha1/graphrevision_types.go
+++ b/api/internal.kro.run/v1alpha1/graphrevision_types.go
@@ -18,6 +18,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// GraphRevision condition types.
+//
+// Ready (root)
+// └── GraphVerified — snapshot compiled successfully
+const (
+	// GraphRevisionConditionTypeGraphVerified is true when the immutable
+	// RGD snapshot in this GraphRevision has been compiled into a valid
+	// resource graph. False with reason "InvalidGraph" when compilation
+	// fails.
+	GraphRevisionConditionTypeGraphVerified krov1alpha1.ConditionType = "GraphVerified"
+)
+
 // GraphRevisionSpec defines the desired state of GraphRevision.
 // It captures an immutable snapshot of the source ResourceGraphDefinition.
 type GraphRevisionSpec struct {

--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -24,24 +24,34 @@ type ConditionType string
 
 func (c ConditionType) String() string { return string(c) }
 
+// ResourceGraphDefinition condition types.
+//
+// Ready (root)
+// ├── GraphRevisionsResolved — all revisions discovered and latest state known
+// ├── GraphAccepted          — RGD spec schema and resources are valid
+// ├── KindReady              — generated CRD is established
+// └── ControllerReady        — instance reconciler is registered and serving
 const (
-	// ResourceGraphDefinitionConditionTypeGraphVerified indicates the state of the directed
-	// acyclic graph (DAG) that kro uses to manage the resources in a
-	// ResourceGraphDefinition.
-	ResourceGraphDefinitionConditionTypeGraphVerified ConditionType = "GraphVerified"
-	// ResourceGraphDefinitionConditionTypeCustomResourceDefinitionSynced indicates the state of the
-	// CustomResourceDefinition (CRD) that kro uses to manage the resources in a
-	// ResourceGraphDefinition.
-	ResourceGraphDefinitionConditionTypeCustomResourceDefinitionSynced ConditionType = "CustomResourceDefinitionSynced"
-	// ResourceGraphDefinitionConditionTypeReconcilerReady indicates the state of the reconciler.
-	// Whenever an ResourceGraphDefinition resource is created, kro will spin up a
-	// reconciler for that resource. This condition indicates the state of the
-	// reconciler.
-	ResourceGraphDefinitionConditionTypeReconcilerReady ConditionType = "ReconcilerReady"
-
-	// GraphRevisionConditionTypeGraphVerified indicates the graph snapshot has
-	// been compiled and validated successfully.
-	GraphRevisionConditionTypeGraphVerified ConditionType = "GraphVerified"
+	// RGDConditionTypeGraphAccepted is true when the RGD spec (schema and
+	// resource templates) passes validation. False with reason
+	// "InvalidResourceGraph" when the spec contains errors.
+	RGDConditionTypeGraphAccepted ConditionType = "GraphAccepted"
+	// RGDConditionTypeGraphRevisionsResolved is true when all
+	// GraphRevisions for this RGD have been discovered, no terminating
+	// revisions remain in flight, and the latest revision's state in the
+	// in-memory registry is known. Unknown while revisions are settling
+	// (terminating GRs still deleting), warming (latest not yet in the
+	// cache or registry), or compiling (latest is Pending). False when
+	// the latest revision fails compilation.
+	RGDConditionTypeGraphRevisionsResolved ConditionType = "GraphRevisionsResolved"
+	// RGDConditionTypeKindReady is true when the generated
+	// CustomResourceDefinition has been applied and its Established
+	// condition is true.
+	RGDConditionTypeKindReady ConditionType = "KindReady"
+	// RGDConditionTypeControllerReady is true when the instance reconciler
+	// for this RGD's generated kind is registered with the dynamic
+	// controller and ready to reconcile instances.
+	RGDConditionTypeControllerReady ConditionType = "ControllerReady"
 )
 
 // Condition is the common struct used by all CRDs managed by ACK service

--- a/pkg/apis/condition_set.go
+++ b/pkg/apis/condition_set.go
@@ -20,6 +20,7 @@ package apis
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +35,25 @@ import (
 type ConditionSet struct {
 	ConditionTypes
 	object Object
+}
+
+// pruneConditions removes condition types listed in ConditionTypes.prunes
+// from the object's conditions.
+func (c ConditionSet) pruneConditions() {
+	if c.object == nil || len(c.prunes) == 0 {
+		return
+	}
+	conditions := c.object.GetConditions()
+	filtered := conditions[:0:0]
+	for _, cond := range conditions {
+		if slices.Contains(c.prunes, cond.Type.String()) {
+			continue
+		}
+		filtered = append(filtered, cond)
+	}
+	if len(filtered) != len(conditions) {
+		c.object.SetConditions(filtered)
+	}
 }
 
 // Root returns the root Condition, typically "Ready" or "Succeeded"

--- a/pkg/apis/condition_types.go
+++ b/pkg/apis/condition_types.go
@@ -40,12 +40,29 @@ func NewSucceededConditions(d ...string) ConditionTypes {
 type ConditionTypes struct {
 	root       string
 	dependents []string
+	// prunes lists condition types from previous releases that should be
+	// removed when the condition set is initialized. This handles upgrades
+	// where a condition was renamed or dropped — the old entry would
+	// otherwise persist with a stale observedGeneration forever.
+	prunes []string
+}
+
+// Prunes returns a copy of ConditionTypes that will remove the listed condition
+// types when For() initializes a ConditionSet. Use this to clean up condition
+// types that were renamed or dropped in previous releases.
+func (ct ConditionTypes) Prunes(types ...string) ConditionTypes {
+	ct.prunes = append(ct.prunes[:len(ct.prunes):len(ct.prunes)], types...)
+	return ct
 }
 
 // For creates a ConditionSet from an object using the original
 // ConditionTypes as a reference. Status must be a pointer to a struct.
 func (ct ConditionTypes) For(object Object) ConditionSet {
 	cs := ConditionSet{object: object, ConditionTypes: ct}
+	// Remove deprecated condition types before initializing the current set.
+	if len(ct.prunes) > 0 {
+		cs.pruneConditions()
+	}
 	// Set known conditions Unknown if not set.
 	// Set the root condition first to get consistent timing for LastTransitionTime
 	for _, t := range append([]string{ct.root}, ct.dependents...) {

--- a/pkg/apis/condition_types_test.go
+++ b/pkg/apis/condition_types_test.go
@@ -36,6 +36,8 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 )
 
 func TestNewReadyConditions(t *testing.T) {
@@ -102,6 +104,80 @@ func TestNewSucceededConditions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrunes(t *testing.T) {
+	const (
+		oldFoo     = "OldFoo"
+		ancientFoo = "AncientFoo"
+	)
+
+	t.Run("removes listed condition types on For", func(t *testing.T) {
+		set := NewReadyConditions("Foo").Prunes(oldFoo, ancientFoo)
+		dut := &TestResource{}
+		dut.SetConditions([]v1alpha1.Condition{
+			{Type: v1alpha1.ConditionType(oldFoo), Status: metav1.ConditionTrue},
+			{Type: v1alpha1.ConditionType(ancientFoo), Status: metav1.ConditionFalse},
+			{Type: "Foo", Status: metav1.ConditionTrue},
+		})
+
+		set.For(dut)
+
+		for _, c := range dut.GetConditions() {
+			if string(c.Type) == oldFoo || string(c.Type) == ancientFoo {
+				t.Errorf("condition %q should have been pruned", c.Type)
+			}
+		}
+		// Foo + Ready (initialized by For)
+		if got := dut.GetConditions(); len(got) != 2 {
+			t.Errorf("expected 2 conditions, got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("no-op when pruned types absent", func(t *testing.T) {
+		set := NewReadyConditions("Foo").Prunes(oldFoo)
+		dut := &TestResource{}
+
+		cs := set.For(dut)
+		cs.SetTrue("Foo")
+
+		before := len(dut.GetConditions())
+		set.For(dut)
+
+		if got := len(dut.GetConditions()); got != before {
+			t.Errorf("expected %d conditions, got %d", before, got)
+		}
+	})
+
+	t.Run("does not affect original ConditionTypes", func(t *testing.T) {
+		original := NewReadyConditions("Foo")
+		withPrunes := original.Prunes(oldFoo)
+
+		dut := &TestResource{}
+		dut.SetConditions([]v1alpha1.Condition{
+			{Type: v1alpha1.ConditionType(oldFoo), Status: metav1.ConditionTrue},
+		})
+
+		// Original should not prune.
+		original.For(dut)
+		found := false
+		for _, c := range dut.GetConditions() {
+			if string(c.Type) == oldFoo {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("original ConditionTypes should not have pruned OldFoo")
+		}
+
+		// With prunes should prune.
+		withPrunes.For(dut)
+		for _, c := range dut.GetConditions() {
+			if string(c.Type) == oldFoo {
+				t.Error("Prunes variant should have removed OldFoo")
+			}
+		}
+	})
 }
 
 func TestNonTerminalCondition(t *testing.T) {

--- a/pkg/controller/graphrevision/controller_status.go
+++ b/pkg/controller/graphrevision/controller_status.go
@@ -32,7 +32,7 @@ import (
 const (
 	// GraphVerified is the condition type indicating whether a GraphRevision
 	// has been successfully compiled and validated.
-	GraphVerified = string(krov1alpha1.GraphRevisionConditionTypeGraphVerified)
+	GraphVerified = string(internalv1alpha1.GraphRevisionConditionTypeGraphVerified)
 )
 
 var graphRevisionConditionTypes = apis.NewReadyConditions(GraphVerified)

--- a/pkg/controller/graphrevision/controller_test.go
+++ b/pkg/controller/graphrevision/controller_test.go
@@ -471,7 +471,7 @@ func TestGraphRevisionStatusCases(t *testing.T) {
 				assert.Equal(t, []string{"config", "deploy"}, stored.Status.TopologicalOrder)
 				require.Len(t, stored.Status.Resources, 1)
 				assert.Equal(t, "deploy", stored.Status.Resources[0].ID)
-				verified := findCondition(stored.Status.Conditions, v1alpha1.GraphRevisionConditionTypeGraphVerified)
+				verified := findCondition(stored.Status.Conditions, internalv1alpha1.GraphRevisionConditionTypeGraphVerified)
 				require.NotNil(t, verified)
 				assert.Equal(t, metav1.ConditionTrue, verified.Status)
 			},
@@ -652,7 +652,7 @@ func TestGraphRevisionReconcilerFailsCleanlyWhenSpecHashingFails(t *testing.T) {
 	assert.Nil(t, resources)
 	assert.Nil(t, activeEntry)
 
-	verified := findCondition(revision.Status.Conditions, v1alpha1.GraphRevisionConditionTypeGraphVerified)
+	verified := findCondition(revision.Status.Conditions, internalv1alpha1.GraphRevisionConditionTypeGraphVerified)
 	require.NotNil(t, verified)
 	assert.Equal(t, metav1.ConditionFalse, verified.Status)
 	require.NotNil(t, verified.Reason)
@@ -695,7 +695,7 @@ func assertStoredRevisionState(
 		assert.Equal(t, *wantFinalizer, metadata.HasGraphRevisionFinalizer(stored))
 	}
 	if wantVerified != nil {
-		verified := findCondition(stored.Status.Conditions, v1alpha1.GraphRevisionConditionTypeGraphVerified)
+		verified := findCondition(stored.Status.Conditions, internalv1alpha1.GraphRevisionConditionTypeGraphVerified)
 		require.NotNil(t, verified)
 		assert.Equal(t, *wantVerified, verified.Status)
 	}

--- a/pkg/controller/resourcegraphdefinition/controller_status.go
+++ b/pkg/controller/resourcegraphdefinition/controller_status.go
@@ -117,25 +117,28 @@ func (r *ResourceGraphDefinitionReconciler) setUnmanaged(ctx context.Context, rg
 
 const (
 	Ready                  = "Ready"
-	GraphAccepted          = "GraphAccepted"
-	GraphRevisionsResolved = "GraphRevisionsResolved"
-	KindReady              = "KindReady"
-	ControllerReady        = "ControllerReady"
+	GraphAccepted          = string(v1alpha1.RGDConditionTypeGraphAccepted)
+	GraphRevisionsResolved = string(v1alpha1.RGDConditionTypeGraphRevisionsResolved)
+	KindReady              = string(v1alpha1.RGDConditionTypeKindReady)
+	ControllerReady        = string(v1alpha1.RGDConditionTypeControllerReady)
 
 	waitingForGraphRevisionSettlementReason  = "WaitingForGraphRevisionSettlement"
 	waitingForGraphRevisionWarmupReason      = "WaitingForGraphRevisionWarmup"
 	waitingForGraphRevisionCompilationReason = "WaitingForGraphRevisionCompilation"
 )
 
-var rgdConditionTypes = apis.NewReadyConditions(GraphRevisionsResolved, GraphAccepted, KindReady, ControllerReady)
+var rgdConditionTypes = apis.NewReadyConditions(GraphRevisionsResolved, GraphAccepted, KindReady, ControllerReady).
+	// ResourceGraphAccepted was renamed to GraphAccepted in v0.9. The old
+	// condition persists with a stale observedGeneration on upgraded RGDs.
+	Prunes("ResourceGraphAccepted")
 
 // NewConditionsMarkerFor creates a marker to manage conditions for ResourceGraphDefinitions.
 //
 // Ready
-// ├── GraphRevisionsResolved  — graph revisions settled and latest compiled
-// ├── GraphAccepted   — spec valid and revision created
-// ├── KindReady       — CRD established
-// └── ControllerReady — dynamic controller registered
+// ├── GraphRevisionsResolved — all revisions discovered and latest state known
+// ├── GraphAccepted          — spec schema and resources are valid
+// ├── KindReady              — generated CRD is established
+// └── ControllerReady        — instance reconciler registered and serving
 //
 // All four are dependents of Ready.
 
@@ -231,12 +234,12 @@ func (m *ConditionsMarker) KindUnready(msg string) {
 
 // --- ControllerReady ---
 
-// ControllerRunning signals the microcontroller is up and running for this RGD-Kind.
+// ControllerRunning signals the instance reconciler is registered and serving.
 func (m *ConditionsMarker) ControllerRunning() {
 	m.cs.SetTrueWithReason(ControllerReady, "Running", "controller is running")
 }
 
-// ControllerFailedToStart signals the microcontroller had an issue when starting.
+// ControllerFailedToStart signals the instance reconciler failed to register.
 func (m *ConditionsMarker) ControllerFailedToStart(msg string) {
 	m.cs.SetFalse(ControllerReady, "FailedToStart", msg)
 }

--- a/pkg/controller/resourcegraphdefinition/controller_status_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_status_test.go
@@ -560,3 +560,42 @@ func TestSetUnmanaged(t *testing.T) {
 		})
 	}
 }
+
+func TestPrunesDeprecatedConditions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("strips ResourceGraphAccepted on marker init", func(t *testing.T) {
+		t.Parallel()
+
+		rgd := newTestRGD("upgraded-rgd")
+		// Simulate v0.8.5 state: ResourceGraphAccepted present alongside current conditions.
+		rgd.Status.Conditions = v1alpha1.Conditions{
+			{Type: "ResourceGraphAccepted", Status: metav1.ConditionTrue, ObservedGeneration: 1},
+			{Type: v1alpha1.ConditionType(GraphAccepted), Status: metav1.ConditionTrue},
+			{Type: v1alpha1.ConditionType(KindReady), Status: metav1.ConditionTrue},
+			{Type: v1alpha1.ConditionType(ControllerReady), Status: metav1.ConditionTrue},
+		}
+
+		// NewConditionsMarkerFor calls For() which triggers Prunes.
+		NewConditionsMarkerFor(rgd)
+
+		for _, c := range rgd.Status.Conditions {
+			assert.NotEqual(t, v1alpha1.ConditionType("ResourceGraphAccepted"), c.Type,
+				"ResourceGraphAccepted should have been pruned")
+		}
+	})
+
+	t.Run("no-op when deprecated condition absent", func(t *testing.T) {
+		t.Parallel()
+
+		rgd := newTestRGD("fresh-rgd")
+		NewConditionsMarkerFor(rgd)
+
+		before := len(rgd.Status.Conditions)
+
+		// Second call should not change anything.
+		NewConditionsMarkerFor(rgd)
+
+		assert.Len(t, rgd.Status.Conditions, before)
+	})
+}

--- a/test/integration/suites/core/graphrevision_conditions_test.go
+++ b/test/integration/suites/core/graphrevision_conditions_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GraphRevision Conditions", func() {
 			err := env.Client.Get(ctx, types.NamespacedName{Name: grName}, fresh)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			assertConditionContract(g, fresh, krov1alpha1.GraphRevisionConditionTypeGraphVerified, conditionExpectation{
+			assertConditionContract(g, fresh, internalv1alpha1.GraphRevisionConditionTypeGraphVerified, conditionExpectation{
 				status:  metav1.ConditionTrue,
 				reason:  "Verified",
 				message: "graph revision compiled and verified",
@@ -80,7 +80,7 @@ var _ = Describe("GraphRevision Conditions", func() {
 			err := env.Client.Get(ctx, types.NamespacedName{Name: grName}, fresh)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			assertConditionContract(g, fresh, krov1alpha1.GraphRevisionConditionTypeGraphVerified, conditionExpectation{
+			assertConditionContract(g, fresh, internalv1alpha1.GraphRevisionConditionTypeGraphVerified, conditionExpectation{
 				status:  metav1.ConditionFalse,
 				reason:  "InvalidGraph",
 				message: wantMessage,

--- a/test/integration/suites/core/graphrevision_test.go
+++ b/test/integration/suites/core/graphrevision_test.go
@@ -86,7 +86,7 @@ var _ = Describe("GraphRevision Lifecycle", func() {
 
 			graphVerified := findGRCondition(
 				currentGRs[0].Status.Conditions,
-				krov1alpha1.GraphRevisionConditionTypeGraphVerified,
+				internalv1alpha1.GraphRevisionConditionTypeGraphVerified,
 			)
 			g.Expect(graphVerified).ToNot(BeNil())
 			g.Expect(graphVerified.Status).To(Equal(metav1.ConditionTrue))
@@ -118,7 +118,7 @@ var _ = Describe("GraphRevision Lifecycle", func() {
 		Expect(gr.OwnerReferences[0].UID).To(Equal(activeRGD.UID))
 
 		// Verify GR status conditions
-		graphVerified := findGRCondition(gr.Status.Conditions, krov1alpha1.GraphRevisionConditionTypeGraphVerified)
+		graphVerified := findGRCondition(gr.Status.Conditions, internalv1alpha1.GraphRevisionConditionTypeGraphVerified)
 		Expect(graphVerified).ToNot(BeNil())
 		Expect(graphVerified.Status).To(Equal(metav1.ConditionTrue))
 


### PR DESCRIPTION
The RGD condition types had inconsistent naming - `ResourceGraphAccepted`
vs the shorter form used everywhere else. This renames them to
`GraphAccepted`, `GraphRevisionsResolved`, `KindReady`, and
`ControllerReady`, and moves `GraphRevisionConditionTypeGraphVerified`
from the public `v1alpha1` package to the internal API where it belongs.

To handle upgrades cleanly, this adds a `Prunes()` method on
`ConditionTypes` that strips deprecated condition types (like the old
`ResourceGraphAccepted`) when a `ConditionSet` is initialized via
`For()`. Without this, renamed conditions would persist with stale
`observedGeneration` values forever on existing resources.

Also adds ASCII trees documenting the condition hierarchy for both RGD
and GraphRevision, and updates all unit and integration tests to use the
new constant locations.