### PR TITLE
fix: block RGD deletion while instances still exist

### DIFF
--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -17,11 +17,14 @@ package resourcegraphdefinition
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -261,6 +264,27 @@ func (r *ResourceGraphDefinitionReconciler) Reconcile(
 	o *v1alpha1.ResourceGraphDefinition,
 ) (ctrl.Result, error) {
 	if !o.DeletionTimestamp.IsZero() {
+		// Block deletion while instances of the generated CRD still exist.
+		// Shutting down the instance controller before instances are gone
+		// leaves them with a dangling finalizer that no controller can remove.
+		gvr := metadata.GetResourceGraphDefinitionInstanceGVR(
+			o.Spec.Schema.Group, o.Spec.Schema.APIVersion, o.Spec.Schema.Kind,
+		)
+		existing, err := r.clientSet.Dynamic().Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1})
+		if err != nil {
+			// If the resource type is gone (CRD already deleted externally),
+			// there can't be any instances — safe to proceed with cleanup.
+			if !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+				return ctrl.Result{}, fmt.Errorf("failed to check for existing instances: %w", err)
+			}
+		} else if len(existing.Items) > 0 {
+			ctrl.LoggerFrom(ctx).Info(
+				"waiting for instances to be deleted before cleaning up ResourceGraphDefinition",
+				"instanceGVR", gvr.String(),
+			)
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+
 		startTime := time.Now()
 		if err := r.cleanupResourceGraphDefinition(ctx, o); err != nil {
 			return ctrl.Result{}, err

--- a/pkg/controller/resourcegraphdefinition/controller_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_test.go
@@ -28,6 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -369,6 +370,17 @@ func newFailingBuilder(err error) resourceGraphBuilder {
 
 func newKROFakeSet() *krofake.FakeSet {
 	return krofake.NewFakeSet(dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()))
+}
+
+// newFakeSetForDeletion creates a FakeSet whose dynamic client knows about the
+// given GVR so that List calls succeed. Pre-populated objects are optional.
+func newFakeSetForDeletion(gvr schema.GroupVersionResource, objs ...runtime.Object) *krofake.FakeSet {
+	dc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "UnstructuredList"},
+		objs...,
+	)
+	return krofake.NewFakeSet(dc)
 }
 
 func testDynamicControllerConfig() dynamiccontroller.Config {
@@ -838,6 +850,7 @@ func TestReconcile(t *testing.T) {
 					Client:            c,
 					apiReader:         c,
 					cfg:               Config{AllowCRDDeletion: true},
+					clientSet:         newFakeSetForDeletion(gvr),
 					dynamicController: dc,
 					crdManager:        manager,
 					revisionsRegistry: revisions.NewRegistry(),
@@ -862,12 +875,14 @@ func TestReconcile(t *testing.T) {
 				now := metav1.Now()
 				rgd.DeletionTimestamp = &now
 
+				gvr := metadata.GetResourceGraphDefinitionInstanceGVR(rgd.Spec.Schema.Group, rgd.Spec.Schema.APIVersion, rgd.Spec.Schema.Kind)
 				c := newTestClient(t, interceptor.Funcs{}, rgd.DeepCopy())
 				manager := &stubCRDManager{deleteErr: errors.New("delete boom")}
 				return &ResourceGraphDefinitionReconciler{
 					Client:            c,
 					apiReader:         c,
 					cfg:               Config{AllowCRDDeletion: true},
+					clientSet:         newFakeSetForDeletion(gvr),
 					dynamicController: newRunningDynamicController(t),
 					crdManager:        manager,
 					revisionsRegistry: revisions.NewRegistry(),
@@ -901,6 +916,7 @@ func TestReconcile(t *testing.T) {
 				return &ResourceGraphDefinitionReconciler{
 					Client:            c,
 					apiReader:         c,
+					clientSet:         newFakeSetForDeletion(gvr),
 					dynamicController: dc,
 					crdManager:        &stubCRDManager{},
 					revisionsRegistry: revisions.NewRegistry(),
@@ -910,6 +926,42 @@ func TestReconcile(t *testing.T) {
 				assert.Equal(t, ctrl.Result{}, result)
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "patch boom")
+				assert.True(t, metadata.HasResourceGraphDefinitionFinalizer(getStoredRGD(t, c, rgd.Name)))
+			},
+		},
+		{
+			name: "blocks deletion while instances still exist",
+			build: func(t *testing.T) (*ResourceGraphDefinitionReconciler, client.WithWatch, *v1alpha1.ResourceGraphDefinition, *stubCRDManager) {
+				rgd := newTestRGD("reconcile-delete-blocked")
+				metadata.SetResourceGraphDefinitionFinalizer(rgd)
+				now := metav1.Now()
+				rgd.DeletionTimestamp = &now
+
+				gvr := metadata.GetResourceGraphDefinitionInstanceGVR(rgd.Spec.Schema.Group, rgd.Spec.Schema.APIVersion, rgd.Spec.Schema.Kind)
+
+				// Create an existing instance of the generated CRD
+				instance := &unstructured.Unstructured{}
+				instance.SetGroupVersionKind(schema.GroupVersionKind{
+					Group: gvr.Group, Version: gvr.Version, Kind: "Network",
+				})
+				instance.SetName("my-instance")
+				instance.SetNamespace("default")
+
+				c := newTestClient(t, interceptor.Funcs{}, rgd.DeepCopy())
+				return &ResourceGraphDefinitionReconciler{
+					Client:            c,
+					apiReader:         c,
+					cfg:               Config{AllowCRDDeletion: true},
+					clientSet:         newFakeSetForDeletion(gvr, instance),
+					dynamicController: newRunningDynamicController(t),
+					crdManager:        &stubCRDManager{},
+					revisionsRegistry: revisions.NewRegistry(),
+				}, c, rgd, nil
+			},
+			check: func(t *testing.T, result ctrl.Result, err error, c client.WithWatch, rgd *v1alpha1.ResourceGraphDefinition, _ *stubCRDManager) {
+				require.NoError(t, err)
+				assert.Equal(t, 10*time.Second, result.RequeueAfter)
+				// Finalizer must still be present
 				assert.True(t, metadata.HasResourceGraphDefinitionFinalizer(getStoredRGD(t, c, rgd.Name)))
 			},
 		},


### PR DESCRIPTION
When a `ResourceGraphDefinition` is deleted, the controller immediately
shuts down the instance micro-controller and optionally deletes the CRD.
If instances of the generated CRD still exist at that point, they are
left with a dangling `kro.run/finalizer` that no controller can remove,
causing `kubectl delete` on the instance to hang indefinitely.

**Root cause:** The RGD deletion path proceeds through cleanup
(controller shutdown + CRD deletion) without checking whether instances
still exist. Once the instance controller is gone, the finalizer on
existing instances can never be removed.

**Fix:** Before proceeding with cleanup in the RGD reconciler's deletion
path, list instances of the generated CRD using the dynamic client. If
any instances are found, log a message and requeue after 10 seconds.
The user must delete all instances first before the RGD can be fully
cleaned up. If the CRD is already gone (deleted externally or not yet
created), the check is skipped and cleanup proceeds normally.

**What changed:**
- `pkg/controller/resourcegraphdefinition/controller.go`: Added instance
  existence check before `cleanupResourceGraphDefinition()` in the
  deletion path. Uses `r.clientSet.Dynamic().Resource(gvr).List()` with
  `Limit: 1` for efficiency.
- `pkg/controller/resourcegraphdefinition/controller_test.go`: Added
  `newFakeSetForDeletion` helper and a new test case
  `blocks_deletion_while_instances_still_exist`. Updated existing
  deletion test cases to include the `clientSet` field.

**How to test:**
```bash
go test ./pkg/controller/resourcegraphdefinition/ -run TestReconcile -v
```

Fixes #1067