### PR TITLE
expose leader election tuning flags in helm chart

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -89,6 +89,9 @@ func main() {
 		rgdMaxCollectionDimensionSize int
 		rgdMaxGraphRevisions          int
 		rgdProgressRequeueDelay       time.Duration
+		leaderElectionLeaseDuration   time.Duration
+		leaderElectionRenewDeadline   time.Duration
+		leaderElectionRetryPeriod     time.Duration
 		featureGatesFlag              string
 	)
 
@@ -160,6 +163,12 @@ func main() {
 		"Maximum number of GraphRevisions to retain per ResourceGraphDefinition")
 	flag.DurationVar(&rgdProgressRequeueDelay, "rgd-progress-requeue-delay", 3*time.Second,
 		"Delay before requeuing while an RGD is waiting for asynchronous progress")
+	flag.DurationVar(&leaderElectionLeaseDuration, "leader-election-lease-duration", 15*time.Second,
+		"Duration that non-leader candidates will wait to force acquire leadership.")
+	flag.DurationVar(&leaderElectionRenewDeadline, "leader-election-renew-deadline", 10*time.Second,
+		"Duration the acting leader will retry refreshing leadership before giving up.")
+	flag.DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 2*time.Second,
+		"Duration between each leader election action.")
 
 	opts := zap.Options{
 		Development: true,
@@ -207,6 +216,9 @@ func main() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "controller.kro.run",
 		LeaderElectionNamespace: leaderElectionNamespace,
+		LeaseDuration:           &leaderElectionLeaseDuration,
+		RenewDeadline:           &leaderElectionRenewDeadline,
+		RetryPeriod:             &leaderElectionRetryPeriod,
 		Controller: ctrlconfig.Controller{
 			// EnableWarmup allows controllers to start their sources (watches/informers) before
 			// leader election is won. This pre-populates caches and improves leader failover time.

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -95,6 +95,12 @@ spec:
               value: {{ .Values.config.rgd.maxGraphRevisions | quote }}
             - name: KRO_RGD_PROGRESS_REQUEUE_DELAY
               value: {{ .Values.config.resourceGraphDefinitionProgressRequeueDelay | quote }}
+            - name: KRO_LEADER_ELECTION_LEASE_DURATION
+              value: {{ .Values.config.leaderElectionLeaseDuration | quote }}
+            - name: KRO_LEADER_ELECTION_RENEW_DEADLINE
+              value: {{ .Values.config.leaderElectionRenewDeadline | quote }}
+            - name: KRO_LEADER_ELECTION_RETRY_PERIOD
+              value: {{ .Values.config.leaderElectionRetryPeriod | quote }}
           args:
             {{- if .Values.config.allowCRDDeletion }}
             - --allow-crd-deletion
@@ -139,6 +145,12 @@ spec:
             - "$(KRO_RGD_MAX_GRAPH_REVISIONS)"
             - --rgd-progress-requeue-delay
             - "$(KRO_RGD_PROGRESS_REQUEUE_DELAY)"
+            - --leader-election-lease-duration
+            - "$(KRO_LEADER_ELECTION_LEASE_DURATION)"
+            - --leader-election-renew-deadline
+            - "$(KRO_LEADER_ELECTION_RENEW_DEADLINE)"
+            - --leader-election-retry-period
+            - "$(KRO_LEADER_ELECTION_RETRY_PERIOD)"
             {{- if .Values.config.enableLeaderElection }}
             - --leader-elect
             {{- if ne .Values.config.leaderElectionNamespace "" }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -126,6 +126,12 @@ config:
   # will attempt to use the namespace of the service account mounted to the Controller
   # pod.
   leaderElectionNamespace: ""
+  # Duration that non-leader candidates will wait to force acquire leadership.
+  leaderElectionLeaseDuration: 15s
+  # Duration the acting leader will retry refreshing leadership before giving up.
+  leaderElectionRenewDeadline: 10s
+  # Duration between each leader election action.
+  leaderElectionRetryPeriod: 2s
   # Enable controller warmup to start controller sources (watches/informers) before
   # leader election is won. This pre-populates caches and improves leader failover time.
   # Requires enableLeaderElection to be true.


### PR DESCRIPTION
The controller-runtime leader election defaults (15s lease, 10s renew, 2s retry) are hardcoded and can't be adjusted without rebuilding. Under heavy API server load - e.g scale testing with hundreds of concurrent reconcilers - the leader can fail to renew its lease in time, causing an unnecessary restart.

Add `--leader-election-lease-duration`, `--leader-election-renew-deadline`, and `--leader-election-retry-period` flags to the controller binary and expose them as helm values.

Defaults remain identical to controller-runtime (15s/10s/2s), so no behavioral change for existing deployments.