### PR TITLE
Fix float type mapped to number in OpenAPI schema for CEL compatibility

### DIFF
--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -163,7 +163,7 @@ func TestBuildOpenAPISchema(t *testing.T) {
 							Schema: &extv1.JSONSchemaProps{
 								Type: "array",
 								Items: &extv1.JSONSchemaPropsOrArray{
-									Schema: &extv1.JSONSchemaProps{Type: "float"},
+									Schema: &extv1.JSONSchemaProps{Type: "number"},
 								},
 							},
 						},

--- a/pkg/simpleschema/types/atomic.go
+++ b/pkg/simpleschema/types/atomic.go
@@ -31,7 +31,14 @@ const (
 func (a Atomic) Deps() []string { return nil }
 
 func (a Atomic) Schema(_ Resolver) (*extv1.JSONSchemaProps, error) {
-	return &extv1.JSONSchemaProps{Type: string(a)}, nil
+	t := string(a)
+	if a == Float {
+		// OpenAPI schema does not have a "float" type.
+		// CEL only recognises "number", so using "float" here causes fields
+		// to appear as undefined in CEL expression compilation.
+		t = "number"
+	}
+	return &extv1.JSONSchemaProps{Type: t}, nil
 }
 
 // IsAtomic returns true if s is an atomic type name.


### PR DESCRIPTION
Fixes #1250

When a `float` field is defined in a `ResourceGraphDefinition` schema,
using it in a CEL expression (e.g. `string(schema.spec.floatValue)`)
fails with: `ERROR: <input>:1:19: undefined field 'floatValue'`
