### PR TITLE
Validate we do not attempt to apply duplicate k8s resources

### DIFF
--- a/pkg/controller/instance/applyset/applyset.go
+++ b/pkg/controller/instance/applyset/applyset.go
@@ -205,6 +205,8 @@ type ApplySet struct {
 func (a *ApplySet) Project(resources []Resource) (Metadata, error) {
 	gks := sets.New[schema.GroupKind]()
 	namespaces := sets.New[string]()
+	seen := make(map[string]string)
+	var conflicts []string
 
 	// Collect GKs and namespaces from current resources
 	for _, r := range resources {
@@ -212,6 +214,18 @@ func (a *ApplySet) Project(resources []Resource) (Metadata, error) {
 			continue
 		}
 		gvk := r.Object.GroupVersionKind()
+
+		// Duplicate check: prevent multiple resource IDs targeting the same K8s object
+		key := fmt.Sprintf("%s/%s/%s/%s/%s",
+			gvk.Group, gvk.Version, gvk.Kind,
+			r.Object.GetNamespace(), r.Object.GetName())
+		if existingID, ok := seen[key]; ok {
+			conflicts = append(conflicts, fmt.Sprintf(
+				"resourceID: %s conflicts with resourceID: %s", r.ID, existingID,
+			))
+		}
+		seen[key] = r.ID
+
 		gks.Insert(gvk.GroupKind())
 
 		mapping, err := a.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
@@ -221,6 +235,10 @@ func (a *ApplySet) Project(resources []Resource) (Metadata, error) {
 		if ns, ok := a.resolvedNamespace(mapping, r.Object); ok && ns != a.parentNamespace {
 			namespaces.Insert(ns)
 		}
+	}
+
+	if len(conflicts) > 0 {
+		return Metadata{}, fmt.Errorf("%w: %s", ErrDuplicateResource, strings.Join(conflicts, ", "))
 	}
 
 	// Union with parent annotations (memory from previous reconciles)

--- a/pkg/controller/instance/applyset/applyset_test.go
+++ b/pkg/controller/instance/applyset/applyset_test.go
@@ -1450,3 +1450,204 @@ func TestMetadata_Annotations(t *testing.T) {
 		t.Errorf("Annotations()[%s] = %q, want %q", ApplySetAdditionalNamespacesAnnotation, got, "default")
 	}
 }
+
+func TestProject_DuplicateResources(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources []Resource
+		wantErr   bool
+		errMatch  string
+	}{
+		{
+			name: "no duplicates - different names",
+			resources: []Resource{
+				{
+					ID: "configmap1",
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata": map[string]interface{}{
+								"name":      "config-one",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+				{
+					ID: "configmap2",
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata": map[string]interface{}{
+								"name":      "config-two",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "duplicate detected - same GVK/namespace/name",
+			resources: []Resource{
+				{
+					ID: "configmap1",
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata": map[string]interface{}{
+								"name":      "config",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+				{
+					ID: "configmap2",
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata": map[string]interface{}{
+								"name":      "config",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+			},
+			wantErr:  true,
+			errMatch: "resourceID: configmap2 conflicts with resourceID: configmap1",
+		},
+		{
+			name: "multiple duplicates reported together",
+			resources: []Resource{
+				{
+					ID: "configmap1",
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata": map[string]interface{}{
+								"name":      "config",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+				{
+					ID: "configmap2",
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata": map[string]interface{}{
+								"name":      "config",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+				{
+					ID: "secret1",
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Secret",
+							"metadata": map[string]interface{}{
+								"name":      "creds",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+				{
+					ID: "secret2",
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Secret",
+							"metadata": map[string]interface{}{
+								"name":      "creds",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+			},
+			wantErr:  true,
+			errMatch: "configmap2 conflicts with.*configmap1.*secret2 conflicts with.*secret1",
+		},
+		{
+			name: "skip resources marked as SkipApply",
+			resources: []Resource{
+				{
+					ID: "configmap1",
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata": map[string]interface{}{
+								"name":      "config",
+								"namespace": "default",
+							},
+						},
+					},
+					SkipApply: false,
+				},
+				{
+					ID: "configmap2",
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata": map[string]interface{}{
+								"name":      "config",
+								"namespace": "default",
+							},
+						},
+					},
+					SkipApply: true,
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := newTestParent(schema.GroupVersionKind{
+				Group:   "kro.run",
+				Version: "v1alpha1",
+				Kind:    "ResourceGroup",
+			})
+
+			a := New(Config{
+				Client:          fake.NewSimpleDynamicClient(runtime.NewScheme()),
+				RESTMapper:      newTestRESTMapper(),
+				Log:             logr.Discard(),
+				ParentNamespace: "default",
+			}, parent)
+
+			_, err := a.Project(tt.resources)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Project() expected error matching %q, got nil", tt.errMatch)
+					return
+				}
+				matched, _ := regexp.MatchString(tt.errMatch, err.Error())
+				if !matched {
+					t.Errorf("Project() error = %q, want match %q", err.Error(), tt.errMatch)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Project() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/instance/applyset/const.go
+++ b/pkg/controller/instance/applyset/const.go
@@ -26,6 +26,9 @@ import (
 // be overwritten without explicit action.
 var ErrApplySetConflict = errors.New("resource belongs to a different ApplySet")
 
+// ErrDuplicateResource is returned when multiple resource IDs target the same Kubernetes object.
+var ErrDuplicateResource = errors.New("found resources with conflicts")
+
 // ApplySetConflictError provides details about an ApplySet membership conflict.
 type ApplySetConflictError struct {
 	ResourceName      string

--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -105,6 +105,9 @@ func (c *Controller) buildApplyInputs(rcx *ReconcileContext) (*reconcileResult, 
 
 	r.supersetPatch, err = r.applier.Project(resources)
 	if err != nil {
+		if errors.Is(err, applyset.ErrDuplicateResource) {
+			return nil, err
+		}
 		return nil, rcx.delayedRequeue(fmt.Errorf("project failed: %w", err))
 	}
 


### PR DESCRIPTION
Addresses 1/2 of this issue https://github.com/kubernetes-sigs/kro/issues/957
```
    different graph nodes in the same instance produce identical resources
    different collection items from the same collection producing identical resources
```

If we define an RGD with duplicate resources 
```
  resources:
    - id: configmap1
      template:
        apiVersion: v1
        kind: ConfigMap
        metadata:
          name: cm1
        data:
          element: "ok"
    - id: configmap2
      template:
        apiVersion: v1
        kind: ConfigMap
        metadata:
          name: cm1
        data:
          element: "ok"
```

we previously would get an infinite reconcile as we fought out the resourceID label

Now throw a validation error