### PR TITLE
feat(perf): use DefaultUnstructuredConverter to eliminate JSON round-trips in conditions

### DIFF
--- a/pkg/controller/instance/events.go
+++ b/pkg/controller/instance/events.go
@@ -66,11 +66,8 @@ func eventTypeForTransition(newStatus metav1.ConditionStatus) string {
 }
 
 // conditionsFromInstance extracts status conditions from an unstructured object.
-//
-// TODO(perf): This performs a JSON marshal/unmarshal round-trip via
-// unstructuredWrapper.GetConditions(). For better performance we could
-// keep raw []v1alpha1.Condition at the resource level to avoid the
-// conversion on every reconciliation.
+// It uses runtime.DefaultUnstructuredConverter to convert directly between
+// map[string]interface{} and typed structs, avoiding JSON serialization overhead.
 func conditionsFromInstance(inst *unstructured.Unstructured) []v1alpha1.Condition {
 	return (&unstructuredWrapper{inst}).GetConditions()
 }

--- a/pkg/controller/instance/status.go
+++ b/pkg/controller/instance/status.go
@@ -16,11 +16,11 @@ package instance
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
@@ -48,34 +48,34 @@ type unstructuredWrapper struct {
 }
 
 func (u *unstructuredWrapper) GetConditions() []v1alpha1.Condition {
-	if conditions, found, err := unstructured.NestedSlice(u.Object, "status", "conditions"); err == nil && found {
-		// Marshal the conditions slice to JSON and then unmarshal to []v1alpha1.Condition
-		conditionsJSON, err := json.Marshal(conditions)
-		if err != nil {
-			panic(err)
-		}
-
-		var result []v1alpha1.Condition
-		if err := json.Unmarshal(conditionsJSON, &result); err != nil {
-			panic(err)
-		}
-		return result
+	condSlice, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if err != nil || !found {
+		return []v1alpha1.Condition{}
 	}
-	return []v1alpha1.Condition{}
+	result := make([]v1alpha1.Condition, 0, len(condSlice))
+	for _, item := range condSlice {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		var c v1alpha1.Condition
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(m, &c); err != nil {
+			continue
+		}
+		result = append(result, c)
+	}
+	return result
 }
 
 func (u *unstructuredWrapper) SetConditions(conditions []v1alpha1.Condition) {
-	// Marshal the conditions to JSON and then unmarshal to interface{} slice
-	conditionsJSON, err := json.Marshal(conditions)
-	if err != nil {
-		return // Fail silently - could log this in the future
+	conditionsInterface := make([]interface{}, 0, len(conditions))
+	for _, c := range conditions {
+		raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&c)
+		if err != nil {
+			return // Fail silently - could log this in the future
+		}
+		conditionsInterface = append(conditionsInterface, raw)
 	}
-
-	var conditionsInterface []interface{}
-	if err := json.Unmarshal(conditionsJSON, &conditionsInterface); err != nil {
-		return // Fail silently - could log this in the future
-	}
-
 	if err := unstructured.SetNestedSlice(u.Object, conditionsInterface, "status", "conditions"); err != nil {
 		return // Fail silently - could log this in the future
 	}
@@ -212,15 +212,16 @@ func (c *Controller) updateStatus(rcx *ReconcileContext) error {
 func (rcx *ReconcileContext) initialStatus() map[string]interface{} {
 	inst := rcx.Instance
 
-	conds := condSet.For(&unstructuredWrapper{inst}).List()
+	cs := condSet.For(&unstructuredWrapper{inst})
+	conds := cs.List()
 
-	b, err := json.Marshal(conds)
-	if err != nil {
-		panic(err)
-	}
-	var arr []interface{}
-	if err := json.Unmarshal(b, &arr); err != nil {
-		panic(err)
+	arr := make([]interface{}, 0, len(conds))
+	for _, c := range conds {
+		raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&c)
+		if err != nil {
+			panic(err)
+		}
+		arr = append(arr, raw)
 	}
 
 	// Start fresh - user-defined status fields come solely from current resolution,
@@ -229,7 +230,7 @@ func (rcx *ReconcileContext) initialStatus() map[string]interface{} {
 	status := map[string]interface{}{
 		"conditions": arr,
 	}
-	if condSet.For(&unstructuredWrapper{inst}).IsRootReady() {
+	if cs.IsRootReady() {
 		status["state"] = v1alpha1.InstanceStateActive
 	} else {
 		status["state"] = rcx.StateManager.State


### PR DESCRIPTION
Replaced `json.Marshal`/`json.Unmarshal` round-trips in `unstructuredWrapper.GetConditions()`, `SetConditions()`, and `initialStatus()` with `runtime.DefaultUnstructuredConverter`, which converts directly between `map[string]interface{}` and typed structs without intermediate JSON byte serialization.

### Why

The JSON round-trip was executed 10-20+ times per reconciliation (every `ConditionSet` operation calls `GetConditions()`/`SetConditions()` internally). `DefaultUnstructuredConverter` avoids the allocation and parsing overhead of JSON bytes.

### Future Work

If profiling shows condition conversion remains a bottleneck, a deeper refactor could store `[]v1alpha1.Condition` directly in `ReconcileContext`, parse once at reconciliation start, and serialize once at the end — eliminating repeated conversions entirely. This would require reworking the `Object` interface used by `ConditionSet`.
