### PR TITLE
fix: validate resource ID length against Kubernetes label value limit

### DIFF
--- a/pkg/graph/validation.go
+++ b/pkg/graph/validation.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/cel/ast"
@@ -148,6 +149,15 @@ func validateResourceIDs(rgd *v1alpha1.ResourceGraphDefinition) error {
 
 		if !isValidResourceID(res.ID) {
 			return fmt.Errorf("id %s is not a valid KRO resource id: must be lower camelCase", res.ID)
+		}
+
+		// Resource IDs are used as Kubernetes label values (kro.run/node-id),
+		// which are limited to 63 characters.
+		if len(res.ID) > validation.LabelValueMaxLength {
+			return fmt.Errorf("id %q exceeds the maximum length of %d characters: "+
+				"resource IDs are used as Kubernetes label values (kro.run/node-id) "+
+				"which must be no more than %d characters",
+				res.ID, validation.LabelValueMaxLength, validation.LabelValueMaxLength)
 		}
 
 		if _, ok := seen[res.ID]; ok {

--- a/pkg/graph/validation_test.go
+++ b/pkg/graph/validation_test.go
@@ -82,6 +82,28 @@ func TestValidateRGResourceNames(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "Resource ID at exactly 63 characters",
+			rgd: &v1alpha1.ResourceGraphDefinition{
+				Spec: v1alpha1.ResourceGraphDefinitionSpec{
+					Resources: []*v1alpha1.Resource{
+						{ID: "aResourceIdentifierThatIsExactlySixtyThreeCharactersLongXXXXXXX"},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Resource ID exceeding 63 characters",
+			rgd: &v1alpha1.ResourceGraphDefinition{
+				Spec: v1alpha1.ResourceGraphDefinitionSpec{
+					Resources: []*v1alpha1.Resource{
+						{ID: "thisIsAnExtremelyLongResourceIdentifierThatExceedsSixtyThreeCharactersLimit"},
+					},
+				},
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -329,6 +351,21 @@ func TestValidateResourceGraphDefinition(t *testing.T) {
 								{"invalid_IteratorName": "b"},
 							},
 						},
+					},
+					Schema: &v1alpha1.Schema{
+						Kind: "ValidKindName",
+					},
+				},
+			},
+			rgdConfig: defaultRGDConfig,
+			wantErr:   true,
+		},
+		{
+			name: "Resource ID exceeding Kubernetes label value length limit",
+			rgd: &v1alpha1.ResourceGraphDefinition{
+				Spec: v1alpha1.ResourceGraphDefinitionSpec{
+					Resources: []*v1alpha1.Resource{
+						{ID: "thisIsAnExtremelyLongResourceIdentifierThatExceedsSixtyThreeCharactersLimit"},
 					},
 					Schema: &v1alpha1.Schema{
 						Kind: "ValidKindName",


### PR DESCRIPTION
Resource IDs are used as Kubernetes label values via the `kro.run/node-id`
label. When an ID exceeds 63 characters, the Kubernetes API rejects the
child resource creation at runtime, leaving instances stuck in
`IN_PROGRESS` with no clear signal at RGD validation time.

Add a length check in `validateResourceIDs()` so RGDs with oversized IDs
fail early during graph building with a descriptive error message.

**What changed:**
- `pkg/graph/validation.go`: Added `validation.LabelValueMaxLength` (63) length
  check for resource IDs in `validateResourceIDs()`, after the format check and
  before the duplicate check
- `pkg/graph/validation_test.go`: Added test cases for exactly-63-char IDs
  (passes) and 75-char IDs (rejected), in both `TestValidateRGResourceNames`
  and `TestValidateResourceGraphDefinition`

**How to test:**
```bash
make test WHAT=unit
# or specifically:
go test ./pkg/graph/ -run "TestValidateRGResourceNames|TestValidateResourceGraphDefinition" -v
```

Fixes #1055