### PR TITLE
docs: link access control docs from non-Helm installation instructions

### DIFF
--- a/website/docs/docs/getting-started/01-Installation.md
+++ b/website/docs/docs/getting-started/01-Installation.md
@@ -89,6 +89,20 @@ echo $KRO_VERSION
 kubectl create namespace kro-system
 kubectl apply -f https://github.com/kubernetes-sigs/kro/releases/download/v$KRO_VERSION/$KRO_VARIANT.yaml
 ```
+
+:::warning[**Access Control Setup Required**]
+The raw manifest installation uses the **aggregation** RBAC mode, which only grants kro
+minimal permissions by default. You will need to create additional `ClusterRole` resources
+for each resource type in your `ResourceGraphDefinitions`. Without this, RGD instances will
+fail to reconcile.
+
+See the [Access Control](../advanced/01-access-control.md#aggregation-access) documentation
+for details and examples.
+
+If you prefer the Helm chart's default behavior (full cluster access), use one of the Helm
+installation methods above instead.
+:::
+
   </TabItem>
 </Tabs>
 

--- a/website/versioned_docs/version-0.9.0/docs/getting-started/01-Installation.md
+++ b/website/versioned_docs/version-0.9.0/docs/getting-started/01-Installation.md
@@ -89,6 +89,20 @@ echo $KRO_VERSION
 kubectl create namespace kro-system
 kubectl apply -f https://github.com/kubernetes-sigs/kro/releases/download/v$KRO_VERSION/$KRO_VARIANT.yaml
 ```
+
+:::warning[**Access Control Setup Required**]
+The raw manifest installation uses the **aggregation** RBAC mode, which only grants kro
+minimal permissions by default. You will need to create additional `ClusterRole` resources
+for each resource type in your `ResourceGraphDefinitions`. Without this, RGD instances will
+fail to reconcile.
+
+See the [Access Control](../advanced/01-access-control.md#aggregation-access) documentation
+for details and examples.
+
+If you prefer the Helm chart's default behavior (full cluster access), use one of the Helm
+installation methods above instead.
+:::
+
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
The raw manifest installation uses the **aggregation** RBAC mode, which
only grants kro minimal permissions by default. Users following the Quick
Start or other examples after a non-Helm install hit permission errors
because the required `ClusterRole` resources are not created. The Helm
chart defaults to `unrestricted` mode, so this issue only affects non-Helm
installs.

**What changed:**
- Added a `:::warning` admonition box in the "Raw manifest installation" tab
  of the getting-started Installation page
- The warning explains the RBAC difference and links directly to the
  [Access Control](../advanced/01-access-control.md#aggregation-access)
  documentation with examples
- Applied to both `docs/` (next) and `versioned_docs/version-0.9.0/`

Fixes #1209