### PR TITLE
Add listType and listMapKey marker support to SimpleSchema

### DIFF
--- a/pkg/simpleschema/markers.go
+++ b/pkg/simpleschema/markers.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -86,6 +87,10 @@ const (
 	MarkerTypeMinItems MarkerType = "minItems"
 	// MarkerTypeMaxItems represents the `maxItems` marker.
 	MarkerTypeMaxItems MarkerType = "maxItems"
+	// MarkerTypeListType represents the `listType` marker.
+	MarkerTypeListType MarkerType = "listType"
+	// MarkerTypeListMapKey represents the `listMapKey` marker.
+	MarkerTypeListMapKey MarkerType = "listMapKey"
 )
 
 func markerTypeFromString(s string) (MarkerType, error) {
@@ -93,7 +98,7 @@ func markerTypeFromString(s string) (MarkerType, error) {
 	case MarkerTypeRequired, MarkerTypeDefault, MarkerTypeDescription,
 		MarkerTypeMinimum, MarkerTypeMaximum, MarkerTypeValidation, MarkerTypeEnum, MarkerTypeImmutable,
 		MarkerTypePattern, MarkerTypeUniqueItems, MarkerTypeMinLength, MarkerTypeMaxLength, MarkerTypeMinItems,
-		MarkerTypeMaxItems:
+		MarkerTypeMaxItems, MarkerTypeListType, MarkerTypeListMapKey:
 		return MarkerType(s), nil
 	default:
 		return "", fmt.Errorf("%w: %s", ErrUnknownMarker, s)
@@ -221,6 +226,26 @@ func applyMarkers(schema *extv1.JSONSchemaProps, markers []*Marker, key string, 
 			return err
 		}
 	}
+
+	if err := fieldLevelValidation(schema); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// apply validations that need to check the interaction between markers.
+func fieldLevelValidation(schema *extv1.JSONSchemaProps) error {
+	if len(schema.XListMapKeys) > 0 {
+		if schema.XListType == nil {
+			return fmt.Errorf("listMapKey set while listType is unset, listType must be set to map")
+		}
+		if *schema.XListType != "map" {
+			return fmt.Errorf(
+				"listMapKey set while listType is set to %s, listType must be set to map", *schema.XListType)
+		}
+	}
+
 	return nil
 }
 
@@ -257,9 +282,48 @@ func applyMarker(schema *extv1.JSONSchemaProps, marker *Marker, key string, pare
 		return applyMinItemsMarker(schema, marker)
 	case MarkerTypeMaxItems:
 		return applyMaxItemsMarker(schema, marker)
+	case MarkerTypeListType:
+		return applyListTypeMarker(schema, marker)
+	case MarkerTypeListMapKey:
+		return applyListMapKeyMarker(schema, marker)
 	default:
 		return fmt.Errorf("%w: %s", ErrUnknownMarker, marker.MarkerType)
 	}
+	return nil
+}
+
+func applyListTypeMarker(schema *extv1.JSONSchemaProps, marker *Marker) error {
+	if schema.Type != schemaTypeArray {
+		return fmt.Errorf("listType marker only applies to array types")
+	}
+	if marker.Value != "atomic" && marker.Value != "set" && marker.Value != "map" {
+		return fmt.Errorf(
+			"unsupported value for listType %s, needs to be one of atomic, set, or map", marker.Value)
+	}
+
+	// Setting unique=true sets XListType to "set", don't overwrite another listType.
+	if schema.XListType != nil && *schema.XListType != marker.Value {
+		return fmt.Errorf("listType attempting to overwrite set type of %s, "+
+			"this can happen if you set contradictory markers like unique=true | listType=map", *schema.XListType)
+	}
+	schema.XListType = &marker.Value
+
+	return nil
+}
+
+func applyListMapKeyMarker(schema *extv1.JSONSchemaProps, marker *Marker) error {
+	if schema.Type != schemaTypeArray {
+		return fmt.Errorf("listMapKey marker only applies to array types")
+	}
+
+	if slices.Contains(schema.XListMapKeys, marker.Value) {
+		return fmt.Errorf("duplicate listMapKey marker, value %s", marker.Value)
+	}
+	schema.XListMapKeys = append(schema.XListMapKeys, marker.Value)
+
+	// Intentionally leaving some validations to Kubernetes for simplicity
+	// 1. that the fields specified exist and are not nested
+	// 2. that the fields are set either to required or have a default value
 	return nil
 }
 
