### PR TITLE
watch graph revisions by `spec.snapshot.name` for orphan adoption

### DIFF
--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -134,6 +134,10 @@ func (r *ResourceGraphDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) e
 			},
 		).
 		Owns(&internalv1alpha1.GraphRevision{}).
+		Watches(
+			&internalv1alpha1.GraphRevision{},
+			handler.EnqueueRequestsFromMapFunc(r.findRGDsForGraphRevision),
+		).
 		WatchesMetadata(
 			&extv1.CustomResourceDefinition{},
 			handler.EnqueueRequestsFromMapFunc(r.findRGDsForCRD),
@@ -229,6 +233,26 @@ func (r *ResourceGraphDefinitionReconciler) findRGDsForCRD(ctx context.Context, 
 				Name: rgdName,
 			},
 		},
+	}
+}
+
+// findRGDsForGraphRevision enqueues the RGD named in spec.snapshot.name.
+//
+// This watch supplements .Owns() which only covers GRs with an ownerReference.
+// Orphaned revisions (ownerRef stripped or never set) still carry the RGD name
+// in their spec, so this watch ensures the RGD is notified and can adopt them.
+// Together the two watches cover both identity axes: ownerRef (GC/lifecycle)
+// and spec.snapshot.name (logical grouping used by listGraphRevisions).
+func (r *ResourceGraphDefinitionReconciler) findRGDsForGraphRevision(_ context.Context, obj client.Object) []reconcile.Request {
+	gr, ok := obj.(*internalv1alpha1.GraphRevision)
+	if !ok {
+		return nil
+	}
+	if gr.Spec.Snapshot.Name == "" {
+		return nil
+	}
+	return []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Name: gr.Spec.Snapshot.Name}},
 	}
 }
 

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile.go
@@ -26,6 +26,7 @@ import (
 
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -86,10 +87,18 @@ func (r *ResourceGraphDefinitionReconciler) reconcileResourceGraphDefinition(
 		return ctrl.Result{}, nil, nil, err
 	}
 
-	graphRevisions, hasTerminating, err := r.listGraphRevisions(ctx, rgd)
+	graphRevisions, hasTerminating, orphanIndices, err := r.listGraphRevisions(ctx, rgd)
 	if err != nil {
 		resolutionResult = graphRevisionResolutionResultFailed
 		return ctrl.Result{}, nil, nil, fmt.Errorf("listing graph revisions: %w", err)
+	}
+
+	// Adopt orphaned revisions by stamping the current RGD's ownerReference.
+	// This restores cascade-delete semantics and .Owns() watch coverage.
+	if len(orphanIndices) > 0 {
+		if err := r.adoptGraphRevisions(ctx, rgd, graphRevisions, orphanIndices); err != nil {
+			return ctrl.Result{}, nil, nil, fmt.Errorf("adopting orphaned graph revisions: %w", err)
+		}
 	}
 
 	// If no live revisions exist, clear any stale registry entries from a
@@ -416,31 +425,90 @@ func newCRDError(err error) error             { return &crdError{err} }
 func newMicroControllerError(err error) error { return &microControllerError{err} }
 
 // listGraphRevisions returns the graph revisions for an RGD, split into live
-// and terminating sets.
+// and terminating sets, and identifies orphans that need adoption.
 //
 // GraphRevisions are grouped by RGD name (not UID) so a recreated RGD with the
 // same name can adopt the existing revisions. The list uses the direct API
 // reader with a CRD selectable field on spec.snapshot.name rather than a
 // cache-only field index. The caller uses the terminating flag to defer
 // decisions while GC is in flight.
-func (r *ResourceGraphDefinitionReconciler) listGraphRevisions(ctx context.Context, rgd *v1alpha1.ResourceGraphDefinition) (live []internalv1alpha1.GraphRevision, hasTerminating bool, err error) {
+//
+// A live revision is considered orphaned when it lacks a controller ownerReference
+// pointing to the current RGD UID. This happens after an orphan-policy delete or
+// when a GR is created externally with a matching spec.snapshot.name.
+func (r *ResourceGraphDefinitionReconciler) listGraphRevisions(ctx context.Context, rgd *v1alpha1.ResourceGraphDefinition) (live []internalv1alpha1.GraphRevision, hasTerminating bool, orphans []int, err error) {
 	revisionList := &internalv1alpha1.GraphRevisionList{}
 	if err := r.apiReader.List(ctx, revisionList, client.MatchingFields{
 		"spec.snapshot.name": rgd.Name,
 	}); err != nil {
-		return nil, false, err
+		return nil, false, nil, err
 	}
 
+	// Separate live revisions from terminating ones. Terminating revisions
+	// are being deleted and should not influence resolution or issuance.
 	live = make([]internalv1alpha1.GraphRevision, 0, len(revisionList.Items))
 	for i := range revisionList.Items {
-		if revisionList.Items[i].GetDeletionTimestamp().IsZero() {
-			live = append(live, revisionList.Items[i])
-		} else {
+		if !revisionList.Items[i].GetDeletionTimestamp().IsZero() {
 			hasTerminating = true
+			continue
+		}
+		live = append(live, revisionList.Items[i])
+	}
+
+	// Identify live revisions missing an ownerReference to the current RGD.
+	// These need adoption to restore cascade-delete and .Owns() watch coverage.
+	for i := range live {
+		if !isOwnedBy(&live[i], rgd.UID) {
+			orphans = append(orphans, i)
 		}
 	}
 
-	return live, hasTerminating, nil
+	return live, hasTerminating, orphans, nil
+}
+
+// isOwnedBy returns true if the GR has a controller ownerReference matching the
+// given RGD UID.
+func isOwnedBy(gr *internalv1alpha1.GraphRevision, uid types.UID) bool {
+	for _, ref := range gr.OwnerReferences {
+		if ref.UID == uid && ref.Kind == metadata.KRORGOwnerReferenceKind && ref.Controller != nil && *ref.Controller {
+			return true
+		}
+	}
+	return false
+}
+
+// adoptGraphRevisions ensures every orphaned GraphRevision is owned by the
+// current RGD. If a GR already has a stale RGD ownerRef (e.g. from a
+// delete-recreate cycle), it is replaced. If none exists, one is added.
+func (r *ResourceGraphDefinitionReconciler) adoptGraphRevisions(
+	ctx context.Context,
+	rgd *v1alpha1.ResourceGraphDefinition,
+	live []internalv1alpha1.GraphRevision,
+	orphanIndices []int,
+) error {
+	log := ctrl.LoggerFrom(ctx)
+	desired := metadata.NewResourceGraphDefinitionOwnerReference(rgd.Name, rgd.UID)
+	for _, idx := range orphanIndices {
+		gr := &live[idx]
+		gr.OwnerReferences = setRGDOwnerReference(gr.OwnerReferences, desired)
+		if err := r.Update(ctx, gr); err != nil {
+			return fmt.Errorf("adopting graph revision %q: %w", gr.Name, err)
+		}
+		log.V(1).Info("adopted graph revision", "graphRevision", gr.Name, "revision", gr.Spec.Revision)
+	}
+	return nil
+}
+
+// setRGDOwnerReference replaces the existing RGD ownerReference in place,
+// or appends one if none exists.
+func setRGDOwnerReference(refs []metav1.OwnerReference, desired metav1.OwnerReference) []metav1.OwnerReference {
+	for i, ref := range refs {
+		if ref.Kind == metadata.KRORGOwnerReferenceKind && ref.APIVersion == metadata.KRORGOwnerReferenceAPIVersion {
+			refs[i] = desired
+			return refs
+		}
+	}
+	return append(refs, desired)
 }
 
 type latestGraphRevisionView struct {
@@ -623,7 +691,7 @@ func (r *ResourceGraphDefinitionReconciler) garbageCollectGraphRevisions(ctx con
 		return nil
 	}
 
-	graphRevisions, _, err := r.listGraphRevisions(ctx, rgd)
+	graphRevisions, _, _, err := r.listGraphRevisions(ctx, rgd)
 	if err != nil {
 		graphRevisionGCErrorsTotal.WithLabelValues().Inc()
 		return fmt.Errorf("listing graph revisions for gc: %w", err)

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile_test.go
@@ -131,10 +131,12 @@ func TestListGraphRevisions_UsesSnapshotNameSelector(t *testing.T) {
 		},
 	}
 
-	got, hasTerminating, err := reconciler.listGraphRevisions(context.Background(), recreatedRGD)
+	got, hasTerminating, orphans, err := reconciler.listGraphRevisions(context.Background(), recreatedRGD)
 	require.NoError(t, err)
 	assert.False(t, hasTerminating)
 	require.Len(t, got, 2)
+	// Both GRs lack an ownerRef pointing to the recreated RGD's UID.
+	assert.Len(t, orphans, 2)
 
 	byRevision := map[int64]internalv1alpha1.GraphRevision{}
 	for _, revision := range got {
@@ -168,10 +170,12 @@ func TestListGraphRevisions_SkipsTerminatingRevisions(t *testing.T) {
 
 	reconciler := &ResourceGraphDefinitionReconciler{Client: cl, apiReader: cl}
 
-	got, hasTerminating, err := reconciler.listGraphRevisions(context.Background(), rgd)
+	got, hasTerminating, orphans, err := reconciler.listGraphRevisions(context.Background(), rgd)
 	require.NoError(t, err)
 	assert.True(t, hasTerminating)
 	require.Len(t, got, 1)
+	// The live GR has no ownerRef, so it's an orphan.
+	assert.Len(t, orphans, 1)
 	assert.Equal(t, int64(2), got[0].Spec.Revision)
 }
 
@@ -1937,6 +1941,376 @@ func TestGraphRevisionRetentionFloor(t *testing.T) {
 			assert.Equal(t, tt.wantFloor, got)
 		})
 	}
+}
+
+func TestIsOwnedBy(t *testing.T) {
+	t.Parallel()
+
+	rgdUID := types.UID("current-uid")
+	staleUID := types.UID("old-uid")
+	otherUID := types.UID("other-uid")
+
+	tests := []struct {
+		name string
+		gr   *internalv1alpha1.GraphRevision
+		want bool
+	}{
+		{
+			name: "no ownerReferences",
+			gr:   &internalv1alpha1.GraphRevision{},
+			want: false,
+		},
+		{
+			name: "owned by current RGD",
+			gr: &internalv1alpha1.GraphRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						metadata.NewResourceGraphDefinitionOwnerReference("demo", rgdUID),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "stale UID from previous RGD incarnation",
+			gr: &internalv1alpha1.GraphRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						metadata.NewResourceGraphDefinitionOwnerReference("demo", staleUID),
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "owned by a different kind with same UID",
+			gr: &internalv1alpha1.GraphRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "SomethingElse",
+							APIVersion: "other.io/v1",
+							UID:        rgdUID,
+							Controller: &[]bool{true}[0],
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "non-controller RGD ref with matching UID",
+			gr: &internalv1alpha1.GraphRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       metadata.KRORGOwnerReferenceKind,
+							APIVersion: metadata.KRORGOwnerReferenceAPIVersion,
+							UID:        rgdUID,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "multiple refs, one matching",
+			gr: &internalv1alpha1.GraphRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Other", APIVersion: "v1", UID: otherUID, Controller: &[]bool{true}[0]},
+						metadata.NewResourceGraphDefinitionOwnerReference("demo", rgdUID),
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isOwnedBy(tt.gr, rgdUID))
+		})
+	}
+}
+
+func TestSetRGDOwnerReference(t *testing.T) {
+	t.Parallel()
+
+	desired := metadata.NewResourceGraphDefinitionOwnerReference("demo", "new-uid")
+	stale := metadata.NewResourceGraphDefinitionOwnerReference("demo", "old-uid")
+	unrelated := metav1.OwnerReference{
+		Kind: "Deployment", APIVersion: "apps/v1", UID: "deploy-uid",
+		Controller: &[]bool{true}[0],
+	}
+
+	tests := []struct {
+		name string
+		refs []metav1.OwnerReference
+		want []metav1.OwnerReference
+	}{
+		{
+			name: "appends when no refs exist",
+			refs: nil,
+			want: []metav1.OwnerReference{desired},
+		},
+		{
+			name: "appends when no RGD ref exists",
+			refs: []metav1.OwnerReference{unrelated},
+			want: []metav1.OwnerReference{unrelated, desired},
+		},
+		{
+			name: "replaces stale RGD ref in place",
+			refs: []metav1.OwnerReference{stale},
+			want: []metav1.OwnerReference{desired},
+		},
+		{
+			name: "replaces stale ref preserving other refs",
+			refs: []metav1.OwnerReference{unrelated, stale},
+			want: []metav1.OwnerReference{unrelated, desired},
+		},
+		{
+			name: "replaces when desired is already present (idempotent)",
+			refs: []metav1.OwnerReference{desired},
+			want: []metav1.OwnerReference{desired},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := setRGDOwnerReference(tt.refs, desired)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestListGraphRevisions_DetectsOrphans(t *testing.T) {
+	t.Parallel()
+
+	rgdUID := types.UID("current-uid")
+	rgd := &v1alpha1.ResourceGraphDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", UID: rgdUID},
+	}
+
+	ownedGR := newListedGraphRevision(rgd, 1, "hash-1")
+	ownedGR.OwnerReferences = []metav1.OwnerReference{
+		metadata.NewResourceGraphDefinitionOwnerReference("demo", rgdUID),
+	}
+
+	orphanNoRef := newListedGraphRevision(rgd, 2, "hash-2")
+	// No ownerReferences — simulates orphan-policy delete.
+
+	staleUID := types.UID("old-uid")
+	orphanStaleRef := newListedGraphRevision(rgd, 3, "hash-3")
+	orphanStaleRef.OwnerReferences = []metav1.OwnerReference{
+		metadata.NewResourceGraphDefinitionOwnerReference("demo", staleUID),
+	}
+
+	cl := newFakeClientBuilder().
+		WithObjects(ownedGR, orphanNoRef, orphanStaleRef).
+		Build()
+	reconciler := &ResourceGraphDefinitionReconciler{Client: cl, apiReader: cl}
+
+	live, hasTerminating, orphans, err := reconciler.listGraphRevisions(context.Background(), rgd)
+	require.NoError(t, err)
+	assert.False(t, hasTerminating)
+	require.Len(t, live, 3)
+	// Revisions 2 (no ref) and 3 (stale ref) are orphans.
+	require.Len(t, orphans, 2)
+	assert.Equal(t, int64(2), live[orphans[0]].Spec.Revision)
+	assert.Equal(t, int64(3), live[orphans[1]].Spec.Revision)
+}
+
+func TestListGraphRevisions_NoOrphansWhenAllOwned(t *testing.T) {
+	t.Parallel()
+
+	rgdUID := types.UID("current-uid")
+	rgd := &v1alpha1.ResourceGraphDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", UID: rgdUID},
+	}
+
+	gr1 := newListedGraphRevision(rgd, 1, "hash-1")
+	gr1.OwnerReferences = []metav1.OwnerReference{
+		metadata.NewResourceGraphDefinitionOwnerReference("demo", rgdUID),
+	}
+	gr2 := newListedGraphRevision(rgd, 2, "hash-2")
+	gr2.OwnerReferences = []metav1.OwnerReference{
+		metadata.NewResourceGraphDefinitionOwnerReference("demo", rgdUID),
+	}
+
+	cl := newFakeClientBuilder().
+		WithObjects(gr1, gr2).
+		Build()
+	reconciler := &ResourceGraphDefinitionReconciler{Client: cl, apiReader: cl}
+
+	live, _, orphans, err := reconciler.listGraphRevisions(context.Background(), rgd)
+	require.NoError(t, err)
+	require.Len(t, live, 2)
+	assert.Empty(t, orphans)
+}
+
+func TestListGraphRevisions_DoesNotCrossBoundaries(t *testing.T) {
+	t.Parallel()
+
+	rgdA := &v1alpha1.ResourceGraphDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "rgd-a", UID: "uid-a"},
+	}
+	rgdB := &v1alpha1.ResourceGraphDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "rgd-b", UID: "uid-b"},
+	}
+
+	// GR belonging to rgd-a.
+	grA := newListedGraphRevision(rgdA, 1, "hash")
+	grA.OwnerReferences = []metav1.OwnerReference{
+		metadata.NewResourceGraphDefinitionOwnerReference("rgd-a", "uid-a"),
+	}
+
+	// GR belonging to rgd-b — must not appear when listing for rgd-a.
+	grB := newListedGraphRevision(rgdB, 1, "hash")
+	grB.OwnerReferences = []metav1.OwnerReference{
+		metadata.NewResourceGraphDefinitionOwnerReference("rgd-b", "uid-b"),
+	}
+
+	cl := newFakeClientBuilder().
+		WithObjects(grA, grB).
+		Build()
+	reconciler := &ResourceGraphDefinitionReconciler{Client: cl, apiReader: cl}
+
+	liveA, _, orphansA, err := reconciler.listGraphRevisions(context.Background(), rgdA)
+	require.NoError(t, err)
+	require.Len(t, liveA, 1)
+	assert.Equal(t, "rgd-a", liveA[0].Spec.Snapshot.Name)
+	assert.Empty(t, orphansA)
+
+	liveB, _, orphansB, err := reconciler.listGraphRevisions(context.Background(), rgdB)
+	require.NoError(t, err)
+	require.Len(t, liveB, 1)
+	assert.Equal(t, "rgd-b", liveB[0].Spec.Snapshot.Name)
+	assert.Empty(t, orphansB)
+}
+
+func TestAdoptGraphRevisions(t *testing.T) {
+	t.Parallel()
+
+	rgdUID := types.UID("current-uid")
+	rgd := &v1alpha1.ResourceGraphDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", UID: rgdUID},
+	}
+
+	t.Run("stamps ownerRef on orphan with no refs", func(t *testing.T) {
+		t.Parallel()
+		gr := newListedGraphRevision(rgd, 1, "hash")
+		cl := newFakeClientBuilder().WithObjects(gr).Build()
+		reconciler := &ResourceGraphDefinitionReconciler{Client: cl, apiReader: cl}
+
+		live := []internalv1alpha1.GraphRevision{*gr}
+		err := reconciler.adoptGraphRevisions(
+			ctrl.LoggerInto(context.Background(), logr.Discard()),
+			rgd, live, []int{0},
+		)
+		require.NoError(t, err)
+
+		var updated internalv1alpha1.GraphRevision
+		require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: gr.Name}, &updated))
+		require.Len(t, updated.OwnerReferences, 1)
+		assert.Equal(t, rgdUID, updated.OwnerReferences[0].UID)
+		assert.Equal(t, metadata.KRORGOwnerReferenceKind, updated.OwnerReferences[0].Kind)
+	})
+
+	t.Run("replaces stale RGD ownerRef", func(t *testing.T) {
+		t.Parallel()
+		gr := newListedGraphRevision(rgd, 2, "hash")
+		gr.OwnerReferences = []metav1.OwnerReference{
+			metadata.NewResourceGraphDefinitionOwnerReference("demo", "old-uid"),
+		}
+		cl := newFakeClientBuilder().WithObjects(gr).Build()
+		reconciler := &ResourceGraphDefinitionReconciler{Client: cl, apiReader: cl}
+
+		live := []internalv1alpha1.GraphRevision{*gr}
+		err := reconciler.adoptGraphRevisions(
+			ctrl.LoggerInto(context.Background(), logr.Discard()),
+			rgd, live, []int{0},
+		)
+		require.NoError(t, err)
+
+		var updated internalv1alpha1.GraphRevision
+		require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: gr.Name}, &updated))
+		require.Len(t, updated.OwnerReferences, 1)
+		assert.Equal(t, rgdUID, updated.OwnerReferences[0].UID)
+	})
+
+	t.Run("preserves non-RGD ownerRefs", func(t *testing.T) {
+		t.Parallel()
+		gr := newListedGraphRevision(rgd, 3, "hash")
+		unrelated := metav1.OwnerReference{
+			Kind: "Deployment", APIVersion: "apps/v1", UID: "deploy-uid",
+		}
+		gr.OwnerReferences = []metav1.OwnerReference{
+			unrelated,
+			metadata.NewResourceGraphDefinitionOwnerReference("demo", "old-uid"),
+		}
+		cl := newFakeClientBuilder().WithObjects(gr).Build()
+		reconciler := &ResourceGraphDefinitionReconciler{Client: cl, apiReader: cl}
+
+		live := []internalv1alpha1.GraphRevision{*gr}
+		err := reconciler.adoptGraphRevisions(
+			ctrl.LoggerInto(context.Background(), logr.Discard()),
+			rgd, live, []int{0},
+		)
+		require.NoError(t, err)
+
+		var updated internalv1alpha1.GraphRevision
+		require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: gr.Name}, &updated))
+		require.Len(t, updated.OwnerReferences, 2)
+		assert.Equal(t, "Deployment", updated.OwnerReferences[0].Kind)
+		assert.Equal(t, rgdUID, updated.OwnerReferences[1].UID)
+	})
+
+	t.Run("adopts multiple orphans", func(t *testing.T) {
+		t.Parallel()
+		gr1 := newListedGraphRevision(rgd, 4, "hash")
+		gr2 := newListedGraphRevision(rgd, 5, "hash")
+		cl := newFakeClientBuilder().WithObjects(gr1, gr2).Build()
+		reconciler := &ResourceGraphDefinitionReconciler{Client: cl, apiReader: cl}
+
+		live := []internalv1alpha1.GraphRevision{*gr1, *gr2}
+		err := reconciler.adoptGraphRevisions(
+			ctrl.LoggerInto(context.Background(), logr.Discard()),
+			rgd, live, []int{0, 1},
+		)
+		require.NoError(t, err)
+
+		for _, name := range []string{gr1.Name, gr2.Name} {
+			var updated internalv1alpha1.GraphRevision
+			require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: name}, &updated))
+			require.Len(t, updated.OwnerReferences, 1)
+			assert.Equal(t, rgdUID, updated.OwnerReferences[0].UID)
+		}
+	})
+
+	t.Run("returns error on update failure", func(t *testing.T) {
+		t.Parallel()
+		gr := newListedGraphRevision(rgd, 6, "hash")
+		cl := newFakeClientBuilder().
+			WithObjects(gr).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Update: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.UpdateOption) error {
+					return fmt.Errorf("api server gone")
+				},
+			}).
+			Build()
+		reconciler := &ResourceGraphDefinitionReconciler{Client: cl, apiReader: cl}
+
+		live := []internalv1alpha1.GraphRevision{*gr}
+		err := reconciler.adoptGraphRevisions(
+			ctrl.LoggerInto(context.Background(), logr.Discard()),
+			rgd, live, []int{0},
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "api server gone")
+	})
 }
 
 func newListedGraphRevision(rgd *v1alpha1.ResourceGraphDefinition, revision int64, specHash string) *internalv1alpha1.GraphRevision {

--- a/pkg/controller/resourcegraphdefinition/controller_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_test.go
@@ -1093,6 +1093,87 @@ func TestResourceGraphDefinitionPrimaryWatchPredicateRejectsNilObjects(t *testin
 	}))
 }
 
