### PR TITLE
feat(runtime): add conditional dependency filtering with caching

### DIFF
--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -15,6 +15,8 @@
 package graph
 
 import (
+	"sync"
+
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
@@ -47,4 +49,9 @@ type Graph struct {
 	// Includes resource schemas (keyed by resource ID) and the instance schema
 	// (keyed by InstanceNodeID). Used at runtime for schema-aware CEL value conversion.
 	ResourceSchemas map[string]*spec.Schema
+
+	// SchemaHashToProcessedDeps caches dependency filtering results.
+	// Key: "specHash:nodeID"
+	// Value: []string (filtered dependencies for that node with that spec)
+	SchemaHashToProcessedDeps sync.Map
 }

--- a/pkg/graph/node.go
+++ b/pkg/graph/node.go
@@ -117,6 +117,22 @@ type ForEachDimension struct {
 // It contains the template, variables, and conditions for a resource.
 // No CRD/schema references are kept here - schemas are only used
 // during build for CEL type-checking.
+//
+// EXPRESSION TYPES: Node contains 4 types of CEL expressions:
+//   - Variables: Template fields (e.g., ${db.host})
+//   - IncludeWhen: Conditions for whether to create resource
+//   - ReadyWhen: Conditions for resource readiness
+//   - ForEach: Iterator expressions for collections
+//
+// When adding new expression types, update these locations:
+//  1. pkg/graph/builder.go: extractTemplateDependencies, extractForEachDependencies, extractConditionDependencies
+//  2. pkg/graph/builder.go: compileNode (expression compilation)
+//  3. pkg/runtime/filter_dependency.go: filterDependencies (runtime dep filtering)
+//  4. pkg/runtime/runtime.go: Phase 3 of FromGraph (expression wiring)
+//  5. pkg/runtime/node_resolve.go: ExpandCollection (if relevant to collections)
+//
+// Note: The need to update expressions across multiple fields is becoming repetitive.
+// Future refactor could consolidate into a single Expressions list that each field references.
 type Node struct {
 	// Meta contains identification metadata (ID, Type, GVR, etc.)
 	Meta NodeMeta
@@ -141,6 +157,46 @@ type Node struct {
 	ForEach []ForEachDimension
 }
 
+// cloneExpression creates a deep copy of an Expression.
+func cloneExpression(expr *krocel.Expression) *krocel.Expression {
+	if expr == nil {
+		return nil
+	}
+	return &krocel.Expression{
+		Original:         expr.Original,
+		OriginalTemplate: expr.OriginalTemplate,
+		References:       slices.Clone(expr.References),
+		Program:          expr.Program,
+	}
+}
+
+// cloneExpressionSlice creates a deep copy of an expression slice.
+func cloneExpressionSlice(exprs []*krocel.Expression) []*krocel.Expression {
+	if exprs == nil {
+		return nil
+	}
+	result := make([]*krocel.Expression, len(exprs))
+	for i, expr := range exprs {
+		result[i] = cloneExpression(expr)
+	}
+	return result
+}
+
+// cloneForEachDimensions creates a deep copy of forEach dimensions.
+func cloneForEachDimensions(dims []ForEachDimension) []ForEachDimension {
+	if dims == nil {
+		return nil
+	}
+	result := make([]ForEachDimension, len(dims))
+	for i, dim := range dims {
+		result[i] = ForEachDimension{
+			Name:       dim.Name,
+			Expression: cloneExpression(dim.Expression),
+		}
+	}
+	return result
+}
+
 // DeepCopy creates a deep copy of the Node.
 // Use this when runtime needs a per-runtime clone to avoid shared slices/maps.
 func (n *Node) DeepCopy() *Node {
@@ -157,9 +213,9 @@ func (n *Node) DeepCopy() *Node {
 			Namespaced:   n.Meta.Namespaced,
 			Dependencies: slices.Clone(n.Meta.Dependencies),
 		},
-		IncludeWhen: slices.Clone(n.IncludeWhen),
-		ReadyWhen:   slices.Clone(n.ReadyWhen),
-		ForEach:     slices.Clone(n.ForEach),
+		IncludeWhen: cloneExpressionSlice(n.IncludeWhen),
+		ReadyWhen:   cloneExpressionSlice(n.ReadyWhen),
+		ForEach:     cloneForEachDimensions(n.ForEach),
 	}
 
 	if n.Template != nil {
@@ -170,7 +226,7 @@ func (n *Node) DeepCopy() *Node {
 		cp.Variables = make([]*variable.ResourceField, len(n.Variables))
 		for i, v := range n.Variables {
 			copyVar := *v
-			copyVar.Expression = new(*v.Expression)
+			copyVar.Expression = cloneExpression(v.Expression)
 			cp.Variables[i] = &copyVar
 		}
 	}

--- a/pkg/runtime/filter_dependency.go
+++ b/pkg/runtime/filter_dependency.go
@@ -1,0 +1,292 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+
+	"github.com/google/cel-go/cel"
+
+	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
+	"github.com/kubernetes-sigs/kro/pkg/cel/ast"
+	"github.com/kubernetes-sigs/kro/pkg/graph"
+)
+
+// preprocessNodeDependencies filters a node's dependencies and updates Expression.References
+// to match. This is the preprocessing step that should be called before wiring dependencies.
+func preprocessNodeDependencies(g *graph.Graph, node *graph.Node, instanceData map[string]any) error {
+	originalDeps := node.Meta.Dependencies
+	filteredDeps, err := filterDependenciesWithCache(g, node, instanceData, originalDeps)
+	if err != nil {
+		return err
+	}
+	node.Meta.Dependencies = filteredDeps
+
+	removedDeps := make(map[string]bool)
+	for _, dep := range originalDeps {
+		removedDeps[dep] = true
+	}
+	for _, dep := range filteredDeps {
+		delete(removedDeps, dep)
+	}
+
+	for _, expr := range node.IncludeWhen {
+		expr.References = removeReferences(expr.References, removedDeps)
+	}
+	for _, expr := range node.ReadyWhen {
+		expr.References = removeReferences(expr.References, removedDeps)
+	}
+	for _, dim := range node.ForEach {
+		dim.Expression.References = removeReferences(dim.Expression.References, removedDeps)
+	}
+	for _, v := range node.Variables {
+		v.Expression.References = removeReferences(v.Expression.References, removedDeps)
+	}
+
+	return nil
+}
+
+func filterDependenciesWithCache(
+	g *graph.Graph,
+	node *graph.Node,
+	instanceData map[string]any,
+	declaredDeps []string,
+) ([]string, error) {
+	specHash, err := hashInstanceData(instanceData)
+	if err != nil {
+		return nil, fmt.Errorf("hash instance data: %w", err)
+	}
+	cacheKey := specHash + ":" + node.Meta.ID
+
+	if cached, ok := g.SchemaHashToProcessedDeps.Load(cacheKey); ok {
+		return cached.([]string), nil
+	}
+
+	filteredDeps, err := filterDependencies(node, instanceData, declaredDeps)
+	if err != nil {
+		return nil, err
+	}
+
+	g.SchemaHashToProcessedDeps.Store(cacheKey, filteredDeps)
+	return filteredDeps, nil
+}
+
+func hashInstanceData(data map[string]any) (string, error) {
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return "", fmt.Errorf("marshal instance data: %w", err)
+	}
+	h := fnv.New64a()
+	h.Write(jsonBytes)
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// removeReferences returns a new slice with denySet items removed.
+func removeReferences(refs []string, denySet map[string]bool) []string {
+	var filtered []string
+	for _, ref := range refs {
+		if !denySet[ref] {
+			filtered = append(filtered, ref)
+		}
+	}
+	return filtered
+}
+
+// filterDependencies uses CEL partial evaluation to determine which dependencies
+// are actually needed. Binds instance object (spec+metadata) and simplifies conditionals
+// (e.g., "schema.spec.useDB ? db : cache" with useDB=true → "db"), then returns only
+// the dependencies referenced in simplified expressions.
+func filterDependencies(
+	node *graph.Node,
+	instanceData map[string]any,
+	declaredDeps []string,
+) ([]string, error) {
+	if !shouldOptimizeDependencies(node) {
+		return declaredDeps, nil
+	}
+
+	allIdentifiers := append([]string{graph.SchemaVarName}, declaredDeps...)
+	env, err := krocel.DefaultEnvironment(krocel.WithResourceIDs(allIdentifiers))
+	if err != nil {
+		return nil, fmt.Errorf("create CEL environment: %w", err)
+	}
+
+	partialEval, err := newPartialEvaluator(env, instanceData, declaredDeps)
+	if err != nil {
+		return nil, fmt.Errorf("create partial evaluator: %w", err)
+	}
+
+	inspector := ast.NewInspectorWithEnv(env, allIdentifiers)
+	referencedResources := make(map[string]struct{})
+	for _, exprStr := range getExpressions(node) {
+		refs, err := extractReferencesFromExpression(partialEval, inspector, exprStr)
+		if err != nil {
+			return nil, err
+		}
+		for _, ref := range refs {
+			referencedResources[ref] = struct{}{}
+		}
+	}
+
+	var filteredDeps []string
+	for _, dep := range declaredDeps {
+		if _, referenced := referencedResources[dep]; referenced {
+			filteredDeps = append(filteredDeps, dep)
+		}
+	}
+
+	return filteredDeps, nil
+}
+
+// getExpressions collects all expression strings from a node that need dependency analysis.
+func getExpressions(node *graph.Node) []string {
+	var exprs []string
+	for _, v := range node.Variables {
+		exprs = append(exprs, v.Expression.Original)
+	}
+	for _, expr := range node.IncludeWhen {
+		exprs = append(exprs, expr.Original)
+	}
+	for _, expr := range node.ReadyWhen {
+		exprs = append(exprs, expr.Original)
+	}
+	for _, iter := range node.ForEach {
+		exprs = append(exprs, iter.Expression.Original)
+	}
+	return exprs
+}
+
+// shouldOptimizeDependencies returns true if the node has non-schema dependencies and expressions.
+func shouldOptimizeDependencies(node *graph.Node) bool {
+	hasNonSchemaDep := false
+	for _, dep := range node.Meta.Dependencies {
+		if dep != graph.SchemaVarName {
+			hasNonSchemaDep = true
+			break
+		}
+	}
+	if !hasNonSchemaDep {
+		return false
+	}
+
+	return len(getExpressions(node)) > 0
+}
+
+// partialEvaluator simplifies CEL expressions by binding schema values and using
+// CEL's partial evaluation to eliminate dead branches in conditionals.
+type partialEvaluator struct {
+	env        *cel.Env
+	activation any
+}
+
+func newPartialEvaluator(env *cel.Env, instanceData map[string]any, resourceIDs []string) (*partialEvaluator, error) {
+	// Create attribute patterns for all resource IDs (mark them as unknown)
+	patterns := make([]*cel.AttributePatternType, 0, len(resourceIDs))
+	for _, resourceID := range resourceIDs {
+		patterns = append(patterns, cel.AttributePattern(resourceID))
+	}
+
+	// Create partial activation: schema is bound, resources are unknown
+	activation, err := cel.PartialVars(
+		map[string]any{graph.SchemaVarName: instanceData},
+		patterns...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create partial activation: %w", err)
+	}
+
+	return &partialEvaluator{
+		env:        env,
+		activation: activation,
+	}, nil
+}
+
+// simplifyExpression attempts partial evaluation on the expression, iterating
+// until a fixed point is reached (no further simplification possible).
+// CEL's partial eval doesn't recursively simplify nested conditionals, so we
+// must iterate.
+func (pe *partialEvaluator) simplifyExpression(exprStr string) (string, error) {
+	const maxIterations = 5
+	current := exprStr
+
+	for i := 0; i < maxIterations; i++ {
+		ast, issues := pe.env.Compile(current)
+		if issues.Err() != nil {
+			// Can't compile - this might happen if expression references
+			// undefined identifiers, which is fine (we'll inspect as-is)
+			return current, nil
+		}
+
+		prg, err := pe.env.Program(ast, cel.EvalOptions(cel.OptTrackState, cel.OptPartialEval))
+		if err != nil {
+			return current, nil
+		}
+
+		_, details, err := prg.Eval(pe.activation)
+		if err != nil {
+			return current, nil
+		}
+
+		if details == nil || details.State() == nil {
+			return current, nil
+		}
+
+		residualAst, err := pe.env.ResidualAst(ast, details)
+		if err != nil {
+			return current, nil
+		}
+
+		residualStr, err := cel.AstToString(residualAst)
+		if err != nil {
+			return current, nil
+		}
+
+		if residualStr == current {
+			return current, nil
+		}
+
+		current = residualStr
+	}
+
+	return current, nil
+}
+
+func extractReferencesFromExpression(
+	partialEval *partialEvaluator,
+	inspector *ast.Inspector,
+	exprStr string,
+) ([]string, error) {
+	simplified, err := partialEval.simplifyExpression(exprStr)
+	if err != nil {
+		return nil, fmt.Errorf("simplify expression: %w", err)
+	}
+
+	inspection, err := inspector.Inspect(simplified)
+	if err != nil {
+		return nil, fmt.Errorf("inspect simplified expression: %w", err)
+	}
+
+	var refs []string
+	for _, dep := range inspection.ResourceDependencies {
+		if dep.ID != graph.SchemaVarName { // Avoid adding schema as a node dependency.
+			refs = append(refs, dep.ID)
+		}
+	}
+
+	return refs, nil
+}

--- a/pkg/runtime/filter_dependency_test.go
+++ b/pkg/runtime/filter_dependency_test.go
@@ -1,0 +1,327 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
+	"github.com/kubernetes-sigs/kro/pkg/graph"
+	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
+)
+
+func TestFilterDependencies(t *testing.T) {
+	tests := []struct {
+		name         string
+		node         *graph.Node
+		instanceSpec map[string]any
+		declaredDeps []string
+		expected     []string
+		expectError  bool
+	}{
+		{
+			name:         "ternary - true branch",
+			node:         nodeWithExpression("schema.spec.useDB ? db.host : pvc.name"),
+			instanceSpec: map[string]any{"spec": map[string]any{"useDB": true}},
+			declaredDeps: []string{"db", "pvc"},
+			expected:     []string{"db"},
+		},
+		{
+			name:         "ternary - false branch",
+			node:         nodeWithExpression("schema.spec.useDB ? db.host : pvc.name"),
+			instanceSpec: map[string]any{"spec": map[string]any{"useDB": false}},
+			declaredDeps: []string{"db", "pvc"},
+			expected:     []string{"pvc"},
+		},
+		{
+			name:         "nested ternary",
+			node:         nodeWithExpression("schema.spec.useDB ? (schema.spec.isReplicated ? primary.host : single.host) : pvc.name"),
+			instanceSpec: map[string]any{"spec": map[string]any{"useDB": true, "isReplicated": false}},
+			declaredDeps: []string{"primary", "single", "pvc"},
+			expected:     []string{"single"},
+		},
+		{
+			name: "multiple expressions - both used",
+			node: nodeWithExpressions([]string{
+				"db.host",
+				"cache.endpoint",
+			}),
+			instanceSpec: map[string]any{},
+			declaredDeps: []string{"db", "cache", "pvc"},
+			expected:     []string{"db", "cache"},
+		},
+		{
+			name:         "no conditionals - all deps used",
+			node:         nodeWithExpression("db.host + ':' + db.port"),
+			instanceSpec: map[string]any{},
+			declaredDeps: []string{"db"},
+			expected:     []string{"db"},
+		},
+		{
+			name:         "forEach iterator with conditional",
+			node:         nodeWithForEach("schema.spec.useDB ? db.replicas : [1, 2, 3]"),
+			instanceSpec: map[string]any{"spec": map[string]any{"useDB": true}},
+			declaredDeps: []string{"db", "pvc"},
+			expected:     []string{"db"},
+		},
+		{
+			name:         "all dependencies filtered out",
+			node:         nodeWithExpression("schema.spec.constant"),
+			instanceSpec: map[string]any{"spec": map[string]any{"constant": "value"}},
+			declaredDeps: []string{"db", "pvc"},
+			expected:     []string{}, // no resource deps, only schema
+		},
+		{
+			name:         "complex nested expression",
+			node:         nodeWithExpression("schema.spec.tier == 'prod' ? (schema.spec.ha ? primary.host : single.host) : dev.host"),
+			instanceSpec: map[string]any{"spec": map[string]any{"tier": "prod", "ha": true}},
+			declaredDeps: []string{"primary", "single", "dev"},
+			expected:     []string{"primary"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered, err := filterDependencies(tt.node, tt.instanceSpec, tt.declaredDeps)
+
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.expected, filtered, "filtered dependencies should match expected")
+		})
+	}
+}
+
+func TestShouldOptimizeDependencies(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *graph.Node
+		expected bool
+	}{
+		{
+			name: "has non-schema deps - should optimize",
+			node: &graph.Node{
+				Meta: graph.NodeMeta{
+					Dependencies: []string{"db", "pvc"},
+				},
+				Variables: []*variable.ResourceField{
+					{
+						FieldDescriptor: variable.FieldDescriptor{
+							Expression: &krocel.Expression{
+								Original:   "schema.useDB ? db.host : pvc.name",
+								References: []string{"schema", "db", "pvc"},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "only schema deps - skip optimization",
+			node: &graph.Node{
+				Meta: graph.NodeMeta{
+					Dependencies: []string{},
+				},
+				Variables: []*variable.ResourceField{
+					{
+						FieldDescriptor: variable.FieldDescriptor{
+							Expression: &krocel.Expression{
+								Original:   "schema.appName",
+								References: []string{"schema"},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "has non-schema deps without schema refs - should optimize",
+			node: &graph.Node{
+				Meta: graph.NodeMeta{
+					Dependencies: []string{"db"},
+				},
+				Variables: []*variable.ResourceField{
+					{
+						FieldDescriptor: variable.FieldDescriptor{
+							Expression: &krocel.Expression{
+								Original:   "db.host",
+								References: []string{"db"},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "has non-schema deps with forEach - should optimize",
+			node: &graph.Node{
+				Meta: graph.NodeMeta{
+					Dependencies: []string{"db"},
+				},
+				ForEach: []graph.ForEachDimension{
+					{
+						Name: "item",
+						Expression: &krocel.Expression{
+							Original:   "schema.items",
+							References: []string{"schema"},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldOptimizeDependencies(tt.node)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPartialEvaluatorSimplify(t *testing.T) {
+	tests := []struct {
+		name         string
+		expression   string
+		instanceSpec map[string]any
+		resourceIDs  []string
+		expected     string
+	}{
+		{
+			name:         "simple ternary - true",
+			expression:   "schema.spec.useDB ? db.host : pvc.name",
+			instanceSpec: map[string]any{"spec": map[string]any{"useDB": true}},
+			resourceIDs:  []string{"db", "pvc"},
+			expected:     "db.host",
+		},
+		{
+			name:         "simple ternary - false",
+			expression:   "schema.spec.useDB ? db.host : pvc.name",
+			instanceSpec: map[string]any{"spec": map[string]any{"useDB": false}},
+			resourceIDs:  []string{"db", "pvc"},
+			expected:     "pvc.name",
+		},
+		{
+			name:         "nested ternary - requires iteration",
+			expression:   "schema.spec.a ? (schema.spec.b ? x.val : y.val) : z.val",
+			instanceSpec: map[string]any{"spec": map[string]any{"a": true, "b": false}},
+			resourceIDs:  []string{"x", "y", "z"},
+			expected:     "y.val",
+		},
+		{
+			name:         "no schema references - unchanged",
+			expression:   "db.host + ':' + db.port",
+			instanceSpec: map[string]any{},
+			resourceIDs:  []string{"db"},
+			expected:     "db.host + \":\" + db.port", // CEL may normalize quotes
+		},
+		{
+			name:         "comparison operator",
+			expression:   "schema.spec.tier == 'prod' ? primary.host : dev.host",
+			instanceSpec: map[string]any{"spec": map[string]any{"tier": "prod"}},
+			resourceIDs:  []string{"primary", "dev"},
+			expected:     "primary.host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, err := krocel.DefaultEnvironment(
+				krocel.WithResourceIDs(append([]string{graph.SchemaVarName}, tt.resourceIDs...)),
+			)
+			require.NoError(t, err)
+
+			pe, err := newPartialEvaluator(env, tt.instanceSpec, tt.resourceIDs)
+			require.NoError(t, err)
+
+			simplified, err := pe.simplifyExpression(tt.expression)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, simplified)
+		})
+	}
+}
+
+// Helper functions to create test nodes
+
+func nodeWithExpression(expr string) *graph.Node {
+	return &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:           "test-node",
+			Dependencies: []string{"schema", "db", "pvc", "primary", "single", "cache", "dev"},
+		},
+		Variables: []*variable.ResourceField{
+			{
+				FieldDescriptor: variable.FieldDescriptor{
+					Path: "test.field",
+					Expression: &krocel.Expression{
+						Original:   expr,
+						References: []string{"schema", "db", "pvc", "primary", "single", "cache", "dev"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func nodeWithExpressions(exprs []string) *graph.Node {
+	vars := make([]*variable.ResourceField, len(exprs))
+	for i, expr := range exprs {
+		vars[i] = &variable.ResourceField{
+			FieldDescriptor: variable.FieldDescriptor{
+				Path: "test.field",
+				Expression: &krocel.Expression{
+					Original:   expr,
+					References: []string{"schema", "db", "cache", "pvc"},
+				},
+			},
+		}
+	}
+	return &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:           "test-node",
+			Dependencies: []string{"schema", "db", "cache", "pvc"},
+		},
+		Variables: vars,
+	}
+}
+
+func nodeWithForEach(iterExpr string) *graph.Node {
+	return &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:           "test-node",
+			Dependencies: []string{"schema", "db", "pvc"},
+		},
+		ForEach: []graph.ForEachDimension{
+			{
+				Name: "item",
+				Expression: &krocel.Expression{
+					Original:   iterExpr,
+					References: []string{"schema", "db", "pvc"},
+				},
+			},
+		},
+	}
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -15,6 +15,7 @@
 package runtime
 
 import (
+	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -113,10 +114,13 @@ func FromGraph(g *graph.Graph, instance *unstructured.Unstructured, rgdConfig gr
 	rt.instance = instNode
 
 	// Phase 2: Wire up dependencies for each node.
-	// Inject instance node as "schema" dep for static expression evaluation.
+	instanceData := withStatusOmitted(instanceObj.Object)
 	for _, id := range rt.order {
 		node := rt.nodes[id]
 		node.deps[graph.InstanceNodeID] = instNode
+		if err := preprocessNodeDependencies(g, node.Spec, instanceData); err != nil {
+			return nil, fmt.Errorf("failed to filter dependencies for node %q: %w", id, err)
+		}
 		for _, depID := range node.Spec.Meta.Dependencies {
 			if dep, ok := rt.nodes[depID]; ok {
 				node.deps[depID] = dep
@@ -125,6 +129,9 @@ func FromGraph(g *graph.Graph, instance *unstructured.Unstructured, rgdConfig gr
 	}
 
 	// Wire up instance node dependencies.
+	if err := preprocessNodeDependencies(g, instNode.Spec, instanceData); err != nil {
+		return nil, fmt.Errorf("failed to filter dependencies for instance node: %w", err)
+	}
 	for _, depID := range instNode.Spec.Meta.Dependencies {
 		if dep, ok := rt.nodes[depID]; ok {
 			instNode.deps[depID] = dep

--- a/test/integration/suites/core/conditional_dependency_test.go
+++ b/test/integration/suites/core/conditional_dependency_test.go
@@ -1,0 +1,346 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+var _ = Describe("Conditional Dependencies", func() {
+	var (
+		namespace string
+	)
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		Expect(env.Client.Create(ctx, ns)).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})).To(Succeed())
+	})
+
+	It("should only create cache service when useCache=true", func(ctx SpecContext) {
+		rgd := generator.NewResourceGraphDefinition("conditional-dep",
+			generator.WithSchema(
+				"ConditionalApp", "v1alpha1",
+				map[string]interface{}{
+					"name":     "string",
+					"useCache": "boolean",
+				},
+				nil,
+			),
+			// Cache service
+			generator.WithResource("cache", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-cache",
+				},
+				"spec": map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{
+							"port":       6379,
+							"targetPort": 6379,
+						},
+					},
+					"selector": map[string]interface{}{
+						"app": "cache",
+					},
+				},
+			}, nil, []string{"${schema.spec.useCache}"}),
+			// Database service
+			generator.WithResource("database", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-db",
+				},
+				"spec": map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{
+							"port":       5432,
+							"targetPort": 5432,
+						},
+					},
+					"selector": map[string]interface{}{
+						"app": "database",
+					},
+				},
+			}, nil, []string{"${!schema.spec.useCache}"}),
+			// App deployment with conditional endpoint reference
+			generator.WithResource("app", map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-app",
+				},
+				"spec": map[string]interface{}{
+					"replicas": 1,
+					"selector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"app": "app",
+						},
+					},
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"app": "app",
+							},
+						},
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "app",
+									"image": "nginx",
+									"env": []interface{}{
+										map[string]interface{}{
+											"name":  "BACKEND_ENDPOINT",
+											"value": "${schema.spec.useCache ? cache.spec.clusterIP : database.spec.clusterIP}",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}, nil, nil),
+		)
+
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+		// Create instance with useCache=true
+		instance := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "kro.run/v1alpha1",
+				"kind":       "ConditionalApp",
+				"metadata": map[string]interface{}{
+					"name":      "test-app",
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"name":     "myapp",
+					"useCache": true,
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		// Verify cache service is created
+		cacheService := &corev1.Service{}
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      "myapp-cache",
+				Namespace: namespace,
+			}, cacheService)
+			g.Expect(err).NotTo(HaveOccurred())
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+		// Verify database service is NOT created
+		dbService := &corev1.Service{}
+		Consistently(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      "myapp-db",
+				Namespace: namespace,
+			}, dbService)
+			g.Expect(errors.IsNotFound(err)).To(BeTrue())
+		}, 5*time.Second, 1*time.Second).Should(Succeed())
+
+		// Verify instance becomes ACTIVE
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      "test-app",
+				Namespace: namespace,
+			}, instance)
+			g.Expect(err).NotTo(HaveOccurred())
+			state, found, err := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(state).To(Equal("ACTIVE"))
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+	})
+
+	It("should only create database service when useCache=false", func(ctx SpecContext) {
+		rgd := generator.NewResourceGraphDefinition("conditional-dep-2",
+			generator.WithSchema(
+				"ConditionalApp2", "v1alpha1",
+				map[string]interface{}{
+					"name":     "string",
+					"useCache": "boolean",
+				},
+				nil,
+			),
+			generator.WithResource("cache", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-cache",
+				},
+				"spec": map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{
+							"port":       6379,
+							"targetPort": 6379,
+						},
+					},
+					"selector": map[string]interface{}{
+						"app": "cache",
+					},
+				},
+			}, nil, []string{"${schema.spec.useCache}"}),
+			generator.WithResource("database", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-db",
+				},
+				"spec": map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{
+							"port":       5432,
+							"targetPort": 5432,
+						},
+					},
+					"selector": map[string]interface{}{
+						"app": "database",
+					},
+				},
+			}, nil, []string{"${!schema.spec.useCache}"}),
+			generator.WithResource("app", map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-app",
+				},
+				"spec": map[string]interface{}{
+					"replicas": 1,
+					"selector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"app": "app",
+						},
+					},
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"app": "app",
+							},
+						},
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "app",
+									"image": "nginx",
+									"env": []interface{}{
+										map[string]interface{}{
+											"name":  "BACKEND_ENDPOINT",
+											"value": "${schema.spec.useCache ? cache.spec.clusterIP : database.spec.clusterIP}",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}, nil, nil),
+		)
+
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+		// Create instance with useCache=false
+		instance := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "kro.run/v1alpha1",
+				"kind":       "ConditionalApp2",
+				"metadata": map[string]interface{}{
+					"name":      "test-app",
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"name":     "myapp",
+					"useCache": false,
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		// Verify database service is created
+		dbService := &corev1.Service{}
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      "myapp-db",
+				Namespace: namespace,
+			}, dbService)
+			g.Expect(err).NotTo(HaveOccurred())
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+		// Verify cache service is NOT created
+		cacheService := &corev1.Service{}
+		Consistently(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      "myapp-cache",
+				Namespace: namespace,
+			}, cacheService)
+			g.Expect(errors.IsNotFound(err)).To(BeTrue())
+		}, 5*time.Second, 1*time.Second).Should(Succeed())
+
+		// Verify instance becomes ACTIVE
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      "test-app",
+				Namespace: namespace,
+			}, instance)
+			g.Expect(err).NotTo(HaveOccurred())
+			state, found, err := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(state).To(Equal("ACTIVE"))
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+	})
+
+})


### PR DESCRIPTION
Filter out unneeded dependencies with CEL partial evaluation

This is more for correctness than an optimization. Consider the expression, 

`'schema.spec.useCache ? cache : database'`, we should only ever have a depencey on cache or database not both as it works today.
 
Based off ideas of this KREP very loosely 

https://github.com/kubernetes-sigs/kro/pull/1125

Limiting to schema allows us to avoid needing to rewrite how we build graphs. The general solution can not be solved easily with the current architecture. Processing nodes bottom up does not allow us to easily optimize out nodes.  