@@ -419,6 +483,9 @@ func applyUniqueItemsMarker(schema *extv1.JSONSchemaProps, marker *Marker) error
 		return fmt.Errorf("uniqueItems marker is only valid for array types, got type: %s", schema.Type)
 	}
 	if isUnique {
+		if schema.XListType != nil && *schema.XListType != "set" {
+			return fmt.Errorf("cannot set unique when listType is set to %s", *schema.XListType)
+		}
 		// Always set x-kubernetes-list-type to "set" when uniqueItems is true
 		// https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions
 		schema.XListType = new("set")

--- a/pkg/simpleschema/markers_test.go
+++ b/pkg/simpleschema/markers_test.go
@@ -339,6 +339,88 @@ func TestApplyMarkers(t *testing.T) {
 			markers:    "maxItems=10",
 			wantErr:    true,
 		},
+		// ListType marker
+		{
+			name:       "listType=map",
+			schemaType: "array",
+			markers:    "listType=map listMapKey=name",
+			want: &extv1.JSONSchemaProps{
+				Type:         "array",
+				XListType:    new("map"),
+				XListMapKeys: []string{"name"},
+			},
+		},
+		{
+			name:       "listType=set",
+			schemaType: "array",
+			markers:    "listType=set",
+			want: &extv1.JSONSchemaProps{
+				Type:      "array",
+				XListType: new("set"),
+			},
+		},
+		{
+			name:       "listType=atomic",
+			schemaType: "array",
+			markers:    "listType=atomic",
+			want: &extv1.JSONSchemaProps{
+				Type:      "array",
+				XListType: new("atomic"),
+			},
+		},
+		{
+			name:       "invalid listType value",
+			schemaType: "array",
+			markers:    "listType=invalid",
+			wantErr:    true,
+		},
+		{
+			name:       "listType on non-array",
+			schemaType: "string",
+			markers:    "listType=map",
+			wantErr:    true,
+		},
+		{
+			name:       "listType conflicts with uniqueItems",
+			schemaType: "array",
+			markers:    "uniqueItems=true listType=map",
+			wantErr:    true,
+		},
+		// ListMapKey marker
+		{
+			name:       "listMapKey with listType=map",
+			schemaType: "array",
+			markers:    "listType=map listMapKey=name listMapKey=namespace",
+			want: &extv1.JSONSchemaProps{
+				Type:         "array",
+				XListType:    new("map"),
+				XListMapKeys: []string{"name", "namespace"},
+			},
+		},
+		{
+			name:       "listMapKey without listType",
+			schemaType: "array",
+			markers:    "listMapKey=name",
+			wantErr:    true,
+		},
+		{
+			name:       "listMapKey with listType=set",
+			schemaType: "array",
+			markers:    "listType=set listMapKey=name",
+			wantErr:    true,
+		},
+		{
+			name:       "listMapKey on non-array",
+			schemaType: "string",
+			markers:    "listMapKey=name",
+			wantErr:    true,
+		},
+		{
+			name:       "duplicate listMapKey",
+			schemaType: "array",
+			markers:    "listType=map listMapKey=name listMapKey=name",
+			wantErr:    true,
+		},
 		// Combined markers
 		{
 			name:       "multiple markers",
@@ -593,6 +675,41 @@ func TestParseMarkers(t *testing.T) {
 			input: "minLength=0",
 			want: []*Marker{
 				{MarkerType: MarkerTypeMinLength, Key: "minLength", Value: "0"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "listType marker",
+			input: "listType=map",
+			want: []*Marker{
+				{MarkerType: MarkerTypeListType, Key: "listType", Value: "map"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "listMapKey marker",
+			input: "listMapKey=name",
+			want: []*Marker{
+				{MarkerType: MarkerTypeListMapKey, Key: "listMapKey", Value: "name"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "multiple listMapKey markers",
+			input: "listMapKey=name listMapKey=namespace",
+			want: []*Marker{
+				{MarkerType: MarkerTypeListMapKey, Key: "listMapKey", Value: "name"},
+				{MarkerType: MarkerTypeListMapKey, Key: "listMapKey", Value: "namespace"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "listType with listMapKey markers",
+			input: "listType=map listMapKey=name listMapKey=id",
+			want: []*Marker{
+				{MarkerType: MarkerTypeListType, Key: "listType", Value: "map"},
+				{MarkerType: MarkerTypeListMapKey, Key: "listMapKey", Value: "name"},
+				{MarkerType: MarkerTypeListMapKey, Key: "listMapKey", Value: "id"},
 			},
 			wantErr: false,
 		},

--- a/website/docs/api/specifications/simple-schema.md
+++ b/website/docs/api/specifications/simple-schema.md
@@ -252,6 +252,8 @@ mode: string | enum="debug,info,warn,error" default="info"
 - `uniqueItems=true`: Ensures array elements are unique
 - `minItems=number`: Minimum number of items in arrays
 - `maxItems=number`: Maximum number of items in arrays
+- `listType=atomic|set|map`: Specifies how Kubernetes should treat the array for merge operations
+- `listMapKey=fieldName`: Specifies which field(s) to use as keys when `listType=map` (can be repeated for composite keys)
 
 Multiple markers can be combined using the `|` separator.
 
@@ -287,6 +289,8 @@ Array fields support validation markers to ensure data quality:
 - **`uniqueItems=false`**: Allows duplicate elements (default behavior)
 - **`minItems=number`**: Sets the minimum number of elements required in the array
 - **`maxItems=number`**: Sets the maximum number of elements allowed in the array
+- **`listType=atomic|set|map`**: Controls how Kubernetes handles array merges (atomic=replace all, set=merge unique values, map=merge by key)
+- **`listMapKey=fieldName`**: Specifies key field(s) when `listType=map` (must be required or have default value). Can be repeated for composite keys.
 
 Examples:
 
@@ -305,6 +309,14 @@ roles: '[]string | uniqueItems=true minItems=1 maxItems=5 required=true descript
 
 # Optional array with size constraints
 priorities: '[]integer | minItems=0 maxItems=3 description="Up to 3 priority levels"'
+
+# Array with map-based merging using custom type
+types:
+  Container:
+    name: string | required=true
+    port: integer | required=true
+spec:
+  containers: '[]Container | listType=map listMapKey=name listMapKey=port'
 ```
 
 For example:


### PR DESCRIPTION


Example
```
apiVersion: kro.run/v1alpha1
kind: ResourceGraphDefinition
metadata:
  name: podwithcontainers.kro.run
spec:
  schema:
    apiVersion: v1alpha1
    kind: PodWithContainers
    # Define custom types
    types:
      Container:
        name: string | required=true
        image: string | required=true
        port: integer | required=true
    spec:
      podName: string
      namespace: string | default=default
      # Use custom type in array with listType=map and listMapKey
      containers: '[]Container | listType=map listMapKey=name listMapKey=port'
  resources:
  - id: configmap
    template:
      apiVersion: v1
      kind: ConfigMap
      metadata:
        name: ${schema.spec.podName}
        namespace: ${schema.spec.namespace}
      data:
        info: "Pod configuration"
```

Generates 
```
  {
      "type": "array",
      "x-kubernetes-list-type": "map",
      "x-kubernetes-list-map-keys": [
          "name",
          "port"
      ],
      "items": {
          "type": "object",
          "required": [
              "image",
              "name",
              "port"
          ],
          "properties": {
              "image": {
                  "type": "string"
              },
              "name": {
                  "type": "string"
              },
              "port": {
                  "type": "integer"
              }
          }
      }
  }
```