### PR TITLE
Remove "v" prefix from Helm chart version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ publish-debug-image: ## Publish kro controller debug image with pprof enabled.
 .PHONY: inject-helm-version
 inject-helm-version:
 	sed $(SED_INPLACE_FLAGS) 's/tag: .*/tag: "$(RELEASE_VERSION)"/' helm/values.yaml
-	sed $(SED_INPLACE_FLAGS) 's/version: .*/version: $(RELEASE_VERSION)/' helm/Chart.yaml
+	sed $(SED_INPLACE_FLAGS) 's/version: .*/version: $(RELEASE_VERSION:v%=%)/' helm/Chart.yaml
 	sed $(SED_INPLACE_FLAGS) 's/appVersion: .*/appVersion: "$(RELEASE_VERSION)"/' helm/Chart.yaml
 
 .PHONY: package-helm


### PR DESCRIPTION
When using the Helm chart for kro via Terraform if I specify the version to be `0.9.1` the chart installs fine but future updates detect this drift:

```tf
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
! update in-place

Terraform will perform the following actions:

# module.*.helm_release.kro will be updated in-place
! resource "helm_release" "kro" {
        id                         = "kro"
        name                       = "kro"
!       version                    = "v0.9.1" -> "0.9.1"
        # (26 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

...
```

I can change the version to `v0.9.1` to stop Terraform from seeing this drift but I'm unable to use `v0.9.1` to upgrade or install from scratch:

```
Error: registry.k8s.io/kro/charts/kro:v0.9.1: not found
```

I believe the solution to this problem is to remove the leading "v" from the Helm chart version. Making this change should allow me to specify `0.9.1` causes the Helm Terraform provider to no longer detect any drift as the version it detects should now match.

By making this change the resource label `helm.sh/chart` will change from `kro-v0.9.1` to `kro-0.9.1`. Other version labels such as `app.kubernetes.io/version: v0.9.1` are unaffected.

I used `make inject-helm-version RELEASE_VERSION=v0.9.1` locally to test my changes.