### PR TITLE
Fix resource leak during deletion when collections reference empty collection

### DIFF
--- a/pkg/runtime/node.go
+++ b/pkg/runtime/node.go
@@ -56,15 +56,23 @@ type Node struct {
 	resourceSchema *spec.Schema
 }
 
-// identityPaths are the template field path prefixes resolved in identity mode,
-// keyed by node type. Only paths relevant to identifying the resource for
-// observation or deletion are included — full template resolution is not needed.
-var identityPaths = map[graph.NodeType][]string{
-	// Single resources are identified by name and namespace.
-	graph.NodeTypeResource: {"metadata.name", "metadata.namespace"},
-	graph.NodeTypeExternal: {"metadata.name", "metadata.namespace"},
+// defaultIdentityPaths are the template field paths used to identify most resource types.
+var defaultIdentityPaths = []string{"metadata.name", "metadata.namespace"}
+
+// identityPathsOverride specifies non-default identity paths for specific node types.
+// Most resources use name and namespace; only special cases need an override.
+var identityPathsOverride = map[graph.NodeType][]string{
 	// External collections have no name; the selector is their identity.
 	graph.NodeTypeExternalCollection: {"metadata.namespace", "metadata.selector"},
+}
+
+// identityPathsForNodeType returns the template field path prefixes that should
+// be resolved when getting a node's identity for observation or deletion.
+func identityPathsForNodeType(nodeType graph.NodeType) []string {
+	if override, ok := identityPathsOverride[nodeType]; ok {
+		return override
+	}
+	return defaultIdentityPaths
 }
 
 // resolveMode controls how template resolution behaves.
@@ -225,7 +233,7 @@ func (n *Node) resolve(mode resolveMode) (result []*unstructured.Unstructured, e
 	// Select vars based on mode.
 	vars := n.templateVars
 	if mode == resolveIdentity {
-		vars = n.templateVarsForPaths(identityPaths[n.Spec.Meta.Type])
+		vars = n.templateVarsForPaths(identityPathsForNodeType(n.Spec.Meta.Type))
 	}
 
 	switch n.Spec.Meta.Type {

--- a/pkg/runtime/node_test.go
+++ b/pkg/runtime/node_test.go
@@ -2448,7 +2448,7 @@ func TestNode_TemplateVarsForPaths(t *testing.T) {
 		},
 		{
 			name:      "filters to identity paths",
-			paths:     identityPaths[graph.NodeTypeResource],
+			paths:     identityPathsForNodeType(graph.NodeTypeResource),
 			wantPaths: []string{"metadata.name", "metadata.namespace"},
 		},
 		{
@@ -2736,6 +2736,59 @@ func TestNode_GetDesiredIdentity(t *testing.T) {
 			validate: func(t *testing.T, _ []*unstructured.Unstructured, err error) {
 				require.Error(t, err)
 				assert.ErrorIs(t, err, ErrDataPending)
+			},
+		},
+		{
+			name: "collection identity ignores annotations with dependencies",
+			node: func() *Node {
+				// Create a dependency node that is NOT observed (simulates empty forEach)
+				depNode := newTestNode("a", graph.NodeTypeCollection).build()
+				// depNode has no observed state, so size(a) would fail
+
+				// Create instance with items for forEach
+				schema := newTestNode(graph.InstanceNodeID, graph.NodeTypeInstance).
+					withObserved(map[string]any{
+						"spec": map[string]any{
+							"items": []any{
+								map[string]any{"id": "x"},
+							},
+						},
+					}).
+					build()
+
+				// Collection B has annotation that references depNode via size(a)
+				// But identity (metadata.name) only depends on the forEach item
+				node := newTestNode("b", graph.NodeTypeCollection).
+					withDep(schema).
+					withDep(depNode).
+					withForEach("schema.spec.items").
+					withTemplate(map[string]any{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]any{
+							"name": "${item.id}",
+							"annotations": map[string]any{
+								"dep": "${string(size(a))}",
+							},
+						},
+					}).
+					withTemplateVar("metadata.name", "item.id").
+					withTemplateVar("metadata.annotations.dep", "string(size(a))").
+					withTemplateExpr("item.id", variable.ResourceVariableKindIteration).
+					withTemplateExpr("string(size(a))", variable.ResourceVariableKindStatic).
+					build()
+				node.Spec.ForEach = []graph.ForEachDimension{
+					{Name: "item", Expression: krocel.NewUncompiled("schema.spec.items")},
+				}
+				node.forEachExprs[0].Expression.References = []string{"schema"}
+				node.templateExprs[1].Expression.References = []string{"a"}
+				return node
+			},
+			validate: func(t *testing.T, result []*unstructured.Unstructured, err error) {
+				// Should succeed - annotations should NOT be evaluated for identity
+				require.NoError(t, err, "GetDesiredIdentity should ignore annotations")
+				require.Len(t, result, 1)
+				assert.Equal(t, "x", result[0].GetName())
 			},
 		},
 		{


### PR DESCRIPTION
Resolved issue here
https://github.com/kubernetes-sigs/kro/issues/1247

Cause seems to be when we updated identity paths we missed a node type
https://github.com/kubernetes-sigs/kro/pull/1232/changes#diff-515649dd828384245d841ca308c508cb1d69aa0f743736c40c8f7ddf601d2b63R60-R65

Make this be an override so new node types get this for free