### PR TITLE
fix: make applyset orphan pruning respect reverse topological order

### DIFF
--- a/pkg/controller/instance/applyset/applyset.go
+++ b/pkg/controller/instance/applyset/applyset.go
@@ -60,12 +60,6 @@ type Interface interface {
 	// Batch metadata contains only GKs/namespaces from THIS apply (not parent memory).
 	Apply(ctx context.Context, resources []Resource, mode ApplyMode) (*ApplyResult, Metadata, error)
 
-	// Prune deletes orphaned resources (those with applyset label but not in KeepUIDs).
-	// Pass Project().PruneScope() to search both current batch locations AND parent memory.
-	// Prune deletes all orphans concurrently without ordering guarantees.
-	// For DAG-aware deletion, use ListOrphans + DeleteOrphan instead.
-	Prune(ctx context.Context, opts PruneOptions) (*PruneResult, error)
-
 	// ListOrphans discovers orphaned resources without deleting them.
 	// Returns candidates that the caller can order (e.g. reverse-topological)
 	// before issuing deletes via DeleteOrphan.
@@ -95,7 +89,7 @@ type ApplyMode struct {
 	Concurrency int // 0 = len(resources)
 }
 
-// PruneOptions controls Prune behavior.
+// PruneOptions controls ListOrphans behavior.
 type PruneOptions struct {
 	// KeepUIDs are UIDs of resources that should NOT be pruned.
 	// Typically from ApplyResult.ObservedUIDs().
@@ -105,8 +99,6 @@ type PruneOptions struct {
 	// Pass the superset scope (union of batch + parent) to ensure
 	// prune finds all orphans.
 	Scope *PruneScope
-	// Concurrency limits parallel delete operations. 0 = len(candidates).
-	Concurrency int
 }
 
 // PruneScope defines the search space for orphan detection.
@@ -324,37 +316,6 @@ func (a *ApplySet) Apply(ctx context.Context, resources []Resource, mode ApplyMo
 	return result, a.buildMetadata(desiredGKs, desiredNamespaces), nil
 }
 
-// Prune deletes orphaned resources (those with applyset label but not in KeepUIDs).
-func (a *ApplySet) Prune(ctx context.Context, opts PruneOptions) (*PruneResult, error) {
-	scopeGKs := opts.Scope.GroupKinds
-
-	// Always include parent namespace in prune scope
-	scopeNamespaces := opts.Scope.Namespaces.Clone()
-	if a.parentNamespace != "" {
-		scopeNamespaces.Insert(a.parentNamespace)
-	} else {
-		scopeNamespaces.Insert(metav1.NamespaceDefault)
-	}
-
-	// Convert GKs to RESTMappings
-	pruneMappings := make([]*meta.RESTMapping, 0, len(scopeGKs))
-	for gk := range scopeGKs {
-		mapping, err := a.restMapper.RESTMapping(gk)
-		if err != nil {
-			return nil, fmt.Errorf("RESTMapping failed for %v: %w", gk, err)
-		}
-		pruneMappings = append(pruneMappings, mapping)
-	}
-
-	// List and delete orphans
-	pruned, conflicts, err := a.prune(ctx, pruneMappings, scopeNamespaces, opts.KeepUIDs, opts.Concurrency)
-	if err != nil {
-		return nil, err
-	}
-
-	return &PruneResult{Pruned: pruned, Conflicts: conflicts}, nil
-}
-
 func (a *ApplySet) applyResource(
 	ctx context.Context,
 	r Resource,
@@ -481,7 +442,7 @@ func (a *ApplySet) ListOrphans(ctx context.Context, opts PruneOptions) ([]Orphan
 		mappings = append(mappings, mapping)
 	}
 
-	return a.listOrphans(ctx, mappings, scopeNamespaces, opts.KeepUIDs, opts.Concurrency)
+	return a.listOrphans(ctx, mappings, scopeNamespaces, opts.KeepUIDs)
 }
 
 // DeleteOrphan deletes a single orphan candidate using a UID precondition
@@ -529,7 +490,6 @@ func (a *ApplySet) listOrphans(
 	mappings []*meta.RESTMapping,
 	namespaces sets.Set[string],
 	keepUIDs sets.Set[types.UID],
-	concurrency int,
 ) ([]OrphanCandidate, error) {
 	type listTask struct {
 		gvr       schema.GroupVersionResource
@@ -552,9 +512,6 @@ func (a *ApplySet) listOrphans(
 	var candidates []OrphanCandidate
 
 	listGroup, listCtx := errgroup.WithContext(ctx)
-	if concurrency > 0 {
-		listGroup.SetLimit(concurrency)
-	}
 	for _, task := range tasks {
 		listGroup.Go(func() error {
 			var list *unstructured.UnstructuredList
@@ -594,59 +551,6 @@ func (a *ApplySet) listOrphans(
 	}
 
 	return candidates, nil
-}
-
-// prune lists and deletes orphans concurrently (flat, unordered).
-// Retained for the convenience Prune() method.
-func (a *ApplySet) prune(
-	ctx context.Context,
-	mappings []*meta.RESTMapping,
-	namespaces sets.Set[string],
-	keepUIDs sets.Set[types.UID],
-	concurrency int,
-) ([]PruneResultItem, int, error) {
-	candidates, err := a.listOrphans(ctx, mappings, namespaces, keepUIDs, concurrency)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	if concurrency <= 0 {
-		concurrency = len(candidates)
-	}
-	if concurrency == 0 {
-		concurrency = 1
-	}
-
-	eg, egCtx := errgroup.WithContext(ctx)
-	eg.SetLimit(concurrency)
-
-	var mu sync.Mutex
-	var results []PruneResultItem
-	conflicts := 0
-
-	for _, c := range candidates {
-		eg.Go(func() error {
-			result, err := a.DeleteOrphan(egCtx, c)
-			if err != nil {
-				return err
-			}
-			mu.Lock()
-			if result.Pruned != nil {
-				results = append(results, *result.Pruned)
-			}
-			if result.Conflict {
-				conflicts++
-			}
-			mu.Unlock()
-			return nil
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
-		return nil, 0, err
-	}
-
-	return results, conflicts, nil
 }
 
 func (a *ApplySet) parentAnnotationSets() (sets.Set[schema.GroupKind], sets.Set[string]) {

--- a/pkg/controller/instance/applyset/applyset.go
+++ b/pkg/controller/instance/applyset/applyset.go
@@ -62,7 +62,17 @@ type Interface interface {
 
 	// Prune deletes orphaned resources (those with applyset label but not in KeepUIDs).
 	// Pass Project().PruneScope() to search both current batch locations AND parent memory.
+	// Prune deletes all orphans concurrently without ordering guarantees.
+	// For DAG-aware deletion, use ListOrphans + DeleteOrphan instead.
 	Prune(ctx context.Context, opts PruneOptions) (*PruneResult, error)
+
+	// ListOrphans discovers orphaned resources without deleting them.
+	// Returns candidates that the caller can order (e.g. reverse-topological)
+	// before issuing deletes via DeleteOrphan.
+	ListOrphans(ctx context.Context, opts PruneOptions) ([]OrphanCandidate, error)
+
+	// DeleteOrphan deletes a single orphan candidate using a UID precondition.
+	DeleteOrphan(ctx context.Context, candidate OrphanCandidate) (DeleteOrphanResult, error)
 }
 
 // Resource is an input to Apply.
@@ -449,23 +459,81 @@ func (a *ApplySet) resolveNamespace(ns string) string {
 	return ns
 }
 
-func (a *ApplySet) prune(
+// ListOrphans discovers orphaned resources (applyset members not in KeepUIDs)
+// without deleting them. The caller can order the returned candidates before
+// issuing deletes via DeleteOrphan.
+func (a *ApplySet) ListOrphans(ctx context.Context, opts PruneOptions) ([]OrphanCandidate, error) {
+	scopeGKs := opts.Scope.GroupKinds
+
+	scopeNamespaces := opts.Scope.Namespaces.Clone()
+	if a.parentNamespace != "" {
+		scopeNamespaces.Insert(a.parentNamespace)
+	} else {
+		scopeNamespaces.Insert(metav1.NamespaceDefault)
+	}
+
+	mappings := make([]*meta.RESTMapping, 0, len(scopeGKs))
+	for gk := range scopeGKs {
+		mapping, err := a.restMapper.RESTMapping(gk)
+		if err != nil {
+			return nil, fmt.Errorf("RESTMapping failed for %v: %w", gk, err)
+		}
+		mappings = append(mappings, mapping)
+	}
+
+	return a.listOrphans(ctx, mappings, scopeNamespaces, opts.KeepUIDs, opts.Concurrency)
+}
+
+// DeleteOrphan deletes a single orphan candidate using a UID precondition
+// to avoid deleting a resource that was recreated since listing.
+func (a *ApplySet) DeleteOrphan(ctx context.Context, candidate OrphanCandidate) (DeleteOrphanResult, error) {
+	uid := candidate.Object.GetUID()
+	deleteOpts := metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{UID: &uid},
+	}
+
+	var err error
+	if candidate.Object.GetNamespace() != "" {
+		err = a.client.Resource(candidate.GVR).Namespace(candidate.Object.GetNamespace()).Delete(ctx, candidate.Object.GetName(), deleteOpts)
+	} else {
+		err = a.client.Resource(candidate.GVR).Delete(ctx, candidate.Object.GetName(), deleteOpts)
+	}
+
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return DeleteOrphanResult{}, nil
+		}
+		if apierrors.IsConflict(err) {
+			a.log.V(2).Info("skipped prune due to UID mismatch (resource recreated)",
+				"name", candidate.Object.GetName(),
+				"namespace", candidate.Object.GetNamespace(),
+				"gvr", candidate.GVR.String(),
+			)
+			return DeleteOrphanResult{Conflict: true}, nil
+		}
+		return DeleteOrphanResult{}, fmt.Errorf("delete %s/%s: %w", candidate.Object.GetNamespace(), candidate.Object.GetName(), err)
+	}
+
+	a.log.V(2).Info("pruned resource",
+		"name", candidate.Object.GetName(),
+		"namespace", candidate.Object.GetNamespace(),
+		"gvr", candidate.GVR.String(),
+	)
+	return DeleteOrphanResult{Pruned: &PruneResultItem{Object: candidate.Object}}, nil
+}
+
+// listOrphans lists applyset members not in keepUIDs. This is the listing half
+// of the former prune() method.
+func (a *ApplySet) listOrphans(
 	ctx context.Context,
 	mappings []*meta.RESTMapping,
 	namespaces sets.Set[string],
 	keepUIDs sets.Set[types.UID],
 	concurrency int,
-) ([]PruneResultItem, int, error) {
-	// Track candidates with their GVR for deletion
-	type pruneCandidate struct {
-		obj *unstructured.Unstructured
-		gvr schema.GroupVersionResource
-	}
-
-	// Build list tasks
+) ([]OrphanCandidate, error) {
 	type listTask struct {
 		gvr       schema.GroupVersionResource
-		namespace string // empty for cluster-scoped
+		namespace string
 		scoped    bool
 	}
 	var tasks []listTask
@@ -480,9 +548,8 @@ func (a *ApplySet) prune(
 		}
 	}
 
-	// List resources in parallel
-	var listMu sync.Mutex
-	var candidates []pruneCandidate
+	var mu sync.Mutex
+	var candidates []OrphanCandidate
 
 	listGroup, listCtx := errgroup.WithContext(ctx)
 	if concurrency > 0 {
@@ -508,25 +575,41 @@ func (a *ApplySet) prune(
 				}
 			}
 
-			var local []pruneCandidate
+			var local []OrphanCandidate
 			for i := range list.Items {
 				obj := &list.Items[i]
 				if !keepUIDs.Has(obj.GetUID()) {
-					local = append(local, pruneCandidate{obj: obj, gvr: task.gvr})
+					local = append(local, OrphanCandidate{Object: obj, GVR: task.gvr})
 				}
 			}
 
-			listMu.Lock()
+			mu.Lock()
 			candidates = append(candidates, local...)
-			listMu.Unlock()
+			mu.Unlock()
 			return nil
 		})
 	}
 	if err := listGroup.Wait(); err != nil {
+		return nil, err
+	}
+
+	return candidates, nil
+}
+
+// prune lists and deletes orphans concurrently (flat, unordered).
+// Retained for the convenience Prune() method.
+func (a *ApplySet) prune(
+	ctx context.Context,
+	mappings []*meta.RESTMapping,
+	namespaces sets.Set[string],
+	keepUIDs sets.Set[types.UID],
+	concurrency int,
+) ([]PruneResultItem, int, error) {
+	candidates, err := a.listOrphans(ctx, mappings, namespaces, keepUIDs, concurrency)
+	if err != nil {
 		return nil, 0, err
 	}
 
-	// Delete candidates concurrently
 	if concurrency <= 0 {
 		concurrency = len(candidates)
 	}
@@ -543,43 +626,18 @@ func (a *ApplySet) prune(
 
 	for _, c := range candidates {
 		eg.Go(func() error {
-			deleteOpts := metav1.DeleteOptions{
-				Preconditions: &metav1.Preconditions{UID: new(c.obj.GetUID())},
-			}
-			var err error
-			if c.obj.GetNamespace() != "" {
-				err = a.client.Resource(c.gvr).Namespace(c.obj.GetNamespace()).Delete(egCtx, c.obj.GetName(), deleteOpts)
-			} else {
-				err = a.client.Resource(c.gvr).Delete(egCtx, c.obj.GetName(), deleteOpts)
-			}
-
+			result, err := a.DeleteOrphan(egCtx, c)
 			if err != nil {
-				if apierrors.IsNotFound(err) {
-					return nil
-				}
-				if apierrors.IsConflict(err) {
-					a.log.V(2).Info("skipped prune due to UID mismatch (resource recreated)",
-						"name", c.obj.GetName(),
-						"namespace", c.obj.GetNamespace(),
-						"gvr", c.gvr.String(),
-					)
-					mu.Lock()
-					conflicts++
-					mu.Unlock()
-					return nil
-				}
-				return fmt.Errorf("delete %s/%s: %w", c.obj.GetNamespace(), c.obj.GetName(), err)
+				return err
 			}
-
 			mu.Lock()
-			results = append(results, PruneResultItem{Object: c.obj})
+			if result.Pruned != nil {
+				results = append(results, *result.Pruned)
+			}
+			if result.Conflict {
+				conflicts++
+			}
 			mu.Unlock()
-
-			a.log.V(2).Info("pruned resource",
-				"name", c.obj.GetName(),
-				"namespace", c.obj.GetNamespace(),
-				"gvr", c.gvr.String(),
-			)
 			return nil
 		})
 	}

--- a/pkg/controller/instance/applyset/applyset_test.go
+++ b/pkg/controller/instance/applyset/applyset_test.go
@@ -15,6 +15,7 @@
 package applyset
 
 import (
+	"context"
 	"errors"
 	"regexp"
 	"sync/atomic"
@@ -33,6 +34,31 @@ import (
 	"k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
+
+// listAndDeleteOrphans is a test helper that replicates the old Prune() behavior
+// using ListOrphans + DeleteOrphan. It returns aggregated pruned items and conflict count.
+func listAndDeleteOrphans(t *testing.T, ctx context.Context, applier *ApplySet, opts PruneOptions) ([]PruneResultItem, int) {
+	t.Helper()
+	candidates, err := applier.ListOrphans(ctx, opts)
+	if err != nil {
+		t.Fatalf("ListOrphans() error = %v", err)
+	}
+	var pruned []PruneResultItem
+	conflicts := 0
+	for _, c := range candidates {
+		res, err := applier.DeleteOrphan(ctx, c)
+		if err != nil {
+			t.Fatalf("DeleteOrphan() error = %v", err)
+		}
+		if res.Pruned != nil {
+			pruned = append(pruned, *res.Pruned)
+		}
+		if res.Conflict {
+			conflicts++
+		}
+	}
+	return pruned, conflicts
+}
 
 // testParent is a minimal implementation of the parent interface for testing.
 type testParent struct {
@@ -576,16 +602,13 @@ func TestPrune(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Project() error = %v", err)
 			}
-			pruneResult, err := applier.Prune(ctx, PruneOptions{
+			pruned, _ := listAndDeleteOrphans(t, ctx, applier, PruneOptions{
 				KeepUIDs: result.ObservedUIDs(),
 				Scope:    projectMeta.PruneScope(),
 			})
-			if err != nil {
-				t.Fatalf("Prune() error = %v", err)
-			}
 
-			if len(pruneResult.Pruned) != tt.wantPruned {
-				t.Errorf("Prune() pruned %d resources, want %d", len(pruneResult.Pruned), tt.wantPruned)
+			if len(pruned) != tt.wantPruned {
+				t.Errorf("Prune() pruned %d resources, want %d", len(pruned), tt.wantPruned)
 			}
 		})
 	}
@@ -638,18 +661,15 @@ func TestPrune_UIDPrecondition(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Project() error = %v", err)
 		}
-		pruneResult, err := applier.Prune(ctx, PruneOptions{
+		pruned, conflicts := listAndDeleteOrphans(t, ctx, applier, PruneOptions{
 			KeepUIDs: result.ObservedUIDs(),
 			Scope:    projectMeta.PruneScope(),
 		})
-		if err != nil {
-			t.Fatalf("Prune() error = %v", err)
+		if len(pruned) != 1 {
+			t.Errorf("Prune() pruned %d resources, want 1", len(pruned))
 		}
-		if len(pruneResult.Pruned) != 1 {
-			t.Errorf("Prune() pruned %d resources, want 1", len(pruneResult.Pruned))
-		}
-		if pruneResult.Conflicts != 0 {
-			t.Errorf("Prune() conflicts = %d, want 0", pruneResult.Conflicts)
+		if conflicts != 0 {
+			t.Errorf("Prune() conflicts = %d, want 0", conflicts)
 		}
 	})
 
@@ -736,18 +756,15 @@ func TestPrune_UIDPrecondition(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Project() error = %v", err)
 		}
-		pruneResult, err := applier.Prune(ctx, PruneOptions{
+		pruned, conflicts := listAndDeleteOrphans(t, ctx, applier, PruneOptions{
 			KeepUIDs: result.ObservedUIDs(),
 			Scope:    projectMeta.PruneScope(),
 		})
-		if err != nil {
-			t.Fatalf("Prune() error = %v, want nil (409 Conflict should be ignored)", err)
+		if len(pruned) != 0 {
+			t.Errorf("Prune() pruned %d resources, want 0 (UID mismatch should skip)", len(pruned))
 		}
-		if len(pruneResult.Pruned) != 0 {
-			t.Errorf("Prune() pruned %d resources, want 0 (UID mismatch should skip)", len(pruneResult.Pruned))
-		}
-		if pruneResult.Conflicts != 1 {
-			t.Errorf("Prune() conflicts = %d, want 1", pruneResult.Conflicts)
+		if conflicts != 1 {
+			t.Errorf("Prune() conflicts = %d, want 1", conflicts)
 		}
 
 		// Verify the resource still exists in the fake client
@@ -964,18 +981,15 @@ func TestPrune_ParentAnnotationsContributeToPruneScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	pruneResult, err := applier.Prune(t.Context(), PruneOptions{
+	pruned, _ := listAndDeleteOrphans(t, t.Context(), applier, PruneOptions{
 		KeepUIDs: result.ObservedUIDs(),
 		Scope:    projectMeta.PruneScope(),
 	})
-	if err != nil {
-		t.Fatalf("Prune() error = %v", err)
-	}
 
 	// The orphan Secret in old-ns should be pruned because parent annotations
 	// included Secret GK and old-ns namespace in prune scope
-	if len(pruneResult.Pruned) != 1 {
-		t.Errorf("Prune() pruned %d resources, want 1 (orphan from parent annotations)", len(pruneResult.Pruned))
+	if len(pruned) != 1 {
+		t.Errorf("Prune() pruned %d resources, want 1 (orphan from parent annotations)", len(pruned))
 	}
 }
 
@@ -1117,21 +1131,18 @@ func TestPrune_ClusterScopedResource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	pruneResult, err := applier.Prune(ctx, PruneOptions{
+	pruned, _ := listAndDeleteOrphans(t, ctx, applier, PruneOptions{
 		KeepUIDs: result.ObservedUIDs(),
 		Scope:    projectMeta.PruneScope(),
 	})
-	if err != nil {
-		t.Fatalf("Prune() error = %v", err)
-	}
 
 	// The orphan cluster-scoped Namespace should be pruned
-	if len(pruneResult.Pruned) != 1 {
-		t.Errorf("Prune() pruned %d resources, want 1 (cluster-scoped orphan)", len(pruneResult.Pruned))
+	if len(pruned) != 1 {
+		t.Errorf("Prune() pruned %d resources, want 1 (cluster-scoped orphan)", len(pruned))
 	}
 
-	if len(pruneResult.Pruned) > 0 && pruneResult.Pruned[0].Object.GetName() != "orphan-ns" {
-		t.Errorf("Pruned wrong resource: got %q, want %q", pruneResult.Pruned[0].Object.GetName(), "orphan-ns")
+	if len(pruned) > 0 && pruned[0].Object.GetName() != "orphan-ns" {
+		t.Errorf("Pruned wrong resource: got %q, want %q", pruned[0].Object.GetName(), "orphan-ns")
 	}
 }
 

--- a/pkg/controller/instance/applyset/result.go
+++ b/pkg/controller/instance/applyset/result.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -58,6 +59,22 @@ type ApplyResultItem struct {
 // PruneResultItem is a successfully pruned resource.
 type PruneResultItem struct {
 	Object *unstructured.Unstructured
+}
+
+// OrphanCandidate is a resource discovered during orphan listing that is
+// a member of the applyset but not in the keep set. Callers use this to
+// apply ordering (e.g. reverse-topological) before issuing deletes.
+type OrphanCandidate struct {
+	Object *unstructured.Unstructured
+	GVR    schema.GroupVersionResource
+}
+
+// DeleteOrphanResult describes the outcome of a single orphan deletion.
+type DeleteOrphanResult struct {
+	// Pruned is non-nil when the delete was accepted by the API server.
+	Pruned *PruneResultItem
+	// Conflict is true when the UID precondition failed (resource was recreated).
+	Conflict bool
 }
 
 // ByID returns a map of results keyed by resource ID for easy lookup.

--- a/pkg/controller/instance/applyset/result.go
+++ b/pkg/controller/instance/applyset/result.go
@@ -28,25 +28,6 @@ type ApplyResult struct {
 	Applied []ApplyResultItem
 }
 
-// PruneResult contains outcomes for prune operations.
-// All items in Pruned are successful deletes (errors return from Prune directly).
-type PruneResult struct {
-	Pruned    []PruneResultItem
-	Conflicts int
-}
-
-// HasPruned returns true if any resources were pruned.
-func (r *PruneResult) HasPruned() bool {
-	return len(r.Pruned) > 0
-}
-
-// HasConflicts returns true if prune encountered UID precondition conflicts.
-// These are safe skips (resource was recreated), but callers may choose to
-// requeue and retry prune while keeping superset prune scope.
-func (r *PruneResult) HasConflicts() bool {
-	return r.Conflicts > 0
-}
-
 // ApplyResultItem is the outcome of applying a single resource.
 type ApplyResultItem struct {
 	ID       string                     // same as input Resource.ID
@@ -110,7 +91,6 @@ func (r *ApplyResult) Errors() error {
 }
 
 // HasClusterMutation returns true if any apply operation changed the cluster.
-// Note: Prune mutations are tracked separately via PruneResult.HasPruned().
 func (r *ApplyResult) HasClusterMutation() bool {
 	for _, item := range r.Applied {
 		if item.Changed {

--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -17,7 +17,10 @@ package instance
 import (
 	"errors"
 	"fmt"
+	"sort"
+	"sync"
 
+	"golang.org/x/sync/errgroup"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -206,8 +209,10 @@ func (c *Controller) processNodes(
 }
 
 // pruneOrphans deletes previously managed resources that are not in the current
-// apply set. It shrinks parent applyset metadata only when prune completes
-// without UID conflicts.
+// apply set. Orphans are deleted in reverse topological order (dependents before
+// dependencies) to avoid breaking cross-resource references during cleanup.
+// Within each dependency layer, deletes are concurrent. It shrinks parent
+// applyset metadata only when prune completes without UID conflicts.
 func (c *Controller) pruneOrphans(
 	rcx *ReconcileContext,
 	applier *applyset.ApplySet,
@@ -216,27 +221,95 @@ func (c *Controller) pruneOrphans(
 	batchMeta applyset.Metadata,
 ) (bool, bool, error) {
 	pruneScope := supersetPatch.PruneScope()
-	pruneResult, err := applier.Prune(rcx.Ctx, applyset.PruneOptions{
+	candidates, err := applier.ListOrphans(rcx.Ctx, applyset.PruneOptions{
 		KeepUIDs: result.ObservedUIDs(),
 		Scope:    pruneScope,
 	})
 	if err != nil {
-		return false, false, rcx.delayedRequeue(fmt.Errorf("prune failed: %w", err))
+		return false, false, rcx.delayedRequeue(fmt.Errorf("list orphans failed: %w", err))
+	}
+	if len(candidates) == 0 {
+		return false, false, nil
 	}
 
-	// Keep superset metadata and retry prune on UID conflicts.
-	if pruneResult.HasConflicts() {
+	// Build node-id → topological position map from the runtime graph.
+	nodes := rcx.Runtime.Nodes()
+	nodePosition := make(map[string]int, len(nodes))
+	for i, node := range nodes {
+		nodePosition[node.Spec.Meta.ID] = i
+	}
+	// Unmapped orphans (unknown or missing node-id) are assigned a position
+	// beyond the last node so they are deleted in the first wave (highest
+	// position = first in reverse order). These are resources whose node was
+	// removed from the graph entirely, so they have no known dependents.
+	unmappedPosition := len(nodes)
+
+	// Group candidates into waves by topological position.
+	waves := make(map[int][]applyset.OrphanCandidate)
+	for _, c := range candidates {
+		nodeID := c.Object.GetLabels()[metadata.NodeIDLabel]
+		pos, ok := nodePosition[nodeID]
+		if !ok {
+			pos = unmappedPosition
+		}
+		waves[pos] = append(waves[pos], c)
+	}
+
+	// Sort wave keys in descending order (reverse topological: dependents first).
+	waveKeys := make([]int, 0, len(waves))
+	for k := range waves {
+		waveKeys = append(waveKeys, k)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(waveKeys)))
+
+	// Delete wave by wave. Within each wave, deletions are concurrent.
+	var pruned []applyset.PruneResultItem
+	conflicts := 0
+
+	for _, key := range waveKeys {
+		waveCandidates := waves[key]
+
+		eg, egCtx := errgroup.WithContext(rcx.Ctx)
+		eg.SetLimit(len(waveCandidates))
+
+		var mu sync.Mutex
+		for _, candidate := range waveCandidates {
+			eg.Go(func() error {
+				res, err := applier.DeleteOrphan(egCtx, candidate)
+				if err != nil {
+					return err
+				}
+				mu.Lock()
+				if res.Pruned != nil {
+					pruned = append(pruned, *res.Pruned)
+				}
+				if res.Conflict {
+					conflicts++
+				}
+				mu.Unlock()
+				return nil
+			})
+		}
+		if err := eg.Wait(); err != nil {
+			return false, false, rcx.delayedRequeue(fmt.Errorf("prune failed: %w", err))
+		}
+	}
+
+	hasPruned := len(pruned) > 0
+	hasConflicts := conflicts > 0
+
+	if hasConflicts {
 		rcx.Log.V(1).Info("prune skipped resources due to UID conflicts; keeping superset applyset metadata for retry",
-			"conflicts", pruneResult.Conflicts,
+			"conflicts", conflicts,
 		)
-		return pruneResult.HasPruned(), true, nil
+		return hasPruned, true, nil
 	}
 
-	// Prune succeeded (errors return directly), safe to shrink metadata
+	// Prune succeeded without conflicts, safe to shrink metadata
 	if err := c.patchInstanceWithApplySetMetadata(rcx, batchMeta); err != nil {
 		rcx.Log.V(1).Info("failed to shrink instance annotations", "error", err)
 	}
-	return pruneResult.HasPruned(), false, nil
+	return hasPruned, false, nil
 }
 
 // createApplySet constructs an applyset configured for the current instance.

--- a/pkg/controller/instance/resources_test.go
+++ b/pkg/controller/instance/resources_test.go
@@ -16,6 +16,8 @@ package instance
 
 import (
 	"errors"
+	"maps"
+	"slices"
 	"sync"
 	"testing"
 
@@ -804,9 +806,9 @@ func TestPruneOrphansRespectsReverseTopologicalOrder(t *testing.T) {
 	// nodeC (position 2) must be deleted before nodeB (position 1),
 	// and nodeB before nodeA (position 0). Since each is in its own wave,
 	// the order is strictly: orphan-c, orphan-b, orphan-a.
-	posC := indexOf(deletionOrder, "orphan-c")
-	posB := indexOf(deletionOrder, "orphan-b")
-	posA := indexOf(deletionOrder, "orphan-a")
+	posC := slices.Index(deletionOrder, "orphan-c")
+	posB := slices.Index(deletionOrder, "orphan-b")
+	posA := slices.Index(deletionOrder, "orphan-a")
 	assert.Less(t, posC, posB, "nodeC orphan should be deleted before nodeB orphan")
 	assert.Less(t, posB, posA, "nodeB orphan should be deleted before nodeA orphan")
 }
@@ -861,29 +863,15 @@ func TestPruneOrphansUnmappedDeletedFirst(t *testing.T) {
 
 	// Unmapped orphan gets position len(nodes)=1, "known" gets position 0.
 	// Reverse order: unmapped (1) first, then known (0).
-	posUnknown := indexOf(deletionOrder, "orphan-unknown")
-	posKnown := indexOf(deletionOrder, "orphan-known")
+	posUnknown := slices.Index(deletionOrder, "orphan-unknown")
+	posKnown := slices.Index(deletionOrder, "orphan-known")
 	assert.Less(t, posUnknown, posKnown, "unmapped orphan should be deleted before known orphan")
 }
 
 func mergeLabels(base, extra map[string]string) map[string]string {
-	merged := make(map[string]string, len(base)+len(extra))
-	for k, v := range base {
-		merged[k] = v
-	}
-	for k, v := range extra {
-		merged[k] = v
-	}
+	merged := maps.Clone(base)
+	maps.Copy(merged, extra)
 	return merged
-}
-
-func indexOf(slice []string, item string) int {
-	for i, s := range slice {
-		if s == item {
-			return i
-		}
-	}
-	return -1
 }
 
 func TestProcessApplyResultsAndReadiness(t *testing.T) {

--- a/pkg/controller/instance/resources_test.go
+++ b/pkg/controller/instance/resources_test.go
@@ -16,6 +16,7 @@ package instance
 
 import (
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -672,7 +673,7 @@ func TestPruneOrphansPaths(t *testing.T) {
 			reactorVerb:     "list",
 			reactorResource: "configmaps",
 			reactorErr:      errors.New("list failed"),
-			wantErr:         "prune failed",
+			wantErr:         "list orphans failed",
 		},
 		{
 			name:            "uid conflicts request retry without error",
@@ -723,6 +724,166 @@ func TestPruneOrphansPaths(t *testing.T) {
 			assert.Equal(t, tt.wantRetry, retry)
 		})
 	}
+}
+
+func TestPruneOrphansRespectsReverseTopologicalOrder(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+
+	// Build a graph: nodeA (position 0) → nodeB (position 1) → nodeC (position 2)
+	// Topological order: A, B, C. Reverse deletion order should be: C, B, A.
+	nodeA := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "nodeA",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: newConfigMapObject("a", ""),
+	}
+	nodeB := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:           "nodeB",
+			Type:         graph.NodeTypeResource,
+			GVR:          controllerTestCMGVR,
+			Namespaced:   true,
+			Dependencies: []string{"nodeA"},
+		},
+		Template: newConfigMapObject("b", ""),
+	}
+	nodeC := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:           "nodeC",
+			Type:         graph.NodeTypeResource,
+			GVR:          controllerTestCMGVR,
+			Namespaced:   true,
+			Dependencies: []string{"nodeB"},
+		},
+		Template: newConfigMapObject("c", ""),
+	}
+
+	// Create orphan objects with node-id labels matching the graph nodes.
+	orphanA := newApplysetManagedConfigMap(instance, "orphan-a", "default")
+	orphanA.SetLabels(mergeLabels(orphanA.GetLabels(), map[string]string{
+		metadata.NodeIDLabel: "nodeA",
+	}))
+	orphanB := newApplysetManagedConfigMap(instance, "orphan-b", "default")
+	orphanB.SetLabels(mergeLabels(orphanB.GetLabels(), map[string]string{
+		metadata.NodeIDLabel: "nodeB",
+	}))
+	orphanC := newApplysetManagedConfigMap(instance, "orphan-c", "default")
+	orphanC.SetLabels(mergeLabels(orphanC.GetLabels(), map[string]string{
+		metadata.NodeIDLabel: "nodeC",
+	}))
+
+	controller, rcx, raw := newControllerAndContext(t, instance,
+		newTestGraph(nodeA, nodeB, nodeC),
+		orphanA, orphanB, orphanC,
+	)
+
+	// Record deletion order via a reactor.
+	var deletionOrder []string
+	var deletionMu sync.Mutex
+	raw.PrependReactor("delete", "configmaps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		da := action.(k8stesting.DeleteAction)
+		deletionMu.Lock()
+		deletionOrder = append(deletionOrder, da.GetName())
+		deletionMu.Unlock()
+		return false, nil, nil // let default reactor handle it
+	})
+
+	applier := controller.createApplySet(rcx)
+	pruned, retry, err := controller.pruneOrphans(rcx, applier, &applyset.ApplyResult{}, applyset.Metadata{
+		GroupKinds: sets.New[schema.GroupKind](controllerTestCMGVK.GroupKind()),
+	}, applyset.Metadata{})
+
+	require.NoError(t, err)
+	assert.True(t, pruned, "should have pruned resources")
+	assert.False(t, retry, "should not need retry")
+	assert.Len(t, deletionOrder, 3, "all three orphans should be deleted")
+
+	// nodeC (position 2) must be deleted before nodeB (position 1),
+	// and nodeB before nodeA (position 0). Since each is in its own wave,
+	// the order is strictly: orphan-c, orphan-b, orphan-a.
+	posC := indexOf(deletionOrder, "orphan-c")
+	posB := indexOf(deletionOrder, "orphan-b")
+	posA := indexOf(deletionOrder, "orphan-a")
+	assert.Less(t, posC, posB, "nodeC orphan should be deleted before nodeB orphan")
+	assert.Less(t, posB, posA, "nodeB orphan should be deleted before nodeA orphan")
+}
+
+func TestPruneOrphansUnmappedDeletedFirst(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+
+	// Graph has one node "known" at position 0.
+	knownNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "known",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: newConfigMapObject("k", ""),
+	}
+
+	// Two orphans: one mapped to "known", one with an unknown node-id.
+	orphanKnown := newApplysetManagedConfigMap(instance, "orphan-known", "default")
+	orphanKnown.SetLabels(mergeLabels(orphanKnown.GetLabels(), map[string]string{
+		metadata.NodeIDLabel: "known",
+	}))
+	orphanUnknown := newApplysetManagedConfigMap(instance, "orphan-unknown", "default")
+	orphanUnknown.SetLabels(mergeLabels(orphanUnknown.GetLabels(), map[string]string{
+		metadata.NodeIDLabel: "removed-node",
+	}))
+
+	controller, rcx, raw := newControllerAndContext(t, instance,
+		newTestGraph(knownNode),
+		orphanKnown, orphanUnknown,
+	)
+
+	var deletionOrder []string
+	var deletionMu sync.Mutex
+	raw.PrependReactor("delete", "configmaps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		da := action.(k8stesting.DeleteAction)
+		deletionMu.Lock()
+		deletionOrder = append(deletionOrder, da.GetName())
+		deletionMu.Unlock()
+		return false, nil, nil
+	})
+
+	applier := controller.createApplySet(rcx)
+	pruned, _, err := controller.pruneOrphans(rcx, applier, &applyset.ApplyResult{}, applyset.Metadata{
+		GroupKinds: sets.New[schema.GroupKind](controllerTestCMGVK.GroupKind()),
+	}, applyset.Metadata{})
+
+	require.NoError(t, err)
+	assert.True(t, pruned)
+	assert.Len(t, deletionOrder, 2)
+
+	// Unmapped orphan gets position len(nodes)=1, "known" gets position 0.
+	// Reverse order: unmapped (1) first, then known (0).
+	posUnknown := indexOf(deletionOrder, "orphan-unknown")
+	posKnown := indexOf(deletionOrder, "orphan-known")
+	assert.Less(t, posUnknown, posKnown, "unmapped orphan should be deleted before known orphan")
+}
+
+func mergeLabels(base, extra map[string]string) map[string]string {
+	merged := make(map[string]string, len(base)+len(extra))
+	for k, v := range base {
+		merged[k] = v
+	}
+	for k, v := range extra {
+		merged[k] = v
+	}
+	return merged
+}
+
+func indexOf(slice []string, item string) int {
+	for i, s := range slice {
+		if s == item {
+			return i
+		}
+	}
+	return -1
 }
 
 func TestProcessApplyResultsAndReadiness(t *testing.T) {

--- a/pkg/controller/instance/test_helpers_test.go
+++ b/pkg/controller/instance/test_helpers_test.go
@@ -335,6 +335,7 @@ func newConfigMapObject(name, namespace string) *unstructured.Unstructured {
 	return obj
 }
 
+//nolint:unparam // namespace is always "default" in current tests but kept for flexibility
 func newApplysetManagedConfigMap(instance *unstructured.Unstructured, name, namespace string) *unstructured.Unstructured {
 	obj := newConfigMapObject(name, namespace)
 	obj.SetUID(types.UID(name + "-uid"))


### PR DESCRIPTION
ApplySet orphan pruning previously deleted all orphaned resources in a flat concurrent pass with no dependency ordering. This caused resources to be deleted before their dependents, breaking includeWhen/readyWhen conditions and stalling RGDs (e.g. when includeWhen flips from true to false, the dependency could be deleted before the dependent).

Split ApplySet.Prune() into ListOrphans() + DeleteOrphan() on the Interface so callers can impose ordering. The instance controller's pruneOrphans() now:

1. Lists orphan candidates via ListOrphans()
2. Maps each candidate to its graph node via the kro.run/node-id label
3. Groups candidates into waves by topological position
4. Deletes waves in reverse order (dependents before dependencies), with concurrent deletion within each wave

Unmapped orphans (nodes removed from the graph entirely) are deleted first since they have no known dependents in the current graph.

Fixes: https://github.com/kubernetes-sigs/kro/issues/1135