### PR TITLE
fix duplicate dependencies in RGD status

### DIFF
--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -571,13 +571,17 @@ func (b *Builder) buildDependencyGraph(
 			return nil, fmt.Errorf("failed to extract dependencies from includeWhen: %w", err)
 		}
 
-		// Add all dependencies to node and DAG
-		allDeps := make([]string, 0, len(templateDeps)+len(forEachDeps)+len(includeWhenDeps))
-		allDeps = append(allDeps, templateDeps...)
-		allDeps = append(allDeps, forEachDeps...)
-		allDeps = append(allDeps, includeWhenDeps...)
-		node.Meta.Dependencies = append(node.Meta.Dependencies, allDeps...)
-		if err := directedAcyclicGraph.AddDependencies(node.Meta.ID, allDeps); err != nil {
+		// Build deduplicated dependency list, then register with the DAG.
+		for _, dep := range templateDeps {
+			node.Meta.addDependency(dep)
+		}
+		for _, dep := range forEachDeps {
+			node.Meta.addDependency(dep)
+		}
+		for _, dep := range includeWhenDeps {
+			node.Meta.addDependency(dep)
+		}
+		if err := directedAcyclicGraph.AddDependencies(node.Meta.ID, node.Meta.Dependencies); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -1188,6 +1188,45 @@ func TestGraphBuilder_DependencyValidation(t *testing.T) {
 			errMsg:  "graph contains a cycle",
 		},
 		{
+			name: "multiple fields referencing same resource are deduplicated",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "vpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks": []interface{}{"10.0.0.0/16"},
+					},
+				}, nil, nil),
+				// This resource references vpc from multiple fields — each
+				// field should contribute at most one dependency entry.
+				generator.WithResource("subnet", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "Subnet",
+					"metadata": map[string]interface{}{
+						"name": "subnet",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlock": "${vpc.status.vpcID}",
+						"vpcID":     "${vpc.status.vpcID}",
+					},
+				}, nil, nil),
+			},
+			validateDeps: func(t *testing.T, g *Graph) {
+				assert.Empty(t, g.Resources["vpc"].Meta.Dependencies)
+				assert.Equal(t, []string{"vpc"}, g.Resources["subnet"].Meta.Dependencies)
+			},
+		},
+		{
 			name: "shared infrastructure dependencies",
 			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(

--- a/pkg/graph/node.go
+++ b/pkg/graph/node.go
@@ -98,6 +98,13 @@ type NodeMeta struct {
 	Dependencies []string
 }
 
+// addDependency appends dep to the dependency list if not already present.
+func (m *NodeMeta) addDependency(dep string) {
+	if !slices.Contains(m.Dependencies, dep) {
+		m.Dependencies = append(m.Dependencies, dep)
+	}
+}
+
 // ForEachDimension represents a parsed forEach dimension from an RGD resource.
 type ForEachDimension struct {
 	// Name is the iterator variable name (e.g., "region")

--- a/pkg/graph/node_test.go
+++ b/pkg/graph/node_test.go
@@ -47,6 +47,49 @@ func TestNodeTypeString(t *testing.T) {
 	}
 }
 
+func TestNodeMeta_AddDependency(t *testing.T) {
+	tests := []struct {
+		name     string
+		deps     []string
+		expected []string
+	}{
+		{
+			name:     "no duplicates",
+			deps:     []string{"a", "b", "c"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "all duplicates",
+			deps:     []string{"a", "a", "a"},
+			expected: []string{"a"},
+		},
+		{
+			name:     "interleaved duplicates",
+			deps:     []string{"a", "b", "a", "c", "b", "c"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "single dependency",
+			deps:     []string{"x"},
+			expected: []string{"x"},
+		},
+		{
+			name:     "empty",
+			deps:     nil,
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &NodeMeta{}
+			for _, dep := range tt.deps {
+				m.addDependency(dep)
+			}
+			assert.Equal(t, tt.expected, m.Dependencies)
+		})
+	}
+}
+
 func TestNodeDeepCopy(t *testing.T) {
 	var nilNode *Node
 	assert.Nil(t, nilNode.DeepCopy())

--- a/test/integration/suites/ackekscluster/suite_test.go
+++ b/test/integration/suites/ackekscluster/suite_test.go
@@ -107,6 +107,40 @@ var _ = Describe("EKSCluster", func() {
 
 			// Verify the ResourceGraphDefinition status
 			g.Expect(createdRGD.Status.TopologicalOrder).To(HaveLen(12))
+
+			// Verify dependency information is correct and deduplicated.
+			// Build a lookup from resource ID to its dependency IDs.
+			depsByID := make(map[string][]string)
+			for _, ri := range createdRGD.Status.Resources {
+				ids := make([]string, 0, len(ri.Dependencies))
+				for _, d := range ri.Dependencies {
+					ids = append(ids, d.ID)
+				}
+				depsByID[ri.ID] = ids
+			}
+			// Resources with no dependencies should not appear in the map.
+			g.Expect(depsByID).ToNot(HaveKey("clusterRole"))
+			g.Expect(depsByID).ToNot(HaveKey("clusterVPC"))
+			g.Expect(depsByID).ToNot(HaveKey("clusterElasticIPAddress"))
+			g.Expect(depsByID).ToNot(HaveKey("clusterAdminRole"))
+			g.Expect(depsByID).ToNot(HaveKey("clusterNodeRole"))
+			// Resources with dependencies — assert exact sets.
+			g.Expect(depsByID["clusterInternetGateway"]).To(ConsistOf("clusterVPC"))
+			g.Expect(depsByID["clusterRouteTable"]).To(ConsistOf(
+				"clusterVPC", "clusterInternetGateway",
+			))
+			g.Expect(depsByID["clusterSubnetA"]).To(ConsistOf("clusterVPC", "clusterRouteTable"))
+			g.Expect(depsByID["clusterSubnetB"]).To(ConsistOf("clusterVPC", "clusterRouteTable"))
+			g.Expect(depsByID["cluster"]).To(ConsistOf(
+				"clusterRole", "clusterSubnetA", "clusterSubnetB",
+			))
+			g.Expect(depsByID["clusterNATGateway"]).To(ConsistOf(
+				"clusterSubnetB", "clusterElasticIPAddress",
+			))
+			g.Expect(depsByID["clusterNodeGroup"]).To(ConsistOf(
+				"cluster", "clusterSubnetA", "clusterSubnetB", "clusterNodeRole",
+			))
+
 			// Verify ready condition.
 			g.Expect(createdRGD.Status.Conditions).ShouldNot(BeEmpty())
 			var readyCondition krov1alpha1.Condition

--- a/test/integration/suites/core/graphrevision_test.go
+++ b/test/integration/suites/core/graphrevision_test.go
@@ -185,6 +185,10 @@ var _ = Describe("GraphRevision Lifecycle", func() {
 											"name":  "CM_NAME",
 											"value": "${configmap.metadata.name}",
 										},
+										map[string]interface{}{
+											"name":  "CM_NS",
+											"value": "${configmap.metadata.namespace}",
+										},
 									},
 								},
 							},

--- a/test/integration/suites/networkingstack/suite_test.go
+++ b/test/integration/suites/networkingstack/suite_test.go
@@ -96,6 +96,21 @@ var _ = Describe("NetworkingStack", func() {
 				"subnetAZB",
 				"subnetAZC",
 			}))
+			// Verify dependency information is correct and deduplicated.
+			depsByID := make(map[string][]string)
+			for _, ri := range createdRGD.Status.Resources {
+				ids := make([]string, 0, len(ri.Dependencies))
+				for _, d := range ri.Dependencies {
+					ids = append(ids, d.ID)
+				}
+				depsByID[ri.ID] = ids
+			}
+			g.Expect(depsByID).ToNot(HaveKey("vpc"))
+			g.Expect(depsByID["securityGroup"]).To(ConsistOf("vpc"))
+			g.Expect(depsByID["subnetAZA"]).To(ConsistOf("vpc"))
+			g.Expect(depsByID["subnetAZB"]).To(ConsistOf("vpc"))
+			g.Expect(depsByID["subnetAZC"]).To(ConsistOf("vpc"))
+
 			// Verify ready condition.
 			g.Expect(createdRGD.Status.Conditions).ShouldNot(BeEmpty())
 			var readyCondition krov1alpha1.Condition


### PR DESCRIPTION
Multiple template variables referencing the same resource produced
duplicate entries in `node.Meta.Dependencies.` The DAG was unaffected
(map-based dedup) but the duplicates propagated into the RGD status,
inflating the dependencies list with repeated IDs.

Introduce `NodeMeta.addDependency` to enforce uniqueness at the data
model boundary. The builder now uses this method instead of raw
append, and feeds the canonical deduplicated list to the DAG.