+func TestFindRGDsForGraphRevision(t *testing.T) {
+	t.Parallel()
+	reconciler := &ResourceGraphDefinitionReconciler{}
+
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []reconcile.Request
+	}{
+		{
+			name: "returns nil for non-GraphRevision object",
+			obj: &extv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "not-a-gr"},
+			},
+		},
+		{
+			name: "returns nil when spec.snapshot.name is empty",
+			obj: &internalv1alpha1.GraphRevision{
+				ObjectMeta: metav1.ObjectMeta{Name: "gr-empty"},
+				Spec: internalv1alpha1.GraphRevisionSpec{
+					Snapshot: internalv1alpha1.ResourceGraphDefinitionSnapshot{},
+				},
+			},
+		},
+		{
+			name: "enqueues RGD from spec.snapshot.name",
+			obj: &internalv1alpha1.GraphRevision{
+				ObjectMeta: metav1.ObjectMeta{Name: "demo-r00001"},
+				Spec: internalv1alpha1.GraphRevisionSpec{
+					Snapshot: internalv1alpha1.ResourceGraphDefinitionSnapshot{
+						Name: "demo-rgd",
+					},
+				},
+			},
+			want: []reconcile.Request{{
+				NamespacedName: types.NamespacedName{Name: "demo-rgd"},
+			}},
+		},
+		{
+			name: "enqueues based on spec not labels",
+			obj: &internalv1alpha1.GraphRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gr-mismatch",
+					Labels: map[string]string{
+						metadata.ResourceGraphDefinitionNameLabel: "label-rgd",
+					},
+				},
+				Spec: internalv1alpha1.GraphRevisionSpec{
+					Snapshot: internalv1alpha1.ResourceGraphDefinitionSnapshot{
+						Name: "spec-rgd",
+					},
+				},
+			},
+			want: []reconcile.Request{{
+				NamespacedName: types.NamespacedName{Name: "spec-rgd"},
+			}},
+		},
+		{
+			name: "enqueues for orphaned GR without ownerReferences",
+			obj: &internalv1alpha1.GraphRevision{
+				ObjectMeta: metav1.ObjectMeta{Name: "orphan-r00001"},
+				Spec: internalv1alpha1.GraphRevisionSpec{
+					Snapshot: internalv1alpha1.ResourceGraphDefinitionSnapshot{
+						Name: "orphan-rgd",
+					},
+				},
+			},
+			want: []reconcile.Request{{
+				NamespacedName: types.NamespacedName{Name: "orphan-rgd"},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, reconciler.findRGDsForGraphRevision(context.Background(), tt.obj))
+		})
+	}
+}
+
 func newPredicateTestRGD(generation int64, deletionTimestamp *metav1.Time) *v1alpha1.ResourceGraphDefinition {
 	return &v1alpha1.ResourceGraphDefinition{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/integration/suites/core/graphrevision_test.go
+++ b/test/integration/suites/core/graphrevision_test.go
@@ -1894,6 +1894,285 @@ func emulateOrphanDeleteForRGD(ctx SpecContext, rgdName string) {
 	}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 }
 
+var _ = Describe("GraphRevision Adoption", func() {
+
+	It("should stamp ownerRef on orphaned revisions after recreate", func(ctx SpecContext) {
+		const numRevisions = 3
+		rgdName := fmt.Sprintf("gr-adopt-%s", rand.String(5))
+		kind := fmt.Sprintf("GrAdopt%s", rand.String(5))
+
+		createRGDWithRevisions(ctx, rgdName, kind, numRevisions)
+
+		// Record the original RGD UID.
+		var originalRGD krov1alpha1.ResourceGraphDefinition
+		Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgdName}, &originalRGD)).To(Succeed())
+		originalUID := originalRGD.UID
+
+		// All GRs should be owned by the original RGD.
+		for _, gr := range listGraphRevisions(ctx, rgdName) {
+			Expect(gr.OwnerReferences).ToNot(BeEmpty())
+			Expect(gr.OwnerReferences[0].UID).To(Equal(originalUID))
+		}
+
+		// Orphan delete: strip ownerRefs, delete RGD.
+		// With the spec.snapshot.name watch, the RGD may re-adopt GRs before
+		// it is deleted, so we cannot assert ownerRefs are empty here.
+		emulateOrphanDeleteForRGD(ctx, rgdName)
+		Expect(listGraphRevisions(ctx, rgdName)).To(HaveLen(numRevisions))
+
+		// Recreate with same spec as the latest revision.
+		rgd2 := generator.NewResourceGraphDefinition(rgdName,
+			generator.WithSchema(
+				kind, "v1alpha1",
+				map[string]interface{}{
+					"data": "string | default=hello",
+				},
+				nil,
+			),
+			generator.WithResource("configmap", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm-${schema.metadata.name}",
+					"labels": map[string]interface{}{
+						"revision": fmt.Sprintf("rev-%d", numRevisions),
+					},
+				},
+				"data": map[string]interface{}{
+					"key": "${schema.spec.data}",
+				},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd2)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			for _, gr := range listGraphRevisions(ctx, rgdName) {
+				_ = env.Client.Delete(ctx, &gr)
+			}
+			_ = env.Client.Delete(ctx, rgd2)
+		})
+
+		// Wait for active, then verify all GRs have been adopted with the new UID.
+		Eventually(func(g Gomega) {
+			fresh := &krov1alpha1.ResourceGraphDefinition{}
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgdName}, fresh)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(fresh.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+
+			newUID := fresh.UID
+			g.Expect(newUID).ToNot(Equal(originalUID), "recreated RGD should have a new UID")
+
+			for _, gr := range listGraphRevisions(ctx, rgdName) {
+				g.Expect(gr.OwnerReferences).ToNot(BeEmpty(),
+					"GR %s should have an ownerRef after adoption", gr.Name)
+				g.Expect(gr.OwnerReferences[0].UID).To(Equal(newUID),
+					"GR %s should be owned by the new RGD UID", gr.Name)
+				g.Expect(gr.OwnerReferences[0].Kind).To(Equal("ResourceGraphDefinition"))
+			}
+		}, 60*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+
+	It("should replace stale ownerRef UID after RGD recreate", func(ctx SpecContext) {
+		rgdName := fmt.Sprintf("gr-stale-%s", rand.String(5))
+		kind := fmt.Sprintf("GrStale%s", rand.String(5))
+
+		// Create RGD and wait for active with 1 revision.
+		rgd := configmapRGD(rgdName, kind)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+
+		var originalRGD krov1alpha1.ResourceGraphDefinition
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgdName}, &originalRGD)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(originalRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+		originalUID := originalRGD.UID
+
+		// Delete the RGD. envtest has no GC, so GRs with ownerRef survive.
+		Expect(env.Client.Delete(ctx, &krov1alpha1.ResourceGraphDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: rgdName},
+		})).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgdName}, &krov1alpha1.ResourceGraphDefinition{})
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// GRs survive with the old UID in ownerRef.
+		grs := listGraphRevisions(ctx, rgdName)
+		Expect(grs).To(HaveLen(1))
+		Expect(grs[0].OwnerReferences).ToNot(BeEmpty())
+		Expect(grs[0].OwnerReferences[0].UID).To(Equal(originalUID))
+
+		// Recreate with the same spec.
+		rgd2 := configmapRGD(rgdName, kind)
+		Expect(env.Client.Create(ctx, rgd2)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			for _, gr := range listGraphRevisions(ctx, rgdName) {
+				_ = env.Client.Delete(ctx, &gr)
+			}
+			_ = env.Client.Delete(ctx, rgd2)
+		})
+
+		// The stale ownerRef should be replaced with the new UID.
+		Eventually(func(g Gomega) {
+			fresh := &krov1alpha1.ResourceGraphDefinition{}
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgdName}, fresh)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(fresh.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+
+			newUID := fresh.UID
+			g.Expect(newUID).ToNot(Equal(originalUID))
+
+			for _, gr := range listGraphRevisions(ctx, rgdName) {
+				g.Expect(gr.OwnerReferences).To(HaveLen(1),
+					"GR %s should have exactly one ownerRef", gr.Name)
+				g.Expect(gr.OwnerReferences[0].UID).To(Equal(newUID),
+					"GR %s should have the new RGD UID, not the stale one", gr.Name)
+			}
+		}, 60*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+
+	It("should not cross boundaries between RGDs with identical specs", func(ctx SpecContext) {
+		rgdNameA := fmt.Sprintf("gr-iso-a-%s", rand.String(5))
+		rgdNameB := fmt.Sprintf("gr-iso-b-%s", rand.String(5))
+		kindA := fmt.Sprintf("GrIsoA%s", rand.String(5))
+		kindB := fmt.Sprintf("GrIsoB%s", rand.String(5))
+
+		// Create two RGDs with the same resource template but different names/kinds.
+		rgdA := configmapRGD(rgdNameA, kindA)
+		rgdB := configmapRGD(rgdNameB, kindB)
+		Expect(env.Client.Create(ctx, rgdA)).To(Succeed())
+		Expect(env.Client.Create(ctx, rgdB)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			for _, name := range []string{rgdNameA, rgdNameB} {
+				for _, gr := range listGraphRevisions(ctx, name) {
+					_ = env.Client.Delete(ctx, &gr)
+				}
+				_ = env.Client.Delete(ctx, &krov1alpha1.ResourceGraphDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: name},
+				})
+			}
+		})
+
+		// Both become active independently.
+		for _, name := range []string{rgdNameA, rgdNameB} {
+			Eventually(func(g Gomega) {
+				fresh := &krov1alpha1.ResourceGraphDefinition{}
+				err := env.Client.Get(ctx, types.NamespacedName{Name: name}, fresh)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(fresh.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+		}
+
+		// Each RGD has exactly 1 revision, scoped to its own name.
+		grsA := listGraphRevisions(ctx, rgdNameA)
+		grsB := listGraphRevisions(ctx, rgdNameB)
+		Expect(grsA).To(HaveLen(1))
+		Expect(grsB).To(HaveLen(1))
+		Expect(grsA[0].Spec.Snapshot.Name).To(Equal(rgdNameA))
+		Expect(grsB[0].Spec.Snapshot.Name).To(Equal(rgdNameB))
+
+		// Verify ownerRefs point to different UIDs.
+		var uidA, uidB types.UID
+		rgdObjA := &krov1alpha1.ResourceGraphDefinition{}
+		rgdObjB := &krov1alpha1.ResourceGraphDefinition{}
+		Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgdNameA}, rgdObjA)).To(Succeed())
+		Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgdNameB}, rgdObjB)).To(Succeed())
+		uidA = rgdObjA.UID
+		uidB = rgdObjB.UID
+		Expect(uidA).ToNot(Equal(uidB))
+
+		Expect(grsA[0].OwnerReferences[0].UID).To(Equal(uidA))
+		Expect(grsB[0].OwnerReferences[0].UID).To(Equal(uidB))
+	})
+
+	It("should adopt an externally injected GR without ownerRef", func(ctx SpecContext) {
+		rgdName := fmt.Sprintf("gr-ext-%s", rand.String(5))
+		kind := fmt.Sprintf("GrExt%s", rand.String(5))
+
+		// Create RGD and wait for active at revision 1.
+		rgd := configmapRGD(rgdName, kind)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+
+		var activeRGD krov1alpha1.ResourceGraphDefinition
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgdName}, &activeRGD)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(activeRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			g.Expect(activeRGD.Status.LastIssuedRevision).To(Equal(int64(1)))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// Inject a GR with spec.snapshot.name pointing to the RGD but NO ownerRef.
+		// Use a mutated template so the spec hash differs from the current RGD,
+		// forcing the controller to re-issue after adoption.
+		mutatedRGD := generator.NewResourceGraphDefinition(rgdName,
+			generator.WithSchema(
+				kind, "v1alpha1",
+				map[string]interface{}{
+					"data": "string | default=hello",
+				},
+				nil,
+			),
+			generator.WithResource("configmap", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm-${schema.metadata.name}",
+					"labels": map[string]interface{}{
+						"injected": "true",
+					},
+				},
+				"data": map[string]interface{}{
+					"key": "${schema.spec.data}",
+				},
+			}, nil, nil),
+		)
+		injectedGR := &internalv1alpha1.GraphRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("%s-r%05d", rgdName, 6),
+				Labels: map[string]string{
+					metadata.ResourceGraphDefinitionNameLabel: rgdName,
+				},
+				// No OwnerReferences — simulates external creation.
+			},
+			Spec: internalv1alpha1.GraphRevisionSpec{
+				Revision: 6,
+				Snapshot: internalv1alpha1.ResourceGraphDefinitionSnapshot{
+					Name: rgdName,
+					Spec: mutatedRGD.Spec,
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, injectedGR)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			for _, gr := range listGraphRevisions(ctx, rgdName) {
+				_ = env.Client.Delete(ctx, &gr)
+			}
+			_ = env.Client.Delete(ctx, &krov1alpha1.ResourceGraphDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: rgdName},
+			})
+		})
+
+		// The RGD should react (spec.snapshot.name watch), adopt the injected GR,
+		// and re-issue because the hash doesn't match.
+		Eventually(func(g Gomega) {
+			fresh := &krov1alpha1.ResourceGraphDefinition{}
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgdName}, fresh)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(fresh.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			// Should have re-issued past revision 6.
+			g.Expect(fresh.Status.LastIssuedRevision).To(BeNumerically(">", int64(6)))
+
+			// The injected GR should now have an ownerRef.
+			var adopted internalv1alpha1.GraphRevision
+			err = env.Client.Get(ctx, types.NamespacedName{Name: injectedGR.Name}, &adopted)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(adopted.OwnerReferences).ToNot(BeEmpty(),
+				"injected GR should be adopted with an ownerRef")
+			g.Expect(adopted.OwnerReferences[0].UID).To(Equal(fresh.UID))
+		}, 60*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+})
+
 func invalidConfigmapRGD(name, kind string) *krov1alpha1.ResourceGraphDefinition {
 	return generator.NewResourceGraphDefinition(name,
 		generator.WithSchema(


### PR DESCRIPTION
The RGD controller watched `GraphRevisions` only via `.Owns()` which
requires an ownerReference. This missed orphaned revisions (`ownerRef`
stripped after orphan-policy delete) and externally created GRs that
carry the right `spec.snapshot.name` but no ownerRef.

Add a spec-based `Watches()` alongside `.Owns()` so the watch trigger
aligns with `listGraphRevisions`, which already groups by
`spec.snapshot.name`. On each reconcile, detect orphaned GRs (missing
or stale controller ownerRef) and adopt them by stamping or replacing
the RGD ownerReference. This restores cascade-delete semantics and
`.Owns()` watch coverage after RGD delete-recreate cycles.