### PR TITLE
Prevent deleting other RGDs resources on CRD conflict

### DIFF
--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -17,6 +17,7 @@ package resourcegraphdefinition
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -64,13 +65,14 @@ type ResourceGraphDefinitionReconciler struct {
 	apiReader      client.Reader
 	instanceLogger logr.Logger
 
-	clientSet         kroclient.SetInterface
-	crdManager        kroclient.CRDClient
-	metadataLabeler   metadata.Labeler
-	rgBuilder         resourceGraphBuilder
-	dynamicController *dynamiccontroller.DynamicController
-	revisionsRegistry *revisions.Registry
-	cfg               Config
+	clientSet             kroclient.SetInterface
+	crdManager            kroclient.CRDClient
+	metadataLabeler       metadata.Labeler
+	rgBuilder             resourceGraphBuilder
+	dynamicController     *dynamiccontroller.DynamicController
+	revisionsRegistry     *revisions.Registry
+	registeredControllers sync.Map
+	cfg                   Config
 
 	newEventRecorder func(string) record.EventRecorder
 }

--- a/pkg/controller/resourcegraphdefinition/controller_cleanup.go
+++ b/pkg/controller/resourcegraphdefinition/controller_cleanup.go
@@ -35,9 +35,15 @@ import (
 func (r *ResourceGraphDefinitionReconciler) cleanupResourceGraphDefinition(ctx context.Context, rgd *v1alpha1.ResourceGraphDefinition) error {
 	ctrl.LoggerFrom(ctx).V(1).Info("cleaning up resource graph definition", "name", rgd.Name)
 
-	// shutdown microcontroller
-	if err := r.shutdownResourceGraphDefinitionMicroController(ctx, new(metadata.GetResourceGraphDefinitionInstanceGVR(rgd.Spec.Schema.Group, rgd.Spec.Schema.APIVersion, rgd.Spec.Schema.Kind))); err != nil {
-		return fmt.Errorf("failed to shutdown microcontroller: %w", err)
+	// Check in-memory map to avoid stale status data
+	if _, registered := r.registeredControllers.Load(rgd.UID); registered {
+		// shutdown microcontroller
+		gvr := metadata.GetResourceGraphDefinitionInstanceGVR(rgd.Spec.Schema.Group, rgd.Spec.Schema.APIVersion, rgd.Spec.Schema.Kind)
+		if err := r.shutdownResourceGraphDefinitionMicroController(ctx, &gvr); err != nil {
+			return fmt.Errorf("failed to shutdown microcontroller: %w", err)
+		}
+	} else {
+		ctrl.LoggerFrom(ctx).V(1).Info("skipping controller shutdown, controller was never registered", "name", rgd.Name)
 	}
 
 	// Registry eviction is NOT done here. The GraphRevision controller evicts
@@ -55,7 +61,7 @@ func (r *ResourceGraphDefinitionReconciler) cleanupResourceGraphDefinition(ctx c
 
 	// cleanup CRD
 	crdName := extractCRDName(rgd.Spec.Schema.Group, rgd.Spec.Schema.Kind)
-	if err := r.cleanupResourceGraphDefinitionCRD(ctx, crdName); err != nil {
+	if err := r.cleanupResourceGraphDefinitionCRD(ctx, rgd.Name, crdName); err != nil {
 		return fmt.Errorf("failed to cleanup CRD %s: %w", crdName, err)
 	}
 
@@ -71,13 +77,30 @@ func (r *ResourceGraphDefinitionReconciler) shutdownResourceGraphDefinitionMicro
 	return nil
 }
 
-// cleanupResourceGraphDefinitionCRD deletes the CRD with the given name if CRD deletion is enabled.
-// If CRD deletion is disabled, it logs the skip and returns nil.
-func (r *ResourceGraphDefinitionReconciler) cleanupResourceGraphDefinitionCRD(ctx context.Context, crdName string) error {
+// cleanupResourceGraphDefinitionCRD deletes the CRD if CRD deletion is enabled and this RGD owns it.
+func (r *ResourceGraphDefinitionReconciler) cleanupResourceGraphDefinitionCRD(ctx context.Context, rgdName, crdName string) error {
 	if !r.cfg.AllowCRDDeletion {
 		ctrl.LoggerFrom(ctx).Info(
 			"skipping CRD deletion because allowCRDDeletion is disabled",
 			"crd", crdName,
+		)
+		return nil
+	}
+
+	// Check if we own this CRD by reading its labels
+	crd, err := r.crdManager.Get(ctx, crdName)
+	if err != nil {
+		// CRD already deleted or never existed
+		return nil
+	}
+
+	owner, ok := crd.GetLabels()[metadata.ResourceGraphDefinitionNameLabel]
+	if !ok || owner != rgdName {
+		ctrl.LoggerFrom(ctx).V(1).Info(
+			"skipping CRD deletion, not owned by this RGD",
+			"crd", crdName,
+			"rgd", rgdName,
+			"owner", owner,
 		)
 		return nil
 	}

--- a/pkg/controller/resourcegraphdefinition/controller_cleanup_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_cleanup_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/kubernetes-sigs/kro/pkg/graph/revisions"
@@ -116,13 +118,19 @@ func TestCleanupResourceGraphDefinition(t *testing.T) {
 			dc := newRunningDynamicController(t)
 			require.NoError(t, dc.Register(context.Background(), gvr, func(context.Context, ctrl.Request) error { return nil }))
 
-			manager := &stubCRDManager{deleteErr: tt.deleteErr}
+			// Set up CRD with ownership label
+			crdWithOwner := newTestCRD(rgd.Spec.Schema.Group, rgd.Spec.Schema.Kind, rgd.Name)
+			manager := &stubCRDManager{
+				deleteErr: tt.deleteErr,
+				getReturn: crdWithOwner,
+			}
 			reconciler := &ResourceGraphDefinitionReconciler{
 				cfg:               Config{AllowCRDDeletion: tt.allowCRDDeletion},
 				dynamicController: dc,
 				crdManager:        manager,
 				revisionsRegistry: revisions.NewRegistry(),
 			}
+			reconciler.registeredControllers.Store(rgd.UID, true)
 
 			err := reconciler.cleanupResourceGraphDefinition(context.Background(), rgd)
 			if tt.wantErr == "" {
@@ -133,6 +141,46 @@ func TestCleanupResourceGraphDefinition(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.wantDeleted, manager.deleted)
+		})
+	}
+}
+
+func TestCleanupSkipsDeregisterWhenNeverRegistered(t *testing.T) {
+	tests := []struct {
+		name                 string
+		markAsRegistered     bool
+		wantDeregisterCalled bool
+	}{
+		{
+			name:                 "skips deregister when controller was never registered",
+			markAsRegistered:     false,
+			wantDeregisterCalled: false,
+		},
+		{
+			name:                 "calls deregister when controller was registered",
+			markAsRegistered:     true,
+			wantDeregisterCalled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rgd := newTestRGD("skip-cleanup")
+			gvr := metadata.GetResourceGraphDefinitionInstanceGVR(rgd.Spec.Schema.Group, rgd.Spec.Schema.APIVersion, rgd.Spec.Schema.Kind)
+			dc := newRunningDynamicController(t)
+
+			reconciler := &ResourceGraphDefinitionReconciler{
+				dynamicController: dc,
+				crdManager:        &stubCRDManager{},
+				revisionsRegistry: revisions.NewRegistry(),
+			}
+
+			if tt.markAsRegistered {
+				require.NoError(t, dc.Register(context.Background(), gvr, func(context.Context, ctrl.Request) error { return nil }))
+				reconciler.registeredControllers.Store(rgd.UID, true)
+			}
+
+			require.NoError(t, reconciler.cleanupResourceGraphDefinition(context.Background(), rgd))
 		})
 	}
 }
@@ -153,6 +201,7 @@ func TestCleanupPreservesRegistryEntries(t *testing.T) {
 		crdManager:        &stubCRDManager{},
 		revisionsRegistry: registry,
 	}
+	reconciler.registeredControllers.Store(rgd.UID, true)
 
 	require.NoError(t, reconciler.cleanupResourceGraphDefinition(context.Background(), rgd))
 
@@ -172,17 +221,32 @@ func TestCleanupResourceGraphDefinitionCRD(t *testing.T) {
 		name             string
 		allowCRDDeletion bool
 		deleteErr        error
+		crdOwner         string
 		wantDeleted      []string
 		wantErr          string
 	}{
 		{
 			name:        "skips deletion when crd deletion is disabled",
 			deleteErr:   errors.New("should not be called"),
+			crdOwner:    "test-rgd",
 			wantDeleted: nil,
+		},
+		{
+			name:             "skips deletion when not owned by this RGD",
+			allowCRDDeletion: true,
+			crdOwner:         "other-rgd",
+			wantDeleted:      nil,
+		},
+		{
+			name:             "deletes when owned by this RGD",
+			allowCRDDeletion: true,
+			crdOwner:         "test-rgd",
+			wantDeleted:      []string{"networks.example.io"},
 		},
 		{
 			name:             "returns delete errors",
 			allowCRDDeletion: true,
+			crdOwner:         "test-rgd",
 			deleteErr:        errors.New("delete boom"),
 			wantDeleted:      []string{"networks.example.io"},
 			wantErr:          "error deleting CRD",
@@ -191,13 +255,17 @@ func TestCleanupResourceGraphDefinitionCRD(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := &stubCRDManager{deleteErr: tt.deleteErr}
+			crd := newTestCRD("example.io", "Network", tt.crdOwner)
+			manager := &stubCRDManager{
+				deleteErr: tt.deleteErr,
+				getReturn: crd,
+			}
 			reconciler := &ResourceGraphDefinitionReconciler{
 				cfg:        Config{AllowCRDDeletion: tt.allowCRDDeletion},
 				crdManager: manager,
 			}
 
-			err := reconciler.cleanupResourceGraphDefinitionCRD(context.Background(), "networks.example.io")
+			err := reconciler.cleanupResourceGraphDefinitionCRD(context.Background(), "test-rgd", "networks.example.io")
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 			} else {
@@ -207,5 +275,17 @@ func TestCleanupResourceGraphDefinitionCRD(t *testing.T) {
 
 			assert.Equal(t, tt.wantDeleted, manager.deleted)
 		})
+	}
+}
+
+func newTestCRD(group, kind, ownerRGD string) *extv1.CustomResourceDefinition {
+	crdName := extractCRDName(group, kind)
+	return &extv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+			Labels: map[string]string{
+				metadata.ResourceGraphDefinitionNameLabel: ownerRGD,
+			},
+		},
 	}
 }

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile.go
@@ -359,6 +359,7 @@ func (r *ResourceGraphDefinitionReconciler) ensureResourceGraphDefinitionControl
 	if err != nil {
 		return newMicroControllerError(err)
 	}
+	r.registeredControllers.Store(rgd.UID, true)
 	return nil
 }
 

--- a/pkg/controller/resourcegraphdefinition/controller_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_test.go
@@ -831,15 +831,27 @@ func TestReconcile(t *testing.T) {
 				gvr := metadata.GetResourceGraphDefinitionInstanceGVR(rgd.Spec.Schema.Group, rgd.Spec.Schema.APIVersion, rgd.Spec.Schema.Kind)
 				require.NoError(t, dc.Register(context.Background(), gvr, func(context.Context, ctrl.Request) error { return nil }))
 
-				manager := &stubCRDManager{}
-				return &ResourceGraphDefinitionReconciler{
+				// Set up CRD with ownership label
+				crdName := extractCRDName(rgd.Spec.Schema.Group, rgd.Spec.Schema.Kind)
+				crd := &extv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: crdName,
+						Labels: map[string]string{
+							metadata.ResourceGraphDefinitionNameLabel: rgd.Name,
+						},
+					},
+				}
+				manager := &stubCRDManager{getReturn: crd}
+				reconciler := &ResourceGraphDefinitionReconciler{
 					Client:            c,
 					apiReader:         c,
 					cfg:               Config{AllowCRDDeletion: true},
 					dynamicController: dc,
 					crdManager:        manager,
 					revisionsRegistry: revisions.NewRegistry(),
-				}, c, rgd, manager
+				}
+				reconciler.registeredControllers.Store(rgd.UID, true)
+				return reconciler, c, rgd, manager
 			},
 			check: func(t *testing.T, result ctrl.Result, err error, c client.WithWatch, rgd *v1alpha1.ResourceGraphDefinition, manager *stubCRDManager) {
 				require.NoError(t, err)
@@ -860,15 +872,30 @@ func TestReconcile(t *testing.T) {
 				rgd.DeletionTimestamp = new(metav1.Now())
 
 				c := newTestClient(t, interceptor.Funcs{}, rgd.DeepCopy())
-				manager := &stubCRDManager{deleteErr: errors.New("delete boom")}
-				return &ResourceGraphDefinitionReconciler{
+				// Set up CRD with ownership label
+				crdName := extractCRDName(rgd.Spec.Schema.Group, rgd.Spec.Schema.Kind)
+				crd := &extv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: crdName,
+						Labels: map[string]string{
+							metadata.ResourceGraphDefinitionNameLabel: rgd.Name,
+						},
+					},
+				}
+				manager := &stubCRDManager{
+					deleteErr: errors.New("delete boom"),
+					getReturn: crd,
+				}
+				reconciler := &ResourceGraphDefinitionReconciler{
 					Client:            c,
 					apiReader:         c,
 					cfg:               Config{AllowCRDDeletion: true},
 					dynamicController: newRunningDynamicController(t),
 					crdManager:        manager,
 					revisionsRegistry: revisions.NewRegistry(),
-				}, c, rgd, manager
+				}
+				reconciler.registeredControllers.Store(rgd.UID, true)
+				return reconciler, c, rgd, manager
 			},
 			check: func(t *testing.T, result ctrl.Result, err error, c client.WithWatch, rgd *v1alpha1.ResourceGraphDefinition, _ *stubCRDManager) {
 				assert.Equal(t, ctrl.Result{}, result)
@@ -894,13 +921,15 @@ func TestReconcile(t *testing.T) {
 				gvr := metadata.GetResourceGraphDefinitionInstanceGVR(rgd.Spec.Schema.Group, rgd.Spec.Schema.APIVersion, rgd.Spec.Schema.Kind)
 				require.NoError(t, dc.Register(context.Background(), gvr, func(context.Context, ctrl.Request) error { return nil }))
 
-				return &ResourceGraphDefinitionReconciler{
+				reconciler := &ResourceGraphDefinitionReconciler{
 					Client:            c,
 					apiReader:         c,
 					dynamicController: dc,
 					crdManager:        &stubCRDManager{},
 					revisionsRegistry: revisions.NewRegistry(),
-				}, c, rgd, nil
+				}
+				reconciler.registeredControllers.Store(rgd.UID, true)
+				return reconciler, c, rgd, nil
 			},
 			check: func(t *testing.T, result ctrl.Result, err error, c client.WithWatch, rgd *v1alpha1.ResourceGraphDefinition, _ *stubCRDManager) {
 				assert.Equal(t, ctrl.Result{}, result)

--- a/test/integration/suites/core/crd_test.go
+++ b/test/integration/suites/core/crd_test.go
@@ -24,6 +24,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
@@ -241,6 +242,130 @@ var _ = Describe("CRD", func() {
 			// Cleanup
 			Expect(env.Client.Delete(ctx, rgd1)).To(Succeed())
 			Expect(env.Client.Delete(ctx, rgd2)).To(Succeed())
+		})
+
+		It("should not disrupt first RGD's controller when deleting a conflicting RGD", func(ctx SpecContext) {
+			// Create first RGD with a resource
+			rgd1 := generator.NewResourceGraphDefinition("test-controller-preserve-1",
+				generator.WithSchema(
+					"PreserveTest", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("cm", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "${schema.metadata.name}-cm",
+						"namespace": namespace,
+					},
+					"data": map[string]interface{}{
+						"key": "${schema.spec.name}",
+					},
+				}, nil, nil),
+			)
+			Expect(env.Client.Create(ctx, rgd1)).To(Succeed())
+
+			// Wait for RGD1 to be Active
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: "test-controller-preserve-1"}, rgd1)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(rgd1.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Create an instance of RGD1
+			instance1 := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "kro.run/v1alpha1",
+					"kind":       "PreserveTest",
+					"metadata": map[string]interface{}{
+						"name":      "test-instance-1",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"name": "value1",
+					},
+				},
+			}
+			Expect(env.Client.Create(ctx, instance1)).To(Succeed())
+
+			// Wait for instance to reconcile and create ConfigMap
+			Eventually(func(g Gomega, ctx SpecContext) {
+				cm := &corev1.ConfigMap{}
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      "test-instance-1-cm",
+					Namespace: namespace,
+				}, cm)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cm.Data["key"]).To(Equal("value1"))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Create second RGD with same CRD (will conflict)
+			rgd2 := generator.NewResourceGraphDefinition("test-controller-preserve-2",
+				generator.WithSchema(
+					"PreserveTest", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+			)
+			Expect(env.Client.Create(ctx, rgd2)).To(Succeed())
+
+			// Wait for RGD2 to be Inactive due to conflict
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: "test-controller-preserve-2"}, rgd2)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(rgd2.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
+			}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Delete RGD2 (the conflicting one)
+			Expect(env.Client.Delete(ctx, rgd2)).To(Succeed())
+
+			// Wait for RGD2 to be fully deleted
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: "test-controller-preserve-2"}, rgd2)
+				g.Expect(err).To(MatchError(errors.IsNotFound, "rgd2 should be deleted"))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Verify RGD1 is still Active
+			err := env.Client.Get(ctx, types.NamespacedName{Name: "test-controller-preserve-1"}, rgd1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rgd1.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+
+			// Create a new instance of RGD1 to verify controller still works
+			instance2 := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "kro.run/v1alpha1",
+					"kind":       "PreserveTest",
+					"metadata": map[string]interface{}{
+						"name":      "test-instance-2",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"name": "value2",
+					},
+				},
+			}
+			Expect(env.Client.Create(ctx, instance2)).To(Succeed())
+
+			// Verify the new instance reconciles successfully
+			Eventually(func(g Gomega, ctx SpecContext) {
+				cm := &corev1.ConfigMap{}
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      "test-instance-2-cm",
+					Namespace: namespace,
+				}, cm)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cm.Data["key"]).To(Equal("value2"))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Cleanup
+			Expect(env.Client.Delete(ctx, instance1)).To(Succeed())
+			Expect(env.Client.Delete(ctx, instance2)).To(Succeed())
+			Expect(env.Client.Delete(ctx, rgd1)).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/kro/issues/1169

Avoid calling Deregister if our RGD hasn't called register on it

Avoid deleting CRDs if our RGD does not own them