### PR TITLE
Fix validation marker overwriting other XValidations

### DIFF
--- a/pkg/simpleschema/markers.go
+++ b/pkg/simpleschema/markers.go
@@ -309,9 +309,10 @@ func applyValidationMarker(schema *extv1.JSONSchemaProps, marker *Marker) error 
 	if strings.TrimSpace(marker.Value) == "" {
 		return fmt.Errorf("validation failed")
 	}
-	schema.XValidations = []extv1.ValidationRule{
-		{Rule: marker.Value, Message: "validation failed"},
-	}
+	schema.XValidations = append(schema.XValidations, extv1.ValidationRule{
+		Rule:    marker.Value,
+		Message: "validation failed",
+	})
 	return nil
 }
 

--- a/pkg/simpleschema/markers_test.go
+++ b/pkg/simpleschema/markers_test.go
@@ -320,6 +320,30 @@ func TestApplyMarkers(t *testing.T) {
 			},
 			wantParent: &extv1.JSONSchemaProps{Required: []string{"field"}},
 		},
+		{
+			name:       "immutable and validation markers together",
+			schemaType: "string",
+			markers:    `immutable=true validation="self.matches('^(pending|active|done)$')"`,
+			want: &extv1.JSONSchemaProps{
+				Type: "string",
+				XValidations: []extv1.ValidationRule{
+					{Rule: "self == oldSelf", Message: "field is immutable"},
+					{Rule: "self.matches('^(pending|active|done)$')", Message: "validation failed"},
+				},
+			},
+		},
+		{
+			name:       "validation and immutable markers together (reversed order)",
+			schemaType: "string",
+			markers:    `validation="self.size() > 0" immutable=true`,
+			want: &extv1.JSONSchemaProps{
+				Type: "string",
+				XValidations: []extv1.ValidationRule{
+					{Rule: "self.size() > 0", Message: "validation failed"},
+					{Rule: "self == oldSelf", Message: "field is immutable"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION

An RGD like this will overwrite the immutable validation and not respect it
```
 apiVersion: kro.run/v1alpha1
  kind: ResourceGraphDefinition
  metadata:
    name: app-with-immutable-status
  spec:
    schema:
      apiVersion: v1alpha1
      kind: Application
      spec:
        status: string | immutable=true validation="self.matches('^(pending|active|done)$')"
    resources:
      - id: configmap
        template:
          apiVersion: v1
          kind: ConfigMap
          metadata:
            name: ${schema.metadata.name}-config
          data:
            status: ${schema.spec.status}
            name: ${schema.spec.name}
```

Switch to using append to catch this case