### PR TITLE
docs(website): rewrite graph revisions page and add interactive diagrams

### DIFF
--- a/website/docs/docs/advanced/05-graph-revisions.md
+++ b/website/docs/docs/advanced/05-graph-revisions.md
@@ -2,197 +2,225 @@
 sidebar_position: 5
 ---
 
+import RevisionFlow from '@site/src/components/RevisionFlow';
+
 # Graph Revisions
 
 Every time you change an RGD's spec, kro creates a numbered, immutable snapshot
-called a **GraphRevision**. You can list them with `kubectl` to see what changed,
-when, and whether the change compiled successfully.
+called a **GraphRevision**. GraphRevisions give you a history of what changed
+and whether each change compiled successfully. If a new spec breaks, you see
+exactly which revision failed and why - instances stop progressing until you
+push a valid spec.
 
-```bash
-$ kubectl get graphrevisions
-NAME             REVISION   READY   AGE
-my-webapp-r00001 1          True    2d
-my-webapp-r00002 2          True    1d
-my-webapp-r00003 3          True    5m
-```
+<RevisionFlow />
 
 :::warning Internal API
-GraphRevisions use the `internal.kro.run/v1alpha1` API group. This API is **not
-intended for programmatic consumption** — its schema, naming conventions, and
-behavior may change across kro releases without notice. You can safely observe
-GraphRevisions via `kubectl` for debugging and auditing purposes, but do not
-build tooling or automation that depends on their structure.
+GraphRevisions use the `internal.kro.run/v1alpha1` API group. This API may
+change across kro releases without notice. You can safely observe GraphRevisions
+via `kubectl` for debugging and auditing, but do not build tooling that depends
+on their structure.
 :::
-
-## What You See
-
-Each GraphRevision has a `READY` column that reflects its API condition state:
-
-| READY     | What it means                                                   |
-| --------- | --------------------------------------------------------------- |
-| `True`    | The snapshot compiled and verified successfully                 |
-| `Unknown` | kro has not written a terminal compile result yet               |
-| `False`   | Compilation or validation of this snapshot failed               |
-
-For short RGD names, GraphRevision names use a zero-padded revision suffix like
-`-r00001`. If the name must be truncated to fit Kubernetes name limits, kro
-adds a hash suffix to keep the name deterministic and unique.
-
-Use `-o wide` to also see the source RGD and spec hash label:
-
-```bash
-$ kubectl get graphrevisions -o wide
-NAME                          RGD        REVISION   HASH              READY   AGE
-my-webapp-r00003              my-webapp  3          a1b2c3d4e5f6...   True    5m
-```
-
-To see the full compilation error on a failed revision:
-
-```bash
-kubectl describe graphrevision my-webapp-r00003
-```
 
 ## What Happens When You Update an RGD
 
-1. kro hashes your new spec. If the hash matches the latest revision, nothing
-   happens — cosmetic YAML changes (key reordering, whitespace) are ignored.
-2. kro validates the spec. If it's invalid, the RGD is marked
-   `GraphAccepted=False` and no revision is created.
-3. A new GraphRevision is created with the next revision number.
-4. The GraphRevision controller compiles the snapshot independently and sets
-   `GraphVerified` plus aggregate `Ready` on the GraphRevision object.
-5. Once the latest revision is compiled, the RGD controller can mark
-   `GraphRevisionsResolved=True` and continue serving-state reconciliation.
+1. **Hash check.** kro hashes the new spec. If the hash matches the latest
+   revision, nothing happens - cosmetic changes like key reordering or
+   whitespace are ignored.
+
+2. **Validation.** kro validates the spec structure. If invalid, the RGD is
+   marked `GraphAccepted=False` and no revision is created.
+
+3. **Issuance.** A new GraphRevision is created with the next revision number.
+   Revision numbers are monotonic and never reused, even after garbage
+   collection. The high-water mark is persisted in `status.lastIssuedRevision`
+   on the RGD, so numbering survives controller restarts.
+
+4. **Compilation.** The GraphRevision controller independently compiles the
+   snapshot - parsing the schema, resolving CEL expressions, and building the
+   dependency graph. On success the GraphRevision is marked
+   `GraphVerified=True`; on failure, `GraphVerified=False` with an error
+   message.
+
+5. **Activation.** Once compiled, the graph is stored in an in-memory registry
+   that instance controllers read from. The RGD is marked
+   `GraphRevisionsResolved=True` and instance reconciliation proceeds.
 
 :::danger Failed revisions block instances
 If the latest revision fails compilation, instances **do not fall back** to an
-older revision. They stop progressing until you push a new valid spec. Always
-check `kubectl get graphrevisions` plus the RGD `Ready`, `GraphAccepted`, and
-`GraphRevisionsResolved` conditions when an update is stuck.
+older revision. They stop progressing until you push a new valid spec.
 :::
+
+## Inspecting Revisions
+
+GraphRevisions have the short name `gr`, so you can use either form:
+
+```bash
+kubectl get gr
+# or
+kubectl get graphrevisions
+```
+
+```text
+NAME              REVISION   READY   AGE
+my-webapp-r00001  1          True    2d
+my-webapp-r00002  2          True    1d
+my-webapp-r00003  3          True    5m
+```
+
+The `READY` column reflects the compilation result: `True` means the snapshot
+compiled successfully, `False` means compilation failed (inspect with
+`kubectl describe`), and `Unknown` means the GraphRevision controller hasn't
+processed it yet.
+
+Use `-o wide` to see the source RGD name and spec hash:
+
+```bash
+kubectl get gr -o wide
+```
+
+```text
+NAME              RGD        REVISION   HASH              READY   AGE
+my-webapp-r00003  my-webapp  3          a1b2c3d4e5f6...   True    5m
+```
+
+To filter revisions for a specific RGD:
+
+```bash
+kubectl get gr -l internal.kro.run/resource-graph-definition-name=my-webapp
+```
+
+You can also filter by spec hash using the `kro.run/graph-revision-hash` label:
+
+```bash
+kubectl get gr -l kro.run/graph-revision-hash=a1b2c3d4e5f6
+```
+
+## GraphRevision Fields
+
+### Spec
+
+| Field                       | Description                                                    |
+| --------------------------- | -------------------------------------------------------------- |
+| `spec.revision`             | Monotonic revision number, unique per RGD                      |
+| `spec.snapshot.name`        | Source RGD name                                                |
+| `spec.snapshot.generation`  | `metadata.generation` of the RGD when this revision was issued |
+| `spec.snapshot.spec`        | Full immutable copy of the RGD spec at issuance time           |
+
+### Status
+
+| Field                     | Description                                                  |
+| ------------------------- | ------------------------------------------------------------ |
+| `status.conditions`       | `GraphVerified` (compilation result) and aggregate `Ready`   |
+| `status.topologicalOrder` | Resource creation order derived from the compiled graph      |
+| `status.resources`        | Per-resource dependency information from the compiled graph  |
+
+### Labels
+
+| Label                                                  | Description                                |
+| ------------------------------------------------------ | ------------------------------------------ |
+| `internal.kro.run/resource-graph-definition-name`      | Source RGD name (selectable field)          |
+| `kro.run/graph-revision-hash`                          | Spec hash for dedup and filtering           |
 
 ## Debugging
 
-**Update is stuck after an RGD spec change:**
+**Update stuck after a spec change?** Check the latest revision:
 
 ```bash
-# List revisions for a specific RGD
-kubectl get graphrevisions -l internal.kro.run/resource-graph-definition-name=<rgd-name>
-
-# If the latest shows READY=False, inspect the error
-kubectl describe graphrevision <name>
+kubectl describe gr my-webapp-r00003
 ```
 
-**Revision number keeps incrementing without spec changes:**
+Look at the `GraphVerified` condition - if `False`, the `Message` field
+contains the compilation error. Fix the RGD spec and reapply.
 
-This shouldn't happen — kro deduplicates by spec hash. Check whether something
-is modifying the RGD spec (e.g., a GitOps tool reapplying with formatting that
-changes semantic content).
+**Want to see the resource ordering?** After a successful compilation, the
+`status.topologicalOrder` field shows the order kro will create resources:
 
-**Instances not picking up a new spec:**
+```bash
+kubectl get gr my-webapp-r00003 -o jsonpath='{.status.topologicalOrder}'
+```
 
-Verify the latest GraphRevision shows `READY=True`. If it's `Unknown`, the
-GraphRevision controller may be backlogged — check controller logs.
+```text
+["config","bucket","deployment","service"]
+```
+
+**Instances not picking up a new spec?** Verify the latest GraphRevision shows
+`READY=True`. If `Unknown`, the GraphRevision controller may not have processed
+it yet - check controller logs.
+
+**Revision number incrementing without spec changes?** This shouldn't happen -
+kro deduplicates by spec hash. Check whether something is modifying the RGD
+spec (e.g., a GitOps tool reapplying with formatting that changes semantic
+content).
+
+**RGD conditions to check when things are stuck:**
+
+| RGD Condition              | Meaning                                                       |
+| -------------------------- | ------------------------------------------------------------- |
+| `GraphAccepted=False`      | Spec validation failed, no revision was created               |
+| `GraphRevisionsResolved=Unknown` | A revision was issued but hasn't been compiled yet      |
+| `GraphRevisionsResolved=False`   | Latest revision failed compilation                      |
+| `GraphRevisionsResolved=True`    | Latest revision compiled successfully, serving active   |
+
+## Naming
+
+GraphRevision names follow the pattern `{rgd-name}-r{revision:05d}`, giving
+zero-padded revision numbers that sort lexicographically in kubectl (up to
+99,999 revisions). If the combined name exceeds the Kubernetes 253-character
+limit, kro truncates the RGD name and appends an FNV hash suffix to prevent
+collisions.
 
 ## Ownership and Lifecycle
 
-Every GraphRevision carries an `ownerReference` pointing back to its source RGD.
-This has two consequences you should know about:
+Every GraphRevision carries an `ownerReference` pointing to its source RGD.
 
 **Deleting an RGD deletes all its revisions.** Kubernetes garbage collection
-cascades the delete. Each revision is finalized individually — kro evicts it from
-the in-memory registry before allowing the object to be removed, so instance
-controllers never read stale compiled graphs from a deleted revision.
+cascades the delete via ownerReferences.
 
-**Recreating an RGD with the same name starts fresh.** The new RGD gets a new
-UID, so it won't match the old ownerReferences. Any leftover registry entries
-from the old RGD are cleaned up on the first reconcile.
+:::tip Preserving revisions across RGD recreation
+To keep GraphRevisions around when deleting an RGD, use orphan deletion:
 
-GraphRevisions are also subject to a **retention limit** — kro keeps at most N
-revisions per RGD (default 5). When the count exceeds the limit, the oldest
-revisions are pruned. The latest revision is always retained regardless of the
-limit.
+```bash
+kubectl delete rgd my-webapp --cascade=orphan
+```
+
+When you recreate the RGD, kro adopts the orphaned GraphRevisions by
+`spec.snapshot.name` - revision history and compiled state carry over.
+:::
 
 ### Immutability
 
-GraphRevision specs are immutable after creation. The API server rejects any
-update to the `spec` field via CEL validation (`self == oldSelf`). This
-guarantees that every revision is a faithful snapshot of the RGD spec at the
-time it was issued — there is no way to silently alter a revision's content
-after the fact.
+GraphRevision specs are immutable after creation. The API server rejects updates
+to the `spec` field via CEL validation (`self == oldSelf`). Every revision is a
+faithful snapshot of the RGD spec at the time it was issued.
+
+### Retention
+
+kro keeps at most N revisions per RGD (default 5). When the count exceeds the
+limit, the oldest revisions are pruned. The latest revision is always retained.
 
 ## Configuration
 
-GraphRevision behavior is controlled through Helm values:
-
-| Setting                                    | Default | Description                        |
+| Helm Value                                 | Default | Description                        |
 | ------------------------------------------ | ------- | ---------------------------------- |
 | `config.graphRevisionConcurrentReconciles` | `1`     | Parallel GraphRevision reconciles  |
 | `config.rgd.maxGraphRevisions`             | `5`     | Maximum revisions retained per RGD |
 
-```yaml
-config:
-  graphRevisionConcurrentReconciles: 1
-  rgd:
-    maxGraphRevisions: 5
-```
-
 For most clusters the defaults are fine. Lower `maxGraphRevisions` if you have
-many frequently-updated RGDs and want to reduce object count. Raise it if you
-need deeper audit history.
+many frequently-updated RGDs and want to reduce object count.
 
-## How It Works
+## How It All Fits Together
 
-Under the hood, the RGD controller and the GraphRevision controller split
-responsibilities:
+The RGD controller and GraphRevision controller split responsibilities cleanly:
 
-```
-RGD spec change
-    │
-    ▼
-Hash current spec ──── matches latest revision? ──── yes ──▶ no-op
-    │
-    no
-    │
-    ▼
-Build current spec ──── invalid? ──▶ mark GraphAccepted=False, stop
-    │
-    ok
-    │
-    ▼
-Create GraphRevision (revision N+1), mark RGD GraphRevisionsResolved=Unknown
-    │
-    ▼
-GR controller compiles snapshot ──── fails? ──▶ GR Ready=False, RGD GraphRevisionsResolved=False
-    │
-    ok
-    │
-    ▼
-GR Ready=True, registry entry becomes Active
-```
+| Responsibility     | Owner                     | What it does                                           |
+| ------------------ | ------------------------- | ------------------------------------------------------ |
+| **Issuance**       | RGD controller            | Hashes spec, deduplicates, creates GraphRevision objects |
+| **Compilation**    | GraphRevision controller  | Compiles snapshot, writes result to in-memory registry  |
+| **Resolution**     | Instance controllers      | Resolve latest compiled graph from registry             |
+| **Garbage collection** | RGD controller        | Prunes old revisions beyond retention limit             |
 
-The RGD controller owns graph revision issuance and resolution: hashing, dedup, issuance, and
-garbage collection. The GraphRevision controller owns compilation: it takes
-each snapshot, builds the graph, updates the GraphRevision conditions, and
-writes the result into an in-memory registry that instance controllers read from.
-
-The GraphRevision API only exposes conditions. The runtime scheduling states
-`Pending`, `Active`, and `Failed` live in kro's in-memory registry rather than
-in `status`.
-
-Instances always resolve the latest issued revision. The revision number is
-monotonic and persisted in `status.lastIssuedRevision` — it survives controller
-restarts and is not reset by garbage collection.
-
-### GraphRevision Fields
-
-| Field                     | Description                                           |
-| ------------------------- | ----------------------------------------------------- |
-| `spec.revision`           | Monotonic revision number within this RGD             |
-| `spec.snapshot.name`      | Source RGD name                                       |
-| `spec.snapshot.spec`      | Full immutable copy of the RGD spec at issuance       |
-| `status.topologicalOrder` | Resource creation order from the compiled graph       |
-| `status.conditions`       | `GraphVerified` and aggregate `Ready`                 |
-
-The spec hash is exposed as the label `kro.run/graph-revision-hash` for
-filtering convenience.
+The runtime scheduling states (`Pending`, `Active`, `Failed`) live in the
+in-memory registry, not in the GraphRevision status. The API only exposes
+`GraphVerified` and aggregate `Ready` conditions. Revision numbering is
+persisted in `status.lastIssuedRevision` on the RGD, so it survives controller
+restarts and is never reset by garbage collection.

--- a/website/docs/docs/concepts/rgd/00-overview.md
+++ b/website/docs/docs/concepts/rgd/00-overview.md
@@ -3,6 +3,8 @@ sidebar_position: 1
 sidebar_label: Overview
 ---
 
+import RGDProcessFlow from '@site/src/components/RGDProcessFlow';
+
 # Overview
 
 A **ResourceGraphDefinition** (RGD) lets you create a custom Kubernetes API that deploys multiple resources together as a single unit. It's the only API you need to configure kro - you define the schema for your new API, the resources it should create, and how data flows between them using CEL expressions.
@@ -16,11 +18,7 @@ When you apply an RGD, kro configures itself to serve your new API. It generates
 3. **Users create instances** of your API
 4. **kro creates and manages** all the underlying resources
 
-<div style={{textAlign: 'center', marginTop: '2rem', marginBottom: '2rem'}}>
-
-<img src="/img/overview-diag.svg" alt="kro RGD Flow" style={{maxWidth: '600px', width: '100%'}} />
-
-</div>
+<RGDProcessFlow />
 
 ## Example
 
@@ -211,6 +209,32 @@ Breaking changes can invalidate existing instances. Ensure you understand the im
 - **Validation**: Users get immediate feedback if they provide invalid values
 - **Reusability**: Define once, use many times across teams
 
+## Graph Revisions
+
+Every time you change an RGD's spec, kro creates an immutable snapshot called a
+**GraphRevision** rather than compiling the spec inline. This separates
+validation from compilation and gives you a visible history of every spec change.
+
+The RGD controller hashes the new spec, deduplicates against the latest
+revision, and creates a new GraphRevision object if the spec actually changed. A
+separate GraphRevision controller then compiles the snapshot independently and
+writes the result into an in-memory registry that instance controllers read from.
+
+You can list revisions with `kubectl get gr`:
+
+```text
+NAME              REVISION   READY   AGE
+my-webapp-r00001  1          True    2d
+my-webapp-r00002  2          True    1d
+my-webapp-r00003  3          True    5m
+```
+
+If the latest revision fails compilation, instances stop progressing until you
+push a valid spec - there is no automatic fallback to an older revision.
+
+For the full details on naming, lifecycle, retention, and debugging, see
+[Graph Revisions](../../advanced/05-graph-revisions.md).
+
 ## Next Steps
 
 Explore the details of ResourceGraphDefinitions:
@@ -224,3 +248,4 @@ Explore the details of ResourceGraphDefinitions:
 - **[CEL Expressions](./03-cel-expressions.md)** - Reference data between resources
 - **[Dependencies & Ordering](./04-dependencies-ordering.md)** - How kro infers dependencies and determines creation order
 - **[Static Type Checking](./05-static-type-checking.md)** - How kro validates RGDs before instances are created
+- **[Graph Revisions](../../advanced/05-graph-revisions.md)** - How kro snapshots and compiles RGD spec changes

--- a/website/src/components/RGDProcessFlow/index.tsx
+++ b/website/src/components/RGDProcessFlow/index.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useRef, useState } from 'react';
+import styles from './styles.module.css';
+
+// Lane x-positions in the 600-wide viewBox
+const USER = 100;
+const API  = 300;
+const KRO  = 500;
+
+// Vertical spacing
+const HEADER_BOTTOM = 60;
+const STEP_START = 90;
+const STEP_GAP = 45;
+
+interface Step {
+  num: number;
+  label: string;
+  from: number;  // x of source lane
+  to: number;    // x of target lane
+  kro?: boolean;
+  self?: boolean;
+}
+
+const steps: Step[] = [
+  { num: 1, label: 'Apply RGD',          from: USER, to: API },
+  { num: 2, label: 'Watch RGDs',         from: KRO,  to: API,  kro: true },
+  { num: 3, label: 'Validate',           from: KRO,  to: KRO,  kro: true, self: true },
+  { num: 4, label: 'Create CRD',         from: KRO,  to: API,  kro: true },
+  { num: 5, label: 'Create instance',    from: USER, to: API },
+  { num: 6, label: 'Watch instances',    from: KRO,  to: API,  kro: true },
+  { num: 7, label: 'Reconcile',          from: KRO,  to: KRO,  kro: true, self: true },
+  { num: 8, label: 'Create resources',   from: KRO,  to: API,  kro: true },
+];
+
+const TOTAL_HEIGHT = STEP_START + steps.length * STEP_GAP + 20;
+
+export default function RGDProcessFlow(): JSX.Element {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    if (ref.current) observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={ref} className={`${styles.container} ${visible ? styles.visible : ''}`}>
+      <svg
+        className={styles.svg}
+        viewBox={`0 0 600 ${TOTAL_HEIGHT}`}
+        preserveAspectRatio="xMidYMid meet"
+      >
+        <defs>
+          <marker id="seq-arrow" viewBox="0 0 10 8" refX="10" refY="4" markerWidth="8" markerHeight="6" markerUnits="userSpaceOnUse" orient="auto">
+            <path d="M0,0.5 L9,4 L0,7.5Z" fill="currentColor" />
+          </marker>
+          <marker id="seq-arrow-kro" viewBox="0 0 10 8" refX="10" refY="4" markerWidth="8" markerHeight="6" markerUnits="userSpaceOnUse" orient="auto">
+            <path d="M0,0.5 L9,4 L0,7.5Z" fill="var(--ifm-color-primary)" />
+          </marker>
+        </defs>
+
+        {/* Column headers */}
+        <g className={styles.header}>
+          {/* User */}
+          <rect x={USER - 50} y="8" width="100" height="42" rx="8" fill="var(--ifm-background-color)" stroke="var(--ifm-color-emphasis-300)" strokeWidth="1.5" />
+          <text x={USER} y="35" textAnchor="middle" className={styles.headerLabel}>User</text>
+
+          {/* API Server */}
+          <rect x={API - 60} y="8" width="120" height="42" rx="8" fill="var(--ifm-background-color)" stroke="var(--ifm-color-emphasis-300)" strokeWidth="1.5" />
+          <text x={API} y="35" textAnchor="middle" className={styles.headerLabel}>API Server</text>
+
+          {/* kro */}
+          <rect x={KRO - 40} y="8" width="80" height="42" rx="8" fill="var(--ifm-background-color)" stroke="var(--ifm-color-primary)" strokeWidth="1.5" />
+          <text x={KRO} y="35" textAnchor="middle" className={styles.headerLabelKro}>kro</text>
+        </g>
+
+        {/* Vertical lane lines */}
+        <line x1={USER} y1={HEADER_BOTTOM} x2={USER} y2={TOTAL_HEIGHT} stroke="var(--ifm-color-emphasis-200)" strokeWidth="1.5" strokeDasharray="4 4" />
+        <line x1={API}  y1={HEADER_BOTTOM} x2={API}  y2={TOTAL_HEIGHT} stroke="var(--ifm-color-emphasis-200)" strokeWidth="1.5" strokeDasharray="4 4" />
+        <line x1={KRO}  y1={HEADER_BOTTOM} x2={KRO}  y2={TOTAL_HEIGHT} stroke="rgba(91, 127, 201, 0.25)" strokeWidth="1.5" strokeDasharray="4 4" />
+
+        {/* Steps */}
+        {steps.map((step, i) => {
+          const y = STEP_START + i * STEP_GAP;
+          const color = step.kro ? 'var(--ifm-color-primary)' : 'var(--ifm-color-emphasis-600)';
+          const markerUrl = step.kro ? 'url(#seq-arrow-kro)' : 'url(#seq-arrow)';
+
+          if (step.self) {
+            // Self-loop: small loop to the right of the kro lane
+            return (
+              <g key={step.num} className={`${styles.step} ${styles[`delay${i}`]}`}>
+                <path
+                  d={`M${KRO},${y} h30 v20 h-30`}
+                  fill="none"
+                  stroke={color}
+                  strokeWidth="1.5"
+                  markerEnd={markerUrl}
+                />
+                <text x={KRO + 38} y={y + 6} className={step.kro ? styles.stepLabelKro : styles.stepLabel}>
+                  {step.label}
+                </text>
+                {/* Number on top of the lane line */}
+                <circle cx={KRO} cy={y} r="10" className={step.kro ? styles.numBgKro : styles.numBg} />
+                <text x={KRO} y={y + 4} textAnchor="middle" className={styles.numText}>{step.num}</text>
+              </g>
+            );
+          }
+
+          const fromX = step.from;
+          const toX = step.to;
+          const dir = fromX < toX ? 1 : -1;
+          // Arrow line with gap for number circle
+          const lineFromX = fromX + dir * 2;
+          const lineToX = toX - dir * 2;
+          const midX = (fromX + toX) / 2;
+
+          return (
+            <g key={step.num} className={`${styles.step} ${styles[`delay${i}`]}`}>
+              {/* Arrow line */}
+              <line
+                x1={lineFromX} y1={y}
+                x2={lineToX} y2={y}
+                stroke={color}
+                strokeWidth="1.5"
+                markerEnd={markerUrl}
+              />
+              {/* Label above arrow */}
+              <text x={midX} y={y - 8} textAnchor="middle" className={step.kro ? styles.stepLabelKro : styles.stepLabel}>
+                {step.label}
+              </text>
+              {/* Number circle at source */}
+              <circle cx={fromX} cy={y} r="10" className={step.kro ? styles.numBgKro : styles.numBg} />
+              <text x={fromX} y={y + 4} textAnchor="middle" className={styles.numText}>{step.num}</text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/website/src/components/RGDProcessFlow/styles.module.css
+++ b/website/src/components/RGDProcessFlow/styles.module.css
@@ -1,0 +1,117 @@
+.container {
+  margin: 2rem 0 2.5rem;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.container.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.svg {
+  display: block;
+  width: 100%;
+  max-width: 580px;
+  margin: 0 auto;
+}
+
+/* ── Headers ── */
+
+.headerLabel {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 14px;
+  font-weight: 700;
+  fill: var(--ifm-color-emphasis-700);
+}
+
+.headerLabelKro {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 14px;
+  font-weight: 800;
+  fill: var(--ifm-color-primary);
+}
+
+/* ── Step rows ── */
+
+.step {
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.visible .step {
+  opacity: 1;
+}
+
+.visible .delay0 { transition-delay: 0.05s; }
+.visible .delay1 { transition-delay: 0.1s; }
+.visible .delay2 { transition-delay: 0.15s; }
+.visible .delay3 { transition-delay: 0.2s; }
+.visible .delay4 { transition-delay: 0.25s; }
+.visible .delay5 { transition-delay: 0.3s; }
+.visible .delay6 { transition-delay: 0.35s; }
+.visible .delay7 { transition-delay: 0.4s; }
+
+/* ── Step labels ── */
+
+.stepLabel {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  font-weight: 600;
+  fill: var(--ifm-color-emphasis-600);
+}
+
+.stepLabelKro {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  font-weight: 600;
+  fill: var(--ifm-color-primary);
+}
+
+/* ── Number circles ── */
+
+.numBg {
+  fill: var(--ifm-color-emphasis-100);
+}
+
+.numBgKro {
+  fill: #e8eef8;
+}
+
+[data-theme='dark'] .numBgKro {
+  fill: #2a3554;
+}
+
+.numText {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 10px;
+  font-weight: 700;
+  fill: var(--ifm-color-emphasis-700);
+}
+
+.numBgKro + .numText {
+  fill: var(--ifm-color-primary);
+}
+
+/* ── Responsive ── */
+
+@media (max-width: 768px) {
+  .svg {
+    max-width: 100%;
+  }
+
+  .headerLabel,
+  .headerLabelKro {
+    font-size: 12px;
+  }
+
+  .stepLabel,
+  .stepLabelKro {
+    font-size: 9px;
+  }
+
+  .numText {
+    font-size: 8px;
+  }
+}

--- a/website/src/components/RevisionFlow/index.tsx
+++ b/website/src/components/RevisionFlow/index.tsx
@@ -1,0 +1,276 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import styles from './styles.module.css';
+
+type Pt = { x: number; y: number };
+
+interface Edge {
+  from: Pt;
+  to: Pt;
+  color: string;
+  dash?: boolean;
+  dim?: boolean;
+}
+
+function edgesFromRefs(
+  graphEl: HTMLDivElement,
+  refs: Record<string, HTMLDivElement | null>,
+): Edge[] {
+  const gr = graphEl.getBoundingClientRect();
+  const w = gr.width;
+  const h = gr.height;
+
+  function right(key: string): Pt {
+    const r = refs[key]?.getBoundingClientRect();
+    if (!r) return { x: 0, y: 0 };
+    return { x: ((r.right - gr.left) / w) * 900, y: ((r.top + r.height / 2 - gr.top) / h) * 340 };
+  }
+
+  function left(key: string): Pt {
+    const r = refs[key]?.getBoundingClientRect();
+    if (!r) return { x: 0, y: 0 };
+    return { x: ((r.left - gr.left) / w) * 900, y: ((r.top + r.height / 2 - gr.top) / h) * 340 };
+  }
+
+  const blue = 'var(--ifm-color-primary)';
+  const green = '#34a853';
+
+  return [
+    { from: right('rgd'), to: left('gr1'), color: blue, dim: true },
+    { from: right('rgd'), to: left('gr2'), color: blue, dim: true },
+    { from: right('rgd'), to: left('gr3'), color: blue },
+    { from: right('gr1'), to: left('c1'), color: green, dash: true, dim: true },
+    { from: right('gr2'), to: left('c2'), color: green, dash: true, dim: true },
+    { from: right('gr3'), to: left('c3'), color: green, dash: true },
+    { from: left('i1'), to: right('c1'), color: blue },
+    { from: left('i2'), to: right('c3'), color: blue },
+  ];
+}
+
+function VerticalArrow({ label, color }: { label: string; color?: string }) {
+  return (
+    <div className={styles.vArrow}>
+      <svg width="20" height="28" viewBox="0 0 20 28">
+        <line x1="10" y1="0" x2="10" y2="20" stroke={color || 'var(--ifm-color-emphasis-400)'} strokeWidth="1.5" strokeDasharray="4 3" />
+        <polygon points="6,20 14,20 10,28" fill={color || 'var(--ifm-color-emphasis-400)'} opacity="0.7" />
+      </svg>
+      <span className={styles.vArrowLabel} style={color ? { color } : undefined}>{label}</span>
+    </div>
+  );
+}
+
+export default function RevisionFlow(): JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const graphRef = useRef<HTMLDivElement>(null);
+  const nodeRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const [visible, setVisible] = useState(false);
+  const [edges, setEdges] = useState<Edge[]>([]);
+  const [wide, setWide] = useState(typeof window !== 'undefined' ? window.innerWidth > 1500 : true);
+
+  const setNodeRef = useCallback((key: string) => (el: HTMLDivElement | null) => {
+    nodeRefs.current[key] = el;
+  }, []);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    if (containerRef.current) observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    function measure() {
+      const isWide = window.innerWidth > 1500;
+      setWide(isWide);
+      if (!isWide || !graphRef.current) {
+        setEdges([]);
+        return;
+      }
+      setEdges(edgesFromRefs(graphRef.current, nodeRefs.current));
+    }
+
+    measure();
+    const timer = setTimeout(measure, 200);
+    window.addEventListener('resize', measure);
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener('resize', measure);
+    };
+  }, [visible]);
+
+  // Shared node markup
+  const rgdNode = (ref?: (el: HTMLDivElement | null) => void, style?: React.CSSProperties) => (
+    <div ref={ref} className={`${styles.node} ${styles.nodeK8s} ${styles.nodeRgd}`} style={style}>
+      <div className={styles.nodeHeader}>
+        <span className={`${styles.badge} ${styles.badgeRgd}`}>RGD</span>
+      </div>
+      <div className={styles.nodeName}>my-webapp</div>
+      <div className={styles.nodeDetail}>schema + 3 resources</div>
+    </div>
+  );
+
+  const grNode = (key: string, name: string, rev: string, old: boolean, latest: boolean, ref?: (el: HTMLDivElement | null) => void, style?: React.CSSProperties) => (
+    <div ref={ref} className={`${styles.node} ${styles.nodeK8s} ${old ? styles.nodeOld : ''} ${latest ? styles.nodeLatest : ''}`} style={style}>
+      <div className={styles.nodeHeader}>
+        <span className={`${styles.badge} ${styles.badgeGr}`}>GraphRevision</span>
+      </div>
+      <div className={styles.nodeName}>{name}</div>
+      <div className={styles.nodeDetail}>{rev}</div>
+    </div>
+  );
+
+  const compiledNode = (key: string, detail: string, old: boolean, active: boolean, ref?: (el: HTMLDivElement | null) => void, style?: React.CSSProperties) => (
+    <div ref={ref} className={`${styles.node} ${styles.nodeMem} ${old ? styles.nodeOld : ''} ${active ? styles.nodeActive : ''}`} style={style}>
+      <div className={styles.nodeHeader}>
+        <span className={styles.memIcon}>&#9881;</span>
+      </div>
+      <div className={styles.nodeName}>Compiled</div>
+      <div className={styles.nodeDetail}>{detail}</div>
+    </div>
+  );
+
+  const instanceNode = (key: string, name: string, rev: string, ref?: (el: HTMLDivElement | null) => void, style?: React.CSSProperties) => (
+    <div ref={ref} className={`${styles.node} ${styles.nodeK8s}`} style={style}>
+      <div className={styles.nodeHeader}>
+        <span className={`${styles.badge} ${styles.badgeInstance}`}>Instance</span>
+      </div>
+      <div className={styles.nodeName}>{name}</div>
+      <div className={styles.nodeRevRef}>{rev}</div>
+    </div>
+  );
+
+  // ── Wide layout (graph with SVG edges) ──
+  if (wide) {
+    return (
+      <div ref={containerRef} className={`${styles.container} ${visible ? styles.visible : ''}`}>
+        <div ref={graphRef} className={styles.graph}>
+          {edges.length > 0 && (
+            <svg className={styles.edges} viewBox="0 0 900 340" preserveAspectRatio="xMidYMid meet">
+              <defs>
+                <marker id="rf-a-blue" viewBox="0 0 10 8" refX="10" refY="4" markerWidth="9" markerHeight="7" markerUnits="userSpaceOnUse" orient="auto">
+                  <path d="M0,0.5 L9,4 L0,7.5Z" fill="var(--ifm-color-primary)" />
+                </marker>
+                <marker id="rf-a-green" viewBox="0 0 10 8" refX="10" refY="4" markerWidth="9" markerHeight="7" markerUnits="userSpaceOnUse" orient="auto">
+                  <path d="M0,0.5 L9,4 L0,7.5Z" fill="#34a853" />
+                </marker>
+              </defs>
+
+              {edges.map((e, i) => (
+                <line
+                  key={i}
+                  x1={e.from.x} y1={e.from.y}
+                  x2={e.to.x} y2={e.to.y}
+                  stroke={e.color}
+                  strokeWidth="1.5"
+                  strokeDasharray={e.dash ? '6 3' : undefined}
+                  markerEnd={e.color.includes('34a853') ? 'url(#rf-a-green)' : 'url(#rf-a-blue)'}
+                  opacity={e.dim ? 0.45 : 0.8}
+                  className={styles.edge}
+                />
+              ))}
+
+              <text x="215" y="148" className={styles.edgeLabel} fill="var(--ifm-color-primary)">issues</text>
+              <text x="448" y="220" className={styles.edgeLabel} fill="#34a853">compiles</text>
+              {edges.length >= 8 && (
+                <text
+                  x={edges[6].from.x + 30}
+                  y={(edges[6].from.y + edges[7].from.y) / 2}
+                  className={styles.edgeLabel}
+                  fill="var(--ifm-color-primary)"
+                >resolves</text>
+              )}
+            </svg>
+          )}
+
+          <div className={styles.nodes}>
+            {rgdNode(setNodeRef('rgd'), { left: '2%', top: '48%', transform: 'translateY(-50%)' })}
+            {grNode('gr1', 'r00001', 'rev 1', true, false, setNodeRef('gr1'), { left: '33%', top: '5%' })}
+            {grNode('gr2', 'r00002', 'rev 2', true, false, setNodeRef('gr2'), { left: '33%', top: '39%' })}
+            {grNode('gr3', 'r00003', 'rev 3', false, true, setNodeRef('gr3'), { left: '33%', top: '73%' })}
+            {compiledNode('c1', 'rev 1', true, false, setNodeRef('c1'), { left: '58%', top: '5%' })}
+            {compiledNode('c2', 'rev 2', true, false, setNodeRef('c2'), { left: '58%', top: '39%' })}
+            {compiledNode('c3', 'rev 3 \u00b7 Active', false, true, setNodeRef('c3'), { left: '58%', top: '73%' })}
+            {instanceNode('i1', 'my-webapp-abc', 'using rev 1', setNodeRef('i1'), { left: '83%', top: '17%' })}
+            {instanceNode('i2', 'my-webapp-xyz', 'using rev 3', setNodeRef('i2'), { left: '83%', top: '61%' })}
+          </div>
+        </div>
+
+        <div className={styles.legend}>
+          <div className={styles.legendItem}>
+            <span className={`${styles.legendSwatch} ${styles.legendK8s}`} />
+            <span className={styles.legendText}>Kubernetes object</span>
+          </div>
+          <div className={styles.legendItem}>
+            <span className={`${styles.legendSwatch} ${styles.legendMem}`} />
+            <span className={styles.legendText}>In-memory</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Narrow layout (vertical flow) ──
+  return (
+    <div ref={containerRef} className={`${styles.container} ${visible ? styles.visible : ''}`}>
+      <div className={styles.vertical}>
+        {/* RGD */}
+        <div className={styles.vSection}>
+          <div className={styles.vSectionLabel}>ResourceGraphDefinition</div>
+          {rgdNode()}
+        </div>
+
+        <VerticalArrow label="issues" color="var(--ifm-color-primary)" />
+
+        {/* GraphRevisions */}
+        <div className={styles.vSection}>
+          <div className={styles.vSectionLabel}>GraphRevisions</div>
+          <div className={styles.vGroup}>
+            {grNode('gr1', 'r00001', 'rev 1', true, false)}
+            {grNode('gr2', 'r00002', 'rev 2', true, false)}
+            {grNode('gr3', 'r00003', 'rev 3', false, true)}
+          </div>
+        </div>
+
+        <VerticalArrow label="compiles into" color="#34a853" />
+
+        {/* Compiled Graphs */}
+        <div className={styles.vSection}>
+          <div className={styles.vSectionLabel}>Compiled Graphs (in-memory)</div>
+          <div className={styles.vGroup}>
+            {compiledNode('c1', 'rev 1', true, false)}
+            {compiledNode('c2', 'rev 2', true, false)}
+            {compiledNode('c3', 'rev 3 \u00b7 Active', false, true)}
+          </div>
+        </div>
+
+        <VerticalArrow label="resolves from" color="var(--ifm-color-primary)" />
+
+        {/* Instances */}
+        <div className={styles.vSection}>
+          <div className={styles.vSectionLabel}>Instances</div>
+          <div className={styles.vGroup}>
+            {instanceNode('i1', 'my-webapp-abc', 'using rev 1')}
+            {instanceNode('i2', 'my-webapp-xyz', 'using rev 3')}
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.legend}>
+        <div className={styles.legendItem}>
+          <span className={`${styles.legendSwatch} ${styles.legendK8s}`} />
+          <span className={styles.legendText}>Kubernetes object</span>
+        </div>
+        <div className={styles.legendItem}>
+          <span className={`${styles.legendSwatch} ${styles.legendMem}`} />
+          <span className={styles.legendText}>In-memory</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/RevisionFlow/styles.module.css
+++ b/website/src/components/RevisionFlow/styles.module.css
@@ -1,0 +1,348 @@
+.container {
+  margin: 2.5rem 0 3rem;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.container.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ── Graph ── */
+
+.graph {
+  position: relative;
+  width: 100%;
+  max-width: 880px;
+  margin: 0 auto;
+  aspect-ratio: 900 / 340;
+  padding: 0.5rem;
+}
+
+/* ── SVG edges ── */
+
+.edges {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.edge {
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+
+.visible .edge {
+  opacity: 1;
+  transition-delay: 0.25s;
+}
+
+.edgeLabel {
+  font-family: var(--ifm-font-family-base);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  opacity: 0.5;
+}
+
+/* ── Nodes ── */
+
+.nodes {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+.node {
+  position: absolute;
+  border-radius: 8px;
+  padding: 0.6rem 0.9rem;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.67rem;
+  text-align: center;
+  min-width: 110px;
+}
+
+/* ── K8s objects ── */
+
+.nodeK8s {
+  border: 1.5px solid var(--ifm-color-primary);
+  background: var(--ifm-background-color);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+}
+
+[data-theme='dark'] .nodeK8s {
+  background: var(--ifm-background-surface-color);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+
+.nodeRgd {
+  min-width: 140px;
+}
+
+/* ── In-memory nodes ── */
+
+.nodeMem {
+  border: 1.5px dashed #34a853;
+  background: rgba(52, 168, 83, 0.03);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+[data-theme='dark'] .nodeMem {
+  background: rgba(52, 168, 83, 0.06);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.22);
+}
+
+/* ── Dim old revisions ── */
+
+.nodeOld {
+  opacity: 0.55;
+}
+
+/* unused but kept for class application */
+.nodeLatest {}
+.nodeActive {}
+
+/* ── Node content ── */
+
+.nodeHeader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  margin-bottom: 0.2rem;
+}
+
+.nodeName {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--ifm-heading-color);
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+.nodeDetail {
+  font-size: 0.62rem;
+  color: var(--ifm-color-emphasis-700);
+  margin-top: 0.12rem;
+  letter-spacing: 0.01em;
+  font-weight: 500;
+}
+
+.nodeRevRef {
+  font-size: 0.62rem;
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+  margin-top: 0.15rem;
+  letter-spacing: 0.01em;
+}
+
+/* ── Badges ── */
+
+.badge {
+  font-size: 0.54rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.14rem 0.42rem;
+  border-radius: 4px;
+  line-height: 1;
+}
+
+.badgeRgd {
+  background: rgba(91, 127, 201, 0.12);
+  color: var(--ifm-color-primary);
+}
+
+[data-theme='dark'] .badgeRgd {
+  background: rgba(147, 197, 253, 0.14);
+}
+
+.badgeGr {
+  background: rgba(212, 148, 10, 0.12);
+  color: #9a7000;
+}
+
+[data-theme='dark'] .badgeGr {
+  background: rgba(240, 192, 64, 0.14);
+  color: #f0c040;
+}
+
+.badgeInstance {
+  background: rgba(234, 67, 53, 0.1);
+  color: #c5221f;
+}
+
+[data-theme='dark'] .badgeInstance {
+  background: rgba(234, 67, 53, 0.14);
+  color: #f28b82;
+}
+
+.memIcon {
+  font-size: 0.72rem;
+  color: #34a853;
+  line-height: 1;
+}
+
+.latestTag {
+  font-size: 0.4rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.06rem 0.26rem;
+  border-radius: 3px;
+  background: rgba(91, 127, 201, 0.08);
+  color: var(--ifm-color-primary);
+  line-height: 1;
+}
+
+.readyDot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #34a853;
+  box-shadow: 0 0 0 2px rgba(52, 168, 83, 0.15);
+}
+
+/* ── Legend (below) ── */
+
+.legend {
+  display: flex;
+  gap: 1.6rem;
+  justify-content: center;
+  margin-top: 1.2rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+  max-width: 340px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.legendSwatch {
+  display: inline-block;
+  width: 14px;
+  height: 10px;
+  border-radius: 2px;
+}
+
+.legendK8s {
+  border: 1.5px solid var(--ifm-color-primary);
+  background: var(--ifm-background-color);
+}
+
+.legendMem {
+  border: 1.5px dashed #34a853;
+  background: var(--ifm-background-color);
+}
+
+.legendText {
+  font-family: var(--ifm-font-family-base);
+  font-size: 0.68rem;
+  color: var(--ifm-color-emphasis-700);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+/* ── Vertical layout ── */
+
+.vertical {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+  max-width: 360px;
+  margin: 0 auto;
+}
+
+.vSection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.vSectionLabel {
+  font-family: var(--ifm-font-family-base);
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ifm-color-emphasis-500);
+  margin-bottom: 0.5rem;
+}
+
+.vGroup {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  width: 100%;
+}
+
+.vGroup .node,
+.vSection > .node {
+  position: relative;
+  width: 100%;
+  max-width: 260px;
+}
+
+.vArrow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.3rem 0;
+  color: var(--ifm-color-emphasis-400);
+}
+
+.vArrowLabel {
+  font-family: var(--ifm-font-family-base);
+  font-size: 0.52rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ifm-color-emphasis-500);
+  margin-top: 0.15rem;
+}
+
+@media (max-width: 768px) {
+  .container {
+    margin: 1.5rem 0 2rem;
+  }
+
+  .vertical {
+    max-width: 280px;
+  }
+
+  .vGroup .node,
+  .vSection > .node {
+    max-width: 220px;
+    padding: 0.4rem 0.6rem;
+  }
+
+  .nodeName {
+    font-size: 0.62rem;
+  }
+
+  .nodeDetail,
+  .nodeRevRef {
+    font-size: 0.5rem;
+  }
+
+  .legend {
+    gap: 1rem;
+    max-width: 240px;
+  }
+}


### PR DESCRIPTION
The graph revisions doc was flat and hard to navigate - conditions
presented as a bare True/Unknown/False table, ASCII art instead of a
real diagram, rollout language for a feature that doesn't exist, and
field tables that duplicated the API reference.

Rewrite the page with proper flow: lifecycle first, then inspection,
then debugging with a conditions-to-meaning table, fields reference
(spec/status/labels), and a responsibility breakdown at the bottom.
Add the `gr` shortname and `kro.run/graph-revision-hash` label that
were undocumented.

Replace the static Excalidraw SVG in the RGD overview with
RGDProcessFlow, a sequence diagram component with swim lanes. Add
RevisionFlow, a DAG component showing RGD issuing GraphRevisions,
compilation into in-memory graphs, and instances resolving from them.
Both collapse to vertical layouts on narrow screens.

Add a Graph Revisions section to the RGD overview linking to the
full advanced doc.