### PR TITLE
fix: instance deletion stuck when SSA field manager owns finalizer

### DIFF
--- a/pkg/controller/instance/deletion.go
+++ b/pkg/controller/instance/deletion.go
@@ -15,6 +15,7 @@
 package instance
 
 import (
+	"encoding/json"
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
@@ -241,16 +243,50 @@ func resourceClientFor(
 	return rcx.Client.Resource(desc.GVR)
 }
 
-// setUnmanaged removes the instance finalizer using SSA.
+// setUnmanaged removes the instance finalizer using JSON merge patch with retry on conflict.
+// Uses merge patch (not SSA) to avoid field manager ownership blocking finalizer removal.
 func (c *Controller) setUnmanaged(rcx *ReconcileContext, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	if exist := metadata.HasInstanceFinalizer(obj); !exist {
 		return obj, nil
 	}
 	rcx.Log.Info("Removing managed state", "name", obj.GetName(), "namespace", obj.GetNamespace())
-	instancePatch := instanceSSAPatch(obj)
-	instancePatch.SetFinalizers(obj.GetFinalizers())
-	metadata.RemoveInstanceFinalizer(instancePatch)
-	updated, err := rcx.InstanceClient().Apply(rcx.Ctx, instancePatch.GetName(), instancePatch, metav1.ApplyOptions{FieldManager: FieldManagerForLabeler, Force: true})
+
+	var updated *unstructured.Unstructured
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Re-fetch fresh object on each retry attempt
+		current, err := rcx.InstanceClient().Get(rcx.Ctx, obj.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		// Check if finalizer still exists after re-fetch
+		if !metadata.HasInstanceFinalizer(current) {
+			updated = current
+			return nil
+		}
+
+		clone := current.DeepCopy()
+		metadata.RemoveInstanceFinalizer(clone)
+
+		patchData, err := json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"resourceVersion": current.GetResourceVersion(),
+				"finalizers":      clone.GetFinalizers(),
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to marshal finalizer patch: %w", err)
+		}
+
+		updated, err = rcx.InstanceClient().Patch(
+			rcx.Ctx,
+			current.GetName(),
+			types.MergePatchType,
+			patchData,
+			metav1.PatchOptions{},
+		)
+		return err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update unmanaged state: %w", err)
 	}

--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -15,14 +15,18 @@
 package instance
 
 import (
+	"encoding/json"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
@@ -323,6 +327,58 @@ func TestSetUnmanaged(t *testing.T) {
 			assert.Equal(t, tt.wantManaged, metadata.HasInstanceFinalizer(patched))
 		})
 	}
+}
+
+func TestSetUnmanagedRetriesOnConflict(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	instance.SetResourceVersion("1")
+	metadata.SetInstanceFinalizer(instance)
+	instance.SetFinalizers(append(instance.GetFinalizers(), "other.io/finalizer"))
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
+
+	var attempts atomic.Int32
+	raw.PrependReactor("get", "webapps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		attempt := attempts.Add(1)
+		obj := instance.DeepCopy()
+		obj.SetResourceVersion(string(rune('0' + attempt)))
+		return true, obj, nil
+	})
+
+	raw.PrependReactor("patch", "webapps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		patchAction := action.(k8stesting.PatchAction)
+		var patchPayload map[string]interface{}
+		err := json.Unmarshal(patchAction.GetPatch(), &patchPayload)
+		require.NoError(t, err)
+
+		patchMeta, ok := patchPayload["metadata"].(map[string]interface{})
+		require.True(t, ok, "patch must include metadata")
+		_, hasResourceVersion := patchMeta["resourceVersion"]
+		require.True(t, hasResourceVersion, "patch must include resourceVersion")
+
+		finalizers, ok := patchMeta["finalizers"].([]interface{})
+		require.True(t, ok, "patch must include finalizers array")
+		require.Equal(t, []interface{}{"other.io/finalizer"}, finalizers, "only kro finalizer should be removed")
+
+		attempt := attempts.Load()
+		if attempt == 1 {
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Group: "kro.run", Resource: "webapps"},
+				"demo",
+				errors.New("conflict"),
+			)
+		}
+		result := instance.DeepCopy()
+		result.SetFinalizers([]string{"other.io/finalizer"})
+		result.SetResourceVersion("2")
+		return true, result, nil
+	})
+
+	patched, err := controller.setUnmanaged(rcx, rcx.Instance)
+	require.NoError(t, err)
+	assert.False(t, metadata.HasInstanceFinalizer(patched))
+	assert.Equal(t, []string{"other.io/finalizer"}, patched.GetFinalizers())
+	assert.GreaterOrEqual(t, attempts.Load(), int32(2))
 }
 
 func TestRemoveFinalizerMarksInstanceNotManagedOnError(t *testing.T) {

--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -15,14 +15,18 @@
 package instance
 
 import (
+	"encoding/json"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
@@ -323,6 +327,58 @@ func TestSetUnmanaged(t *testing.T) {
 			assert.Equal(t, tt.wantManaged, metadata.HasInstanceFinalizer(patched))
 		})
 	}
+}
+
+func TestSetUnmanagedRetriesOnConflict(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	instance.SetResourceVersion("1")
+	metadata.SetInstanceFinalizer(instance)
+	instance.SetFinalizers(append(instance.GetFinalizers(), "other.io/finalizer"))
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
+
+	var attempts atomic.Int32
+	raw.PrependReactor("get", "webapps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		attempt := attempts.Add(1)
+		obj := instance.DeepCopy()
+		obj.SetResourceVersion(string('0' + attempt))
+		return true, obj, nil
+	})
+
+	raw.PrependReactor("patch", "webapps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		patchAction := action.(k8stesting.PatchAction)
+		var patchPayload map[string]interface{}
+		err := json.Unmarshal(patchAction.GetPatch(), &patchPayload)
+		require.NoError(t, err)
+
+		patchMeta, ok := patchPayload["metadata"].(map[string]interface{})
+		require.True(t, ok, "patch must include metadata")
+		_, hasResourceVersion := patchMeta["resourceVersion"]
+		require.True(t, hasResourceVersion, "patch must include resourceVersion")
+
+		finalizers, ok := patchMeta["finalizers"].([]interface{})
+		require.True(t, ok, "patch must include finalizers array")
+		require.Equal(t, []interface{}{"other.io/finalizer"}, finalizers, "only kro finalizer should be removed")
+
+		attempt := attempts.Load()
+		if attempt == 1 {
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Group: "kro.run", Resource: "webapps"},
+				"demo",
+				errors.New("conflict"),
+			)
+		}
+		result := instance.DeepCopy()
+		result.SetFinalizers([]string{"other.io/finalizer"})
+		result.SetResourceVersion("2")
+		return true, result, nil
+	})
+
+	patched, err := controller.setUnmanaged(rcx, rcx.Instance)
+	require.NoError(t, err)
+	assert.False(t, metadata.HasInstanceFinalizer(patched))
+	assert.Equal(t, []string{"other.io/finalizer"}, patched.GetFinalizers())
+	assert.GreaterOrEqual(t, attempts.Load(), int32(2))
 }
 
 func TestRemoveFinalizerMarksInstanceNotManagedOnError(t *testing.T) {


### PR DESCRIPTION
Fix issue causing instances to hang on deletion if they were created before this commit 
https://github.com/kubernetes-sigs/kro/commit/7e4aeaffdfdc67a6a6da5242a9d40498a833dac4

If the Kro finalizer is owned by another field manager and we do an empty SSA apply without that finalizer, then we just release our ownership. Since another field manager owns that field k8s won't remove it.

We do specify with force=true, but there is no conflict since our SSA is not specifying what our intent is with that field, just that we don't care about the field.

Switch to just using merge patch to avoid dealing with this edge case.

We also were adding ourselves as an owner to other finalizers which wasn't great. 

Matches this pattern
https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/garbagecollector/operations.go#L104