### PR TITLE
Add an option to disable using field selectors

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -94,6 +94,7 @@ func main() {
 		leaderElectionRenewDeadline   time.Duration
 		leaderElectionRetryPeriod     time.Duration
 		featureGatesFlag              string
+		useFieldSelectors             bool
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8078", "The address the metric endpoint binds to.")
@@ -170,6 +171,8 @@ func main() {
 		"Duration the acting leader will retry refreshing leadership before giving up.")
 	flag.DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 2*time.Second,
 		"Duration between each leader election action.")
+	flag.BoolVar(&useFieldSelectors, "use-field-selectors", true,
+		"Use field selectors when true, otherwise fall back to label selectors. Set to false for Kubernetes <= 1.30 compatibility.")
 
 	opts := zap.Options{
 		Development: true,
@@ -270,6 +273,7 @@ func main() {
 			ProgressRequeueDelay:    rgdProgressRequeueDelay,
 			MaxConcurrentReconciles: resourceGraphDefinitionConcurrentReconciles,
 			MaxGraphRevisions:       rgdMaxGraphRevisions,
+			UseFieldSelectors:       useFieldSelectors,
 			RGDConfig: graph.RGDConfig{
 				MaxCollectionSize:          rgdMaxCollectionSize,
 				MaxCollectionDimensionSize: rgdMaxCollectionDimensionSize,

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -55,6 +55,7 @@ type Config struct {
 	ProgressRequeueDelay    time.Duration
 	MaxConcurrentReconciles int
 	MaxGraphRevisions       int
+	UseFieldSelectors       bool
 	RGDConfig               graph.RGDConfig
 }
 

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile.go
@@ -430,19 +430,28 @@ func newMicroControllerError(err error) error { return &microControllerError{err
 // and terminating sets, and identifies orphans that need adoption.
 //
 // GraphRevisions are grouped by RGD name (not UID) so a recreated RGD with the
-// same name can adopt the existing revisions. The list uses the direct API
-// reader with a CRD selectable field on spec.snapshot.name rather than a
-// cache-only field index. The caller uses the terminating flag to defer
-// decisions while GC is in flight.
+// same name can adopt the existing revisions. The list uses either field selectors
+// (spec.snapshot.name) or label selectors based on the UseFieldSelectors config.
+// The caller uses the terminating flag to defer decisions while GC is in flight.
 //
 // A live revision is considered orphaned when it lacks a controller ownerReference
 // pointing to the current RGD UID. This happens after an orphan-policy delete or
 // when a GR is created externally with a matching spec.snapshot.name.
 func (r *ResourceGraphDefinitionReconciler) listGraphRevisions(ctx context.Context, rgd *v1alpha1.ResourceGraphDefinition) (live []internalv1alpha1.GraphRevision, hasTerminating bool, orphans []int, err error) {
 	revisionList := &internalv1alpha1.GraphRevisionList{}
-	if err := r.apiReader.List(ctx, revisionList, client.MatchingFields{
-		"spec.snapshot.name": rgd.Name,
-	}); err != nil {
+	opts := []client.ListOption{
+		client.MatchingLabels{
+			metadata.ResourceGraphDefinitionNameLabel: rgd.Name,
+		},
+	}
+	if r.cfg.UseFieldSelectors {
+		opts = []client.ListOption{
+			client.MatchingFields{
+				"spec.snapshot.name": rgd.Name,
+			},
+		}
+	}
+	if err := r.apiReader.List(ctx, revisionList, opts...); err != nil {
 		return nil, false, nil, err
 	}
 


### PR DESCRIPTION
Some Kubernetes environments may not have access to or want to use field selectors

Add a CLI flag to allows this to be disabled.

Note explicitly avoiding add this as a Helm chart option because this feature is rare