### PR TITLE
fix(instance): surface graph resolution failures in conditions and metrics

### DIFF
--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -207,6 +207,11 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 	compiledGraph, err := c.resolveCompiledGraph()
 	if err != nil {
 		log.Error(err, "failed to resolve graph revision")
+		mark := NewConditionsMarkerFor(inst)
+		mark.GraphResolutionFailed("%v", err)
+		if statusErr := c.updateConditionsStatus(ctx, inst); statusErr != nil {
+			log.Error(statusErr, "failed to update conditions status after graph resolution failure")
+		}
 		return err
 	}
 	runtimeObj, err := runtime.FromGraph(compiledGraph, inst, c.reconcileConfig.RGDConfig)
@@ -261,7 +266,6 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 	annotations := inst.GetAnnotations()
 	reconcileState, ok := annotations[v1alpha1.InstanceReconcileAnnotation]
 	if !ok || !strings.EqualFold(reconcileState, "disabled") {
-		rcx.Mark.ReconciliationActive()
 		if err := c.reconcileNodes(rcx); err != nil {
 			var deletingErr *resourceDeletingError
 			if errors.As(err, &deletingErr) {
@@ -273,8 +277,6 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 			_ = c.updateStatus(rcx)
 			return err
 		}
-	} else {
-		rcx.Mark.ReconciliationSuspended("annotation %s is set to %s", v1alpha1.InstanceReconcileAnnotation, reconcileState)
 	}
 	// Only mark ResourcesReady if all resources reached terminal state.
 	// Resources with unsatisfied readyWhen are in WaitingForReadiness,
@@ -315,9 +317,17 @@ func (c *Controller) ensureManaged(rcx *ReconcileContext) error {
 	return nil
 }
 
+const (
+	graphResolutionReasonNotAvailable = "not_available"
+	graphResolutionReasonFailed       = "failed"
+	graphResolutionReasonUnknown      = "unknown_state"
+)
+
 func (c *Controller) resolveCompiledGraph() (*graph.Graph, error) {
+	gvr := c.gvr.String()
 	latest, ok := c.graphResolver.GetLatestRevision()
 	if !ok {
+		instanceGraphResolutionFailuresTotal.WithLabelValues(gvr, graphResolutionReasonNotAvailable).Inc()
 		return nil, requeue.NeededAfter(fmt.Errorf("latest issued graph revision not available"), c.reconcileConfig.DefaultRequeueDuration)
 	}
 
@@ -326,15 +336,19 @@ func (c *Controller) resolveCompiledGraph() (*graph.Graph, error) {
 		// Active implies the newest issued revision compiled successfully and its
 		// graph is present; this is guaranteed by the GR reconciler and registry
 		// invariant.
+		instanceGraphResolutionSuccessTotal.WithLabelValues(gvr).Inc()
 		return latest.CompiledGraph, nil
 	case revisions.RevisionStatePending:
+		instanceGraphResolutionPendingTotal.WithLabelValues(gvr).Inc()
 		return nil, requeue.NeededAfter(
 			fmt.Errorf("latest issued graph revision %d is pending", latest.Revision),
 			c.reconcileConfig.DefaultRequeueDuration,
 		)
 	case revisions.RevisionStateFailed:
+		instanceGraphResolutionFailuresTotal.WithLabelValues(gvr, graphResolutionReasonFailed).Inc()
 		return nil, requeue.None(fmt.Errorf("latest issued graph revision %d failed", latest.Revision))
 	default:
+		instanceGraphResolutionFailuresTotal.WithLabelValues(gvr, graphResolutionReasonUnknown).Inc()
 		return nil, requeue.NeededAfter(
 			fmt.Errorf("latest issued graph revision %d has unknown state %q", latest.Revision, latest.State),
 			c.reconcileConfig.DefaultRequeueDuration,

--- a/pkg/controller/instance/controller_test.go
+++ b/pkg/controller/instance/controller_test.go
@@ -27,10 +27,14 @@ import (
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+	clientfake "github.com/kubernetes-sigs/kro/pkg/client/fake"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
+	"github.com/kubernetes-sigs/kro/pkg/graph/revisions"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/requeue"
 )
@@ -157,13 +161,6 @@ func TestReconcileStatusPaths(t *testing.T) {
 			wantConditionType:   Ready,
 			wantConditionStatus: metav1.ConditionTrue,
 		},
-		{
-			name:                "suspended reconciliation sets condition",
-			instanceAnnotations: map[string]string{v1alpha1.InstanceReconcileAnnotation: "disabled"},
-			wantState:           string(v1alpha1.InstanceStateActive),
-			wantConditionType:   ReconciliationSuspended,
-			wantConditionStatus: metav1.ConditionTrue,
-		},
 	}
 
 	for _, tt := range tests {
@@ -184,6 +181,101 @@ func TestReconcileStatusPaths(t *testing.T) {
 			require.True(t, found)
 			assert.Equal(t, tt.wantState, state)
 			assert.Equal(t, tt.wantConditionStatus, conditionByType(t, stored, tt.wantConditionType).Status)
+		})
+	}
+}
+
+func TestReconcileGraphResolutionFailureMarksCondition(t *testing.T) {
+	tests := []struct {
+		name        string
+		entry       revisions.Entry
+		hasLatest   bool
+		wantReason  string
+		wantMessage string
+	}{
+		{
+			name:        "not available marks GraphResolved false",
+			hasLatest:   false,
+			wantReason:  "ResolutionFailed",
+			wantMessage: "latest issued graph revision not available",
+		},
+		{
+			name:      "pending revision marks GraphResolved false",
+			hasLatest: true,
+			entry: revisions.Entry{
+				RGDName:  "webapps",
+				Revision: 3,
+				State:    revisions.RevisionStatePending,
+			},
+			wantReason:  "ResolutionFailed",
+			wantMessage: "latest issued graph revision 3 is pending",
+		},
+		{
+			name:      "failed revision marks GraphResolved false",
+			hasLatest: true,
+			entry: revisions.Entry{
+				RGDName:  "webapps",
+				Revision: 5,
+				State:    revisions.RevisionStateFailed,
+			},
+			wantReason:  "ResolutionFailed",
+			wantMessage: "latest issued graph revision 5 failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			raw := newControllerTestDynamicClient(t, instance.DeepCopy())
+			clientSet := clientfake.NewFakeSet(raw)
+			clientSet.SetRESTMapper(buildControllerTestRESTMapper())
+
+			controller := NewController(
+				zap.New(zap.UseDevMode(true)),
+				ReconcileConfig{DefaultRequeueDuration: 2 * time.Second},
+				controllerTestParentGVR,
+				testRevisionResolver{
+					getLatestRevision: func() (revisions.Entry, bool) {
+						return tt.entry, tt.hasLatest
+					},
+					getGraphRevision: func(int64) (revisions.Entry, bool) {
+						return revisions.Entry{}, false
+					},
+				},
+				true,
+				clientSet,
+				metadata.NewKROMetaLabeler(),
+				metadata.NewKROMetaLabeler(),
+				newControllerTestCoordinator(t),
+				record.NewFakeRecorder(100),
+			)
+
+			err := controller.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: "demo", Namespace: "default"},
+			})
+			require.Error(t, err)
+
+			stored := getStoredParentObject(t, raw)
+			cond := conditionByType(t, stored, GraphResolved)
+			assert.Equal(t, metav1.ConditionFalse, cond.Status)
+			require.NotNil(t, cond.Reason)
+			assert.Equal(t, tt.wantReason, *cond.Reason)
+			require.NotNil(t, cond.Message)
+			assert.Contains(t, *cond.Message, tt.wantMessage)
+
+			ready := conditionByType(t, stored, Ready)
+			assert.Equal(t, metav1.ConditionFalse, ready.Status, "Ready should be false when GraphResolved is false")
+
+			im := conditionByType(t, stored, InstanceManaged)
+			assert.Equal(t, metav1.ConditionUnknown, im.Status, "InstanceManaged should be Unknown (never reached)")
+
+			rr := conditionByType(t, stored, ResourcesReady)
+			assert.Equal(t, metav1.ConditionUnknown, rr.Status, "ResourcesReady should be Unknown (never reached)")
+
+			state, found, err := unstructured.NestedString(stored.Object, "status", "state")
+			require.NoError(t, err)
+			require.True(t, found)
+			assert.Equal(t, string(v1alpha1.InstanceStateError), state)
 		})
 	}
 }

--- a/pkg/controller/instance/metrics.go
+++ b/pkg/controller/instance/metrics.go
@@ -25,6 +25,9 @@ func init() {
 		instanceReconcileDurationSeconds,
 		instanceReconcileTotal,
 		instanceReconcileErrorsTotal,
+		instanceGraphResolutionSuccessTotal,
+		instanceGraphResolutionFailuresTotal,
+		instanceGraphResolutionPendingTotal,
 	)
 }
 
@@ -58,6 +61,30 @@ var (
 		prometheus.CounterOpts{
 			Name: "instance_reconcile_errors_total",
 			Help: "Total number of instance reconciliation errors per GVR",
+		},
+		[]string{"gvr"},
+	)
+
+	instanceGraphResolutionSuccessTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "instance_graph_resolution_success_total",
+			Help: "Total number of successful graph resolutions during instance reconciliation",
+		},
+		[]string{"gvr"},
+	)
+
+	instanceGraphResolutionFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "instance_graph_resolution_failures_total",
+			Help: "Total number of graph resolution failures during instance reconciliation",
+		},
+		[]string{"gvr", "reason"},
+	)
+
+	instanceGraphResolutionPendingTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "instance_graph_resolution_pending_total",
+			Help: "Total number of graph resolutions deferred due to pending revision",
 		},
 		[]string{"gvr"},
 	)

--- a/pkg/controller/instance/status.go
+++ b/pkg/controller/instance/status.go
@@ -15,6 +15,7 @@
 package instance
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -28,11 +29,10 @@ import (
 )
 
 const (
-	Ready                   = "Ready"
-	InstanceManaged         = "InstanceManaged"
-	GraphResolved           = "GraphResolved"
-	ResourcesReady          = "ResourcesReady"
-	ReconciliationSuspended = "ReconciliationSuspended"
+	Ready           = "Ready"
+	InstanceManaged = "InstanceManaged"
+	GraphResolved   = "GraphResolved"
+	ResourcesReady  = "ResourcesReady"
 )
 
 var condSet = apis.NewReadyConditions(InstanceManaged, GraphResolved, ResourcesReady)
@@ -120,19 +120,44 @@ func (m *ConditionsMarker) ResourcesDeleting(msg string, args ...any) {
 	m.cs.SetFalse(ResourcesReady, "ResourceDeleting", fmt.Sprintf(msg, args...))
 }
 
-// ReconciliationSuspended signals that reconciliation is suspended
-func (m *ConditionsMarker) ReconciliationSuspended(msg string, args ...any) {
-	m.cs.SetTrueWithReason(ReconciliationSuspended, "Suspended", fmt.Sprintf(msg, args...))
-}
-
-// ReconciliationActive signals that reconciliation is active
-func (m *ConditionsMarker) ReconciliationActive() {
-	m.cs.SetFalse(ReconciliationSuspended, "Active", "Reconciliation is Active")
-}
-
 // ResourcesUnderDeletion signals the controller is currently deleting resources.
 func (m *ConditionsMarker) ResourcesUnderDeletion(msg string, args ...any) {
 	m.cs.SetUnknownWithReason(ResourcesReady, "UnderDeletion", fmt.Sprintf(msg, args...))
+}
+
+// updateConditionsStatus persists only the conditions and state from the
+// instance object. Used on early-exit paths (e.g. graph resolution failure)
+// where a full ReconcileContext is not available.
+func (c *Controller) updateConditionsStatus(ctx context.Context, inst *unstructured.Unstructured) error {
+	ri := c.client.Dynamic().Resource(c.gvr)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var cur *unstructured.Unstructured
+		var err error
+		if c.namespaced {
+			cur, err = ri.Namespace(inst.GetNamespace()).Get(ctx, inst.GetName(), metav1.GetOptions{})
+		} else {
+			cur, err = ri.Get(ctx, inst.GetName(), metav1.GetOptions{})
+		}
+		if err != nil {
+			return err
+		}
+		status, _, _ := unstructured.NestedMap(cur.Object, "status")
+		if status == nil {
+			status = map[string]interface{}{}
+		}
+		// Copy conditions from the marked instance.
+		if conds, found, _ := unstructured.NestedSlice(inst.Object, "status", "conditions"); found {
+			status["conditions"] = conds
+		}
+		status["state"] = string(v1alpha1.InstanceStateError)
+		cur.Object["status"] = status
+		if c.namespaced {
+			_, err = ri.Namespace(inst.GetNamespace()).UpdateStatus(ctx, cur, metav1.UpdateOptions{})
+		} else {
+			_, err = ri.UpdateStatus(ctx, cur, metav1.UpdateOptions{})
+		}
+		return err
+	})
 }
 
 func (c *Controller) updateStatus(rcx *ReconcileContext) error {

--- a/pkg/controller/instance/status_test.go
+++ b/pkg/controller/instance/status_test.go
@@ -42,7 +42,6 @@ func TestConditionsMarkerAndInitialStatus(t *testing.T) {
 	marker := NewConditionsMarkerFor(instance)
 	marker.InstanceManaged()
 	marker.GraphResolved()
-	marker.ReconciliationActive()
 	marker.ResourcesReady()
 
 	rcx := &ReconcileContext{
@@ -53,7 +52,6 @@ func TestConditionsMarkerAndInitialStatus(t *testing.T) {
 	assert.Equal(t, v1alpha1.InstanceStateActive, status["state"])
 
 	marker.ResourcesNotReady("not yet")
-	marker.ReconciliationSuspended("paused")
 	marker.ResourcesUnderDeletion("cleanup")
 	marker.InstanceNotManaged("nope")
 	marker.GraphResolutionFailed("bad graph")
@@ -65,7 +63,6 @@ func TestConditionsMarkerAndInitialStatus(t *testing.T) {
 	assert.Equal(t, metav1.ConditionFalse, conditionByType(t, instance, InstanceManaged).Status)
 	assert.Equal(t, metav1.ConditionFalse, conditionByType(t, instance, GraphResolved).Status)
 	assert.Equal(t, metav1.ConditionUnknown, conditionByType(t, instance, ResourcesReady).Status)
-	assert.Equal(t, metav1.ConditionTrue, conditionByType(t, instance, ReconciliationSuspended).Status)
 }
 
 func TestUpdateStatusPaths(t *testing.T) {


### PR DESCRIPTION
The instance controller silently returned errors when graph resolution failed, leaving stale conditions from the last successful reconcile. Users had no signal on the instance about why it wasn't progressing.

Now `resolveCompiledGraph` failures mark `GraphResolved=False` with the resolution error and persist conditions via a minimal status write path that works without a full `ReconcileContext`. The instance state is set to Error so the failure is visible in kubectl.

Adds `instance_graph_resolution_total` (by gvr) and
`instance_graph_resolution_failures_total` (by gvr, reason) metrics. The reason label distinguishes not_available, pending, failed, and unknown_state cases. The metric is emitted inside resolveCompiledGraph so it fires on every failure path regardless of caller.

Removes the `ReconciliationSuspended` condition - it was a non-terminal condition set independently of the Ready rollup, and the suspend annotation still works without it (it just skips node reconciliation).