### PR TITLE
chore: remove unused ptr functions from tests

### DIFF
--- a/cmd/kro/emulator/emulator_test.go
+++ b/cmd/kro/emulator/emulator_test.go
@@ -562,10 +562,6 @@ func TestGenerateValueWithPreserveUnknownFields(t *testing.T) {
 	})
 }
 
-func ptr[T comparable](v T) *T {
-	return &v
-}
-
 // Helper function to check if a value is either int64 or string
 func isInt64OrString(v interface{}) bool {
 	switch v.(type) {


### PR DESCRIPTION
go now recommends using new() instead
