### PR TITLE
Fix float simpleschema type to generate number in CRD

### DIFF
--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -163,7 +163,7 @@ func TestBuildOpenAPISchema(t *testing.T) {
 							Schema: &extv1.JSONSchemaProps{
 								Type: "array",
 								Items: &extv1.JSONSchemaPropsOrArray{
-									Schema: &extv1.JSONSchemaProps{Type: "float"},
+									Schema: &extv1.JSONSchemaProps{Type: "number"},
 								},
 							},
 						},
@@ -226,6 +226,19 @@ func TestBuildOpenAPISchema(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: true,
+		},
+		{
+			name: "Schema with float field maps to number",
+			obj: map[string]interface{}{
+				"ratio": "float",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"ratio": {Type: "number"},
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "Nested slices",

--- a/pkg/simpleschema/types/atomic.go
+++ b/pkg/simpleschema/types/atomic.go
@@ -31,7 +31,16 @@ const (
 func (a Atomic) Deps() []string { return nil }
 
 func (a Atomic) Schema(_ Resolver) (*extv1.JSONSchemaProps, error) {
-	return &extv1.JSONSchemaProps{Type: string(a)}, nil
+	// The simpleschema DSL uses "float" as a friendly name, but OpenAPI v3
+	// (and therefore CRD validation and CEL) only recognizes "number" for
+	// floating-point values. Without this mapping, CEL expressions that
+	// reference float fields fail with "undefined field" because the
+	// generated CRD has an invalid schema type.
+	t := string(a)
+	if a == Float {
+		t = "number"
+	}
+	return &extv1.JSONSchemaProps{Type: t}, nil
 }
 
 // IsAtomic returns true if s is an atomic type name.


### PR DESCRIPTION
## Summary

Fixes #1250.

The simpleschema DSL uses `float` as a friendly type name, but OpenAPI v3 — and therefore CRD validation and CEL — only recognizes `number` for floating-point values. Previously, a float field in a ResourceGraphDefinition schema generated a CRD with `type: float`, which Kubernetes accepted but CEL treated as an unknown schema. CEL expressions referencing the field then failed with `undefined field`.

The fix maps `Atomic.Float` to `"number"` when generating the JSONSchema, and updates the existing nested-matrix test to expect `number`. Added a new test case covering a top-level float field so this doesn't regress.

This matches the direction @NicholasBlaskey and @Klarekante aligned on in the issue.

## Reproduction

```yaml
apiVersion: kro.run/v1alpha1
kind: ResourceGraphDefinition
metadata:
  name: appconfig
spec:
  schema:
    apiVersion: v1alpha1
    kind: AppConfig
    spec:
      floatValue: float | default=55.5
  resources:
    - id: myConfigmap
      template:
        apiVersion: v1
        kind: ConfigMap
        metadata:
          name: ${schema.metadata.name}-cm
        data:
          floatValue: "${string(schema.spec.floatValue)}"
```

Before this change, applying the above produced:

```
failed to compile template expression "string(schema.spec.floatValue)":
ERROR: <input>:1:19: undefined field 'floatValue'
```

## Test plan

- [x] `go test ./pkg/simpleschema/...` — new `Schema with float field maps to number` case plus existing tests pass
- [x] `go test ./pkg/...` — no downstream breakage
- [x] `go build ./...`