### PR TITLE
Fix collection deletion with CEL errors in forEach identity paths

### DIFF
--- a/pkg/controller/instance/deletion.go
+++ b/pkg/controller/instance/deletion.go
@@ -16,6 +16,8 @@ package instance
 
 import (
 	"fmt"
+	"slices"
+	"strconv"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,6 +80,26 @@ func (c *Controller) planNodesForDeletion(
 		}
 
 		isExternal := nodeMeta.Type == graph.NodeTypeExternal || nodeMeta.Type == graph.NodeTypeExternalCollection
+		isManagedCollection := nodeMeta.Type == graph.NodeTypeCollection
+
+		// Managed collections during deletion: skip identity resolution, LIST by labels.
+		// This avoids CEL evaluation failures in forEach identity paths.
+		if isManagedCollection {
+			items, err := c.listCollectionItems(rcx, nodeMeta.GVR, rid)
+			if err != nil {
+				state.SetError(err)
+				return nil, fmt.Errorf("failed to list collection items for %s: %w", rid, err)
+			}
+			if len(items) == 0 {
+				state.SetDeleted()
+				continue
+			}
+			sortByCollectionIndex(items)
+			node.SetObserved(items)
+			state.SetInProgress()
+			deletionNode = node
+			continue
+		}
 
 		// Resolve identity without readiness gating. External nodes use this to
 		// locate the resource for observation; managed nodes use it as the deletion target.
@@ -119,23 +141,7 @@ func (c *Controller) planNodesForDeletion(
 			panic(fmt.Sprintf("unexpected instance node in deletion: %s", rid))
 
 		case graph.NodeTypeCollection:
-			// Collections are label-selected and can span namespaces; LIST once and
-			// set observed so runtime can compute delete targets in desired order.
-			//
-			// Differently from single resources, we do not do GETs per-item here because
-			// that would be inefficient and cause many API calls during deletion.
-			items, err := c.listCollectionItems(rcx, nodeMeta.GVR, rid)
-			if err != nil {
-				state.SetError(err)
-				return nil, fmt.Errorf("failed to list collection items for %s: %w", rid, err)
-			}
-			if len(items) == 0 {
-				state.SetDeleted()
-				continue
-			}
-			node.SetObserved(items)
-			state.SetInProgress()
-			deletionNode = node
+			panic(fmt.Sprintf("collection node should have been handled earlier: %s", rid))
 
 		case graph.NodeTypeResource:
 			// Single resources delete by identity; GET the object to mark observed and
@@ -255,4 +261,27 @@ func (c *Controller) setUnmanaged(rcx *ReconcileContext, obj *unstructured.Unstr
 		return nil, fmt.Errorf("failed to update unmanaged state: %w", err)
 	}
 	return updated, nil
+}
+
+// sortByCollectionIndex sorts collection items by their kro.run/collection-index label.
+// This preserves forEach iteration order during deletion without requiring forEach expansion.
+// Items without a valid index label are placed at the end in undefined order.
+func sortByCollectionIndex(items []*unstructured.Unstructured) {
+	slices.SortStableFunc(items, func(a, b *unstructured.Unstructured) int {
+		aIdx, aErr := strconv.Atoi(a.GetLabels()[metadata.CollectionIndexLabel])
+		bIdx, bErr := strconv.Atoi(b.GetLabels()[metadata.CollectionIndexLabel])
+
+		// Items without valid index labels sort to the end
+		if aErr != nil && bErr != nil {
+			return 0
+		}
+		if aErr != nil {
+			return 1
+		}
+		if bErr != nil {
+			return -1
+		}
+
+		return aIdx - bIdx
+	})
 }

--- a/pkg/runtime/node.go
+++ b/pkg/runtime/node.go
@@ -284,13 +284,9 @@ func (n *Node) resolve(mode resolveMode) (result []*unstructured.Unstructured, e
 func (n *Node) DeleteTargets() ([]*unstructured.Unstructured, error) {
 	switch n.Spec.Meta.Type {
 	case graph.NodeTypeCollection, graph.NodeTypeResource:
-		desired, err := n.GetDesiredIdentity()
-		if err != nil {
-			return nil, err
-		}
-		if n.Spec.Meta.Type == graph.NodeTypeCollection {
-			return orderedIntersection(n.observed, desired), nil
-		}
+		// Instance deletion: return all observed items without filtering.
+		// Collections list by labels, single resources GET by identity.
+		// Both paths happen in planNodesForDeletion before DeleteTargets is called.
 		return n.observed, nil
 	case graph.NodeTypeInstance, graph.NodeTypeExternal, graph.NodeTypeExternalCollection:
 		panic(fmt.Sprintf("DeleteTargets called for node type %v", n.Spec.Meta.Type))

--- a/pkg/runtime/node_test.go
+++ b/pkg/runtime/node_test.go
@@ -2849,7 +2849,7 @@ func TestNode_DeleteTargets(t *testing.T) {
 			},
 		},
 		{
-			name: "collection deletes only observed objects that still match desired identities in desired order",
+			name: "collection deletes all observed objects during instance deletion",
 			node: func() *Node {
 				schema := newTestNode(graph.InstanceNodeID, graph.NodeTypeInstance).
 					withObserved(map[string]any{
@@ -2881,8 +2881,9 @@ func TestNode_DeleteTargets(t *testing.T) {
 			},
 			validate: func(t *testing.T, _ *Node, result []*unstructured.Unstructured, err error) {
 				require.NoError(t, err)
-				require.Len(t, result, 2)
-				assert.Equal(t, []string{"east", "west"}, []string{result[0].GetName(), result[1].GetName()})
+				// Returns ALL observed items, including orphans (forEach expansion is skipped)
+				require.Len(t, result, 3)
+				assert.Equal(t, []string{"west", "orphan", "east"}, []string{result[0].GetName(), result[1].GetName(), result[2].GetName()})
 			},
 		},
 		{
@@ -2907,7 +2908,7 @@ func TestNode_DeleteTargets(t *testing.T) {
 			expectPanic: true,
 		},
 		{
-			name: "identity resolution errors are surfaced",
+			name: "collections skip identity resolution during deletion",
 			node: func() *Node {
 				schema := newTestNode(graph.InstanceNodeID, graph.NodeTypeInstance).
 					withObserved(map[string]any{"spec": map[string]any{}}).
@@ -2922,6 +2923,9 @@ func TestNode_DeleteTargets(t *testing.T) {
 					}).
 					withTemplateVar("metadata.name", "region").
 					withTemplateExpr("region", variable.ResourceVariableKindIteration).
+					withObservedUnstructured(
+						newUnstructured("v1", "ConfigMap", "tenant-a", "item1"),
+					).
 					build()
 				node.Spec.ForEach = []graph.ForEachDimension{
 					{Name: "region", Expression: krocel.NewUncompiled("schema.spec.regions")},
@@ -2929,9 +2933,11 @@ func TestNode_DeleteTargets(t *testing.T) {
 				node.forEachExprs[0].Expression.References = []string{"schema"}
 				return node
 			},
-			validate: func(t *testing.T, _ *Node, _ []*unstructured.Unstructured, err error) {
-				require.Error(t, err)
-				assert.ErrorIs(t, err, ErrDataPending)
+			validate: func(t *testing.T, _ *Node, result []*unstructured.Unstructured, err error) {
+				// Collections skip GetDesiredIdentity, so no error even though forEach would fail
+				require.NoError(t, err)
+				require.Len(t, result, 1)
+				assert.Equal(t, "item1", result[0].GetName())
 			},
 		},
 		{

--- a/test/integration/suites/core/collection_cel_error_deletion_test.go
+++ b/test/integration/suites/core/collection_cel_error_deletion_test.go
@@ -1,0 +1,164 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/controller/resourcegraphdefinition"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+var _ = Describe("Collection CEL Error Deletion", func() {
+	var (
+		namespace string
+	)
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})).To(Succeed())
+	})
+
+	It("should delete collection instance despite CEL error in forEach identity path", func(ctx SpecContext) {
+		// Create RGD with CEL error in forEach collection identity path
+		rgd := generator.NewResourceGraphDefinition("cel-error-test",
+			generator.WithSchema(
+				"CelErrorTest", "v1alpha1",
+				map[string]interface{}{
+					"counts": "[]integer",
+				},
+				nil,
+			),
+			generator.WithResourceCollection("configmaps", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					// CEL error: division by zero in identity path
+					"name":      "${\"test-\" + string(schema.spec.counts[idx] / 0)}",
+					"namespace": "${schema.metadata.namespace}",
+				},
+				"data": map[string]interface{}{
+					"index": "${string(idx)}",
+				},
+			},
+				[]krov1alpha1.ForEachDimension{
+					{"idx": "${lists.range(size(schema.spec.counts))}"},
+				},
+				nil, nil),
+		)
+
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+
+		// Wait for RGD to become active
+		createdRGD := &krov1alpha1.ResourceGraphDefinition{}
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, createdRGD)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(createdRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+
+			var readyCondition krov1alpha1.Condition
+			for _, cond := range createdRGD.Status.Conditions {
+				if cond.Type == resourcegraphdefinition.Ready {
+					readyCondition = cond
+				}
+			}
+			g.Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// Create instance with values that will trigger CEL error
+		instance := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+				"kind":       "CelErrorTest",
+				"metadata": map[string]interface{}{
+					"name":      "test-instance",
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"counts": []interface{}{5, 10, 15},
+				},
+			},
+		}
+
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		// Instance should fail to reconcile due to CEL error
+		Eventually(func(g Gomega, ctx SpecContext) {
+			var updated unstructured.Unstructured
+			updated.SetGroupVersionKind(instance.GroupVersionKind())
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      instance.GetName(),
+				Namespace: namespace,
+			}, &updated)).To(Succeed())
+
+			// Should have error in status
+			status, ok := updated.Object["status"].(map[string]interface{})
+			g.Expect(ok).To(BeTrue())
+
+			// Check for error in conditions
+			conditions, ok := status["conditions"].([]interface{})
+			g.Expect(ok).To(BeTrue())
+			g.Expect(len(conditions)).To(BeNumerically(">", 0))
+
+			hasError := false
+			for _, c := range conditions {
+				cond := c.(map[string]interface{})
+				if status, ok := cond["status"].(string); ok && status == "False" {
+					hasError = true
+					break
+				}
+			}
+			g.Expect(hasError).To(BeTrue())
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// Now delete the instance - this is the key test
+		// Before the fix, this would hang forever due to CEL evaluation failure
+		Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+
+		// Instance should be deleted successfully despite CEL error
+		Eventually(func(g Gomega, ctx SpecContext) {
+			var updated unstructured.Unstructured
+			updated.SetGroupVersionKind(instance.GroupVersionKind())
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      instance.GetName(),
+				Namespace: namespace,
+			}, &updated)
+			g.Expect(errors.IsNotFound(err)).To(BeTrue())
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+})


### PR DESCRIPTION
Avoid depending on ```GetDesiredIdent``` in deletion path for collections.

For a collection that fails to resolve like 
```
apiVersion: kro.run/v1alpha1
kind: ResourceGraphDefinition
metadata:
  name: workers
spec:
  schema:
    apiVersion: v1alpha1
    kind: Workers
    spec:
      count: integer

  resources:
    - id: pods
      forEach:
        - i: ${lists.range(schema.spec.count)}
      template:
        apiVersion: v1
        kind: Pod
        metadata:
          name: ${"pod-" + string(i / 0)}
          namespace: ${schema.metadata.namespace}
        spec:
          containers:
            - name: app
              image: nginx
```
deletion would hang forever

This also occurs if you go over the max collection size. Prevent this by just relying on labels instead of relying on desired identity. 

Note this is also something that may be worth considering for all nodes. We could instead rely on node-id instead of needing to resolve the cel expression in name for regular resources.