### PR TITLE
Detect min/max constraint changes in CRD compatibility checker

### DIFF
--- a/pkg/graph/crd/compat/changes.go
+++ b/pkg/graph/crd/compat/changes.go
@@ -31,6 +31,20 @@ const (
 	PatternAdded           ChangeType = "PATTERN_ADDED"
 	RequiredDefaultRemoved ChangeType = "REQUIRED_DEFAULT_REMOVED"
 
+	// Breaking - constraint tightened
+	MinimumAdded       ChangeType = "MINIMUM_ADDED"
+	MinimumIncreased   ChangeType = "MINIMUM_INCREASED"
+	MaximumAdded       ChangeType = "MAXIMUM_ADDED"
+	MaximumDecreased   ChangeType = "MAXIMUM_DECREASED"
+	MinLengthAdded     ChangeType = "MIN_LENGTH_ADDED"
+	MinLengthIncreased ChangeType = "MIN_LENGTH_INCREASED"
+	MaxLengthAdded     ChangeType = "MAX_LENGTH_ADDED"
+	MaxLengthDecreased ChangeType = "MAX_LENGTH_DECREASED"
+	MinItemsAdded      ChangeType = "MIN_ITEMS_ADDED"
+	MinItemsIncreased  ChangeType = "MIN_ITEMS_INCREASED"
+	MaxItemsAdded      ChangeType = "MAX_ITEMS_ADDED"
+	MaxItemsDecreased  ChangeType = "MAX_ITEMS_DECREASED"
+
 	// Non-breaking change types
 	PropertyAdded      ChangeType = "PROPERTY_ADDED"
 	DescriptionChanged ChangeType = "DESCRIPTION_CHANGED"
@@ -38,6 +52,20 @@ const (
 	RequiredRemoved    ChangeType = "REQUIRED_REMOVED"
 	EnumExpanded       ChangeType = "ENUM_EXPANDED"
 	PatternRemoved     ChangeType = "PATTERN_REMOVED"
+
+	// Non-breaking - constraint relaxed
+	MinimumRemoved     ChangeType = "MINIMUM_REMOVED"
+	MinimumDecreased   ChangeType = "MINIMUM_DECREASED"
+	MaximumRemoved     ChangeType = "MAXIMUM_REMOVED"
+	MaximumIncreased   ChangeType = "MAXIMUM_INCREASED"
+	MinLengthRemoved   ChangeType = "MIN_LENGTH_REMOVED"
+	MinLengthDecreased ChangeType = "MIN_LENGTH_DECREASED"
+	MaxLengthRemoved   ChangeType = "MAX_LENGTH_REMOVED"
+	MaxLengthIncreased ChangeType = "MAX_LENGTH_INCREASED"
+	MinItemsRemoved    ChangeType = "MIN_ITEMS_REMOVED"
+	MinItemsDecreased  ChangeType = "MIN_ITEMS_DECREASED"
+	MaxItemsRemoved    ChangeType = "MAX_ITEMS_REMOVED"
+	MaxItemsIncreased  ChangeType = "MAX_ITEMS_INCREASED"
 )
 
 // Change represents a single schema change
@@ -163,6 +191,61 @@ func (c Change) Description() string {
 		return fmt.Sprintf("Description field was changed from %s to %s", c.OldValue, c.NewValue)
 	case DefaultChanged:
 		return fmt.Sprintf("Default value was changed from %s to %s", c.OldValue, c.NewValue)
+	default:
+		return c.constraintDescription()
+	}
+}
+
+func (c Change) constraintDescription() string {
+	switch c.ChangeType {
+	case MinimumAdded:
+		return fmt.Sprintf("Minimum constraint %s was added", c.NewValue)
+	case MinimumRemoved:
+		return fmt.Sprintf("Minimum constraint %s was removed", c.OldValue)
+	case MinimumIncreased:
+		return fmt.Sprintf("Minimum was increased from %s to %s", c.OldValue, c.NewValue)
+	case MinimumDecreased:
+		return fmt.Sprintf("Minimum was decreased from %s to %s", c.OldValue, c.NewValue)
+	case MaximumAdded:
+		return fmt.Sprintf("Maximum constraint %s was added", c.NewValue)
+	case MaximumRemoved:
+		return fmt.Sprintf("Maximum constraint %s was removed", c.OldValue)
+	case MaximumDecreased:
+		return fmt.Sprintf("Maximum was decreased from %s to %s", c.OldValue, c.NewValue)
+	case MaximumIncreased:
+		return fmt.Sprintf("Maximum was increased from %s to %s", c.OldValue, c.NewValue)
+	case MinLengthAdded:
+		return fmt.Sprintf("MinLength constraint %s was added", c.NewValue)
+	case MinLengthRemoved:
+		return fmt.Sprintf("MinLength constraint %s was removed", c.OldValue)
+	case MinLengthIncreased:
+		return fmt.Sprintf("MinLength was increased from %s to %s", c.OldValue, c.NewValue)
+	case MinLengthDecreased:
+		return fmt.Sprintf("MinLength was decreased from %s to %s", c.OldValue, c.NewValue)
+	case MaxLengthAdded:
+		return fmt.Sprintf("MaxLength constraint %s was added", c.NewValue)
+	case MaxLengthRemoved:
+		return fmt.Sprintf("MaxLength constraint %s was removed", c.OldValue)
+	case MaxLengthDecreased:
+		return fmt.Sprintf("MaxLength was decreased from %s to %s", c.OldValue, c.NewValue)
+	case MaxLengthIncreased:
+		return fmt.Sprintf("MaxLength was increased from %s to %s", c.OldValue, c.NewValue)
+	case MinItemsAdded:
+		return fmt.Sprintf("MinItems constraint %s was added", c.NewValue)
+	case MinItemsRemoved:
+		return fmt.Sprintf("MinItems constraint %s was removed", c.OldValue)
+	case MinItemsIncreased:
+		return fmt.Sprintf("MinItems was increased from %s to %s", c.OldValue, c.NewValue)
+	case MinItemsDecreased:
+		return fmt.Sprintf("MinItems was decreased from %s to %s", c.OldValue, c.NewValue)
+	case MaxItemsAdded:
+		return fmt.Sprintf("MaxItems constraint %s was added", c.NewValue)
+	case MaxItemsRemoved:
+		return fmt.Sprintf("MaxItems constraint %s was removed", c.OldValue)
+	case MaxItemsDecreased:
+		return fmt.Sprintf("MaxItems was decreased from %s to %s", c.OldValue, c.NewValue)
+	case MaxItemsIncreased:
+		return fmt.Sprintf("MaxItems was increased from %s to %s", c.OldValue, c.NewValue)
 	default:
 		return fmt.Sprintf("Unknown change to %s", c.Path)
 	}

--- a/pkg/graph/crd/compat/schema.go
+++ b/pkg/graph/crd/compat/schema.go
@@ -15,6 +15,7 @@ package compat
 
 import (
 	"bytes"
+	"strconv"
 
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
@@ -93,6 +94,9 @@ func compare(path string, oldSchema, newSchema *v1.JSONSchemaProps) *Report {
 			result.AddBreakingChange(path+".pattern", PatternChanged, oldSchema.Pattern, newSchema.Pattern)
 		}
 	}
+
+	// Compare numeric/length/items constraints
+	compareConstraints(path, oldSchema, newSchema, result)
 
 	// Compare properties
 	compareProperties(path, oldSchema, newSchema, result)
@@ -292,4 +296,122 @@ func toJsonValueSet(values []v1.JSON) map[string]bool {
 		set[string(val.Raw)] = true
 	}
 	return set
+}
+
+// compareConstraints checks for changes to numeric, length, and items constraints.
+func compareConstraints(path string, oldSchema, newSchema *v1.JSONSchemaProps, result *Report) {
+	compareFloatConstraint(path, "minimum", oldSchema.Minimum, newSchema.Minimum, true, result)
+	compareFloatConstraint(path, "maximum", oldSchema.Maximum, newSchema.Maximum, false, result)
+	compareIntConstraint(path, "minLength", oldSchema.MinLength, newSchema.MinLength, true, result)
+	compareIntConstraint(path, "maxLength", oldSchema.MaxLength, newSchema.MaxLength, false, result)
+	compareIntConstraint(path, "minItems", oldSchema.MinItems, newSchema.MinItems, true, result)
+	compareIntConstraint(path, "maxItems", oldSchema.MaxItems, newSchema.MaxItems, false, result)
+}
+
+// compareFloatConstraint compares a float64 pointer constraint field.
+// isLowerBound=true means this is a minimum-style constraint (increase = breaking).
+// isLowerBound=false means this is a maximum-style constraint (decrease = breaking).
+func compareFloatConstraint(path, name string, oldVal, newVal *float64, isLowerBound bool, result *Report) {
+	if oldVal == nil && newVal == nil {
+		return
+	}
+
+	fieldPath := path + "." + name
+	addedType, removedType, tightenedType, relaxedType := constraintChangeTypes(name)
+
+	if oldVal == nil && newVal != nil {
+		result.AddBreakingChange(fieldPath, addedType, "", formatFloat(*newVal))
+		return
+	}
+	if oldVal != nil && newVal == nil {
+		result.AddNonBreakingChange(fieldPath, removedType, formatFloat(*oldVal), "")
+		return
+	}
+
+	if *oldVal == *newVal {
+		return
+	}
+
+	oldStr := formatFloat(*oldVal)
+	newStr := formatFloat(*newVal)
+
+	if isLowerBound {
+		if *newVal > *oldVal {
+			result.AddBreakingChange(fieldPath, tightenedType, oldStr, newStr)
+		} else {
+			result.AddNonBreakingChange(fieldPath, relaxedType, oldStr, newStr)
+		}
+	} else {
+		if *newVal < *oldVal {
+			result.AddBreakingChange(fieldPath, tightenedType, oldStr, newStr)
+		} else {
+			result.AddNonBreakingChange(fieldPath, relaxedType, oldStr, newStr)
+		}
+	}
+}
+
+// compareIntConstraint compares an int64 pointer constraint field.
+// isLowerBound=true means this is a minimum-style constraint (increase = breaking).
+// isLowerBound=false means this is a maximum-style constraint (decrease = breaking).
+func compareIntConstraint(path, name string, oldVal, newVal *int64, isLowerBound bool, result *Report) {
+	if oldVal == nil && newVal == nil {
+		return
+	}
+
+	fieldPath := path + "." + name
+	addedType, removedType, tightenedType, relaxedType := constraintChangeTypes(name)
+
+	if oldVal == nil && newVal != nil {
+		result.AddBreakingChange(fieldPath, addedType, "", strconv.FormatInt(*newVal, 10))
+		return
+	}
+	if oldVal != nil && newVal == nil {
+		result.AddNonBreakingChange(fieldPath, removedType, strconv.FormatInt(*oldVal, 10), "")
+		return
+	}
+
+	if *oldVal == *newVal {
+		return
+	}
+
+	oldStr := strconv.FormatInt(*oldVal, 10)
+	newStr := strconv.FormatInt(*newVal, 10)
+
+	if isLowerBound {
+		if *newVal > *oldVal {
+			result.AddBreakingChange(fieldPath, tightenedType, oldStr, newStr)
+		} else {
+			result.AddNonBreakingChange(fieldPath, relaxedType, oldStr, newStr)
+		}
+	} else {
+		if *newVal < *oldVal {
+			result.AddBreakingChange(fieldPath, tightenedType, oldStr, newStr)
+		} else {
+			result.AddNonBreakingChange(fieldPath, relaxedType, oldStr, newStr)
+		}
+	}
+}
+
+// constraintChangeTypes returns the (added, removed, tightened, relaxed) ChangeTypes for a named constraint.
+func constraintChangeTypes(name string) (added, removed, tightened, relaxed ChangeType) {
+	switch name {
+	case "minimum":
+		return MinimumAdded, MinimumRemoved, MinimumIncreased, MinimumDecreased
+	case "maximum":
+		return MaximumAdded, MaximumRemoved, MaximumDecreased, MaximumIncreased
+	case "minLength":
+		return MinLengthAdded, MinLengthRemoved, MinLengthIncreased, MinLengthDecreased
+	case "maxLength":
+		return MaxLengthAdded, MaxLengthRemoved, MaxLengthDecreased, MaxLengthIncreased
+	case "minItems":
+		return MinItemsAdded, MinItemsRemoved, MinItemsIncreased, MinItemsDecreased
+	case "maxItems":
+		return MaxItemsAdded, MaxItemsRemoved, MaxItemsDecreased, MaxItemsIncreased
+	default:
+		return ChangeType(name + "_ADDED"), ChangeType(name + "_REMOVED"), ChangeType(name + "_TIGHTENED"), ChangeType(name + "_RELAXED")
+	}
+}
+
+func formatFloat(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
 }

--- a/pkg/graph/crd/compat/schema_test.go
+++ b/pkg/graph/crd/compat/schema_test.go
@@ -702,3 +702,247 @@ func TestCompareArrayItems(t *testing.T) {
 		})
 	}
 }
+
+func TestCompareConstraints(t *testing.T) {
+	floatPtr := func(f float64) *float64 { return &f }
+	intPtr := func(i int64) *int64 { return &i }
+
+	tests := []struct {
+		name               string
+		oldSchema          *v1.JSONSchemaProps
+		newSchema          *v1.JSONSchemaProps
+		breakingCount      int
+		nonBreakingCount   int
+		expectedChangeType ChangeType
+	}{
+		// Minimum
+		{
+			name:      "minimum unchanged",
+			oldSchema: &v1.JSONSchemaProps{Type: "integer", Minimum: floatPtr(5)},
+			newSchema: &v1.JSONSchemaProps{Type: "integer", Minimum: floatPtr(5)},
+		},
+		{
+			name:               "minimum added - breaking",
+			oldSchema:          &v1.JSONSchemaProps{Type: "integer"},
+			newSchema:          &v1.JSONSchemaProps{Type: "integer", Minimum: floatPtr(5)},
+			breakingCount:      1,
+			expectedChangeType: MinimumAdded,
+		},
+		{
+			name:             "minimum removed - non-breaking",
+			oldSchema:        &v1.JSONSchemaProps{Type: "integer", Minimum: floatPtr(5)},
+			newSchema:        &v1.JSONSchemaProps{Type: "integer"},
+			nonBreakingCount: 1,
+		},
+		{
+			name:               "minimum increased - breaking",
+			oldSchema:          &v1.JSONSchemaProps{Type: "integer", Minimum: floatPtr(1)},
+			newSchema:          &v1.JSONSchemaProps{Type: "integer", Minimum: floatPtr(5)},
+			breakingCount:      1,
+			expectedChangeType: MinimumIncreased,
+		},
+		{
+			name:             "minimum decreased - non-breaking",
+			oldSchema:        &v1.JSONSchemaProps{Type: "integer", Minimum: floatPtr(5)},
+			newSchema:        &v1.JSONSchemaProps{Type: "integer", Minimum: floatPtr(1)},
+			nonBreakingCount: 1,
+		},
+		// Maximum
+		{
+			name:      "maximum unchanged",
+			oldSchema: &v1.JSONSchemaProps{Type: "integer", Maximum: floatPtr(100)},
+			newSchema: &v1.JSONSchemaProps{Type: "integer", Maximum: floatPtr(100)},
+		},
+		{
+			name:               "maximum added - breaking",
+			oldSchema:          &v1.JSONSchemaProps{Type: "integer"},
+			newSchema:          &v1.JSONSchemaProps{Type: "integer", Maximum: floatPtr(100)},
+			breakingCount:      1,
+			expectedChangeType: MaximumAdded,
+		},
+		{
+			name:             "maximum removed - non-breaking",
+			oldSchema:        &v1.JSONSchemaProps{Type: "integer", Maximum: floatPtr(100)},
+			newSchema:        &v1.JSONSchemaProps{Type: "integer"},
+			nonBreakingCount: 1,
+		},
+		{
+			name:               "maximum decreased - breaking",
+			oldSchema:          &v1.JSONSchemaProps{Type: "integer", Maximum: floatPtr(100)},
+			newSchema:          &v1.JSONSchemaProps{Type: "integer", Maximum: floatPtr(50)},
+			breakingCount:      1,
+			expectedChangeType: MaximumDecreased,
+		},
+		{
+			name:             "maximum increased - non-breaking",
+			oldSchema:        &v1.JSONSchemaProps{Type: "integer", Maximum: floatPtr(50)},
+			newSchema:        &v1.JSONSchemaProps{Type: "integer", Maximum: floatPtr(100)},
+			nonBreakingCount: 1,
+		},
+		// MinLength
+		{
+			name:      "minLength unchanged",
+			oldSchema: &v1.JSONSchemaProps{Type: "string", MinLength: intPtr(3)},
+			newSchema: &v1.JSONSchemaProps{Type: "string", MinLength: intPtr(3)},
+		},
+		{
+			name:               "minLength added - breaking",
+			oldSchema:          &v1.JSONSchemaProps{Type: "string"},
+			newSchema:          &v1.JSONSchemaProps{Type: "string", MinLength: intPtr(3)},
+			breakingCount:      1,
+			expectedChangeType: MinLengthAdded,
+		},
+		{
+			name:             "minLength removed - non-breaking",
+			oldSchema:        &v1.JSONSchemaProps{Type: "string", MinLength: intPtr(3)},
+			newSchema:        &v1.JSONSchemaProps{Type: "string"},
+			nonBreakingCount: 1,
+		},
+		{
+			name:               "minLength increased - breaking",
+			oldSchema:          &v1.JSONSchemaProps{Type: "string", MinLength: intPtr(3)},
+			newSchema:          &v1.JSONSchemaProps{Type: "string", MinLength: intPtr(5)},
+			breakingCount:      1,
+			expectedChangeType: MinLengthIncreased,
+		},
+		{
+			name:             "minLength decreased - non-breaking",
+			oldSchema:        &v1.JSONSchemaProps{Type: "string", MinLength: intPtr(5)},
+			newSchema:        &v1.JSONSchemaProps{Type: "string", MinLength: intPtr(3)},
+			nonBreakingCount: 1,
+		},
+		// MaxLength
+		{
+			name:      "maxLength unchanged",
+			oldSchema: &v1.JSONSchemaProps{Type: "string", MaxLength: intPtr(100)},
+			newSchema: &v1.JSONSchemaProps{Type: "string", MaxLength: intPtr(100)},
+		},
+		{
+			name:               "maxLength added - breaking",
+			oldSchema:          &v1.JSONSchemaProps{Type: "string"},
+			newSchema:          &v1.JSONSchemaProps{Type: "string", MaxLength: intPtr(100)},
+			breakingCount:      1,
+			expectedChangeType: MaxLengthAdded,
+		},
+		{
+			name:             "maxLength removed - non-breaking",
+			oldSchema:        &v1.JSONSchemaProps{Type: "string", MaxLength: intPtr(100)},
+			newSchema:        &v1.JSONSchemaProps{Type: "string"},
+			nonBreakingCount: 1,
+		},
+		{
+			name:               "maxLength decreased - breaking",
+			oldSchema:          &v1.JSONSchemaProps{Type: "string", MaxLength: intPtr(100)},
+			newSchema:          &v1.JSONSchemaProps{Type: "string", MaxLength: intPtr(50)},
+			breakingCount:      1,
+			expectedChangeType: MaxLengthDecreased,
+		},
+		{
+			name:             "maxLength increased - non-breaking",
+			oldSchema:        &v1.JSONSchemaProps{Type: "string", MaxLength: intPtr(50)},
+			newSchema:        &v1.JSONSchemaProps{Type: "string", MaxLength: intPtr(100)},
+			nonBreakingCount: 1,
+		},
+		// MinItems
+		{
+			name:      "minItems unchanged",
+			oldSchema: &v1.JSONSchemaProps{Type: "array", MinItems: intPtr(1)},
+			newSchema: &v1.JSONSchemaProps{Type: "array", MinItems: intPtr(1)},
+		},
+		{
+			name:               "minItems added - breaking",
+			oldSchema:          &v1.JSONSchemaProps{Type: "array"},
+			newSchema:          &v1.JSONSchemaProps{Type: "array", MinItems: intPtr(1)},
+			breakingCount:      1,
+			expectedChangeType: MinItemsAdded,
+		},
+		{
+			name:             "minItems removed - non-breaking",
+			oldSchema:        &v1.JSONSchemaProps{Type: "array", MinItems: intPtr(1)},
+			newSchema:        &v1.JSONSchemaProps{Type: "array"},
+			nonBreakingCount: 1,
+		},
+		{
+			name:               "minItems increased - breaking",
+			oldSchema:          &v1.JSONSchemaProps{Type: "array", MinItems: intPtr(1)},
+			newSchema:          &v1.JSONSchemaProps{Type: "array", MinItems: intPtr(3)},
+			breakingCount:      1,
+			expectedChangeType: MinItemsIncreased,
+		},
+		{
+			name:             "minItems decreased - non-breaking",
+			oldSchema:        &v1.JSONSchemaProps{Type: "array", MinItems: intPtr(3)},
+			newSchema:        &v1.JSONSchemaProps{Type: "array", MinItems: intPtr(1)},
+			nonBreakingCount: 1,
+		},
+		// MaxItems
+		{
+			name:      "maxItems unchanged",
+			oldSchema: &v1.JSONSchemaProps{Type: "array", MaxItems: intPtr(10)},
+			newSchema: &v1.JSONSchemaProps{Type: "array", MaxItems: intPtr(10)},
+		},
+		{
+			name:               "maxItems added - breaking",
+			oldSchema:          &v1.JSONSchemaProps{Type: "array"},
+			newSchema:          &v1.JSONSchemaProps{Type: "array", MaxItems: intPtr(10)},
+			breakingCount:      1,
+			expectedChangeType: MaxItemsAdded,
+		},
+		{
+			name:             "maxItems removed - non-breaking",
+			oldSchema:        &v1.JSONSchemaProps{Type: "array", MaxItems: intPtr(10)},
+			newSchema:        &v1.JSONSchemaProps{Type: "array"},
+			nonBreakingCount: 1,
+		},
+		{
+			name:               "maxItems decreased - breaking",
+			oldSchema:          &v1.JSONSchemaProps{Type: "array", MaxItems: intPtr(10)},
+			newSchema:          &v1.JSONSchemaProps{Type: "array", MaxItems: intPtr(5)},
+			breakingCount:      1,
+			expectedChangeType: MaxItemsDecreased,
+		},
+		{
+			name:             "maxItems increased - non-breaking",
+			oldSchema:        &v1.JSONSchemaProps{Type: "array", MaxItems: intPtr(5)},
+			newSchema:        &v1.JSONSchemaProps{Type: "array", MaxItems: intPtr(10)},
+			nonBreakingCount: 1,
+		},
+		// Combined
+		{
+			name:             "both minimum and maximum removed - non-breaking",
+			oldSchema:        &v1.JSONSchemaProps{Type: "integer", Minimum: floatPtr(1), Maximum: floatPtr(100)},
+			newSchema:        &v1.JSONSchemaProps{Type: "integer"},
+			nonBreakingCount: 2,
+		},
+		{
+			name:          "both minimum and maximum added - breaking",
+			oldSchema:     &v1.JSONSchemaProps{Type: "integer"},
+			newSchema:     &v1.JSONSchemaProps{Type: "integer", Minimum: floatPtr(1), Maximum: floatPtr(100)},
+			breakingCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Compare(tt.oldSchema, tt.newSchema)
+
+			if tt.breakingCount > 0 {
+				assert.False(t, result.IsCompatible(), "Expected incompatible")
+				assert.Equal(t, tt.breakingCount, len(result.BreakingChanges),
+					"Unexpected number of breaking changes: %v", result.BreakingChanges)
+
+				if tt.expectedChangeType != "" && len(result.BreakingChanges) > 0 {
+					assert.Equal(t, tt.expectedChangeType, result.BreakingChanges[0].ChangeType,
+						"Unexpected change type")
+				}
+			} else {
+				assert.True(t, result.IsCompatible(), "Expected compatible but got: %v", result.BreakingChanges)
+			}
+
+			if tt.nonBreakingCount > 0 {
+				assert.Equal(t, tt.nonBreakingCount, len(result.NonBreakingChanges),
+					"Unexpected number of non-breaking changes: %v", result.NonBreakingChanges)
+			}
+		})
+	}
+}

--- a/test/integration/suites/core/crd_test.go
+++ b/test/integration/suites/core/crd_test.go
@@ -560,6 +560,70 @@ var _ = Describe("CRD", func() {
 			// Cleanup
 			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
 		})
+
+		It("should update CRD when minimum/maximum markers are removed", func(ctx SpecContext) {
+			rgd := generator.NewResourceGraphDefinition("test-constraint-removal",
+				generator.WithSchema(
+					"ConstraintRemoval", "v1alpha1",
+					map[string]interface{}{
+						"replicas": "integer | default=3 minimum=1 maximum=10",
+					},
+					nil,
+				),
+			)
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+
+			// Wait for RGD to become active and CRD to have constraints
+			crd := &apiextensionsv1.CustomResourceDefinition{}
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+
+				err = env.Client.Get(ctx, types.NamespacedName{
+					Name: "constraintremovals.kro.run",
+				}, crd)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				props := crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties
+				g.Expect(props["spec"].Properties["replicas"].Minimum).ToNot(BeNil())
+				g.Expect(*props["spec"].Properties["replicas"].Minimum).To(Equal(1.0))
+				g.Expect(props["spec"].Properties["replicas"].Maximum).ToNot(BeNil())
+				g.Expect(*props["spec"].Properties["replicas"].Maximum).To(Equal(10.0))
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Remove minimum and maximum markers
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				rgd.Spec.Schema.Spec = toRawExtension(map[string]interface{}{
+					"replicas": "integer | default=3",
+				})
+
+				err = env.Client.Update(ctx, rgd)
+				g.Expect(err).ToNot(HaveOccurred())
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Verify CRD constraints are removed
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+
+				err = env.Client.Get(ctx, types.NamespacedName{
+					Name: "constraintremovals.kro.run",
+				}, crd)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				props := crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties
+				g.Expect(props["spec"].Properties["replicas"].Minimum).To(BeNil())
+				g.Expect(props["spec"].Properties["replicas"].Maximum).To(BeNil())
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Cleanup
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
 	})
 
 	Context("CRD Watch Reconciliation", func() {


### PR DESCRIPTION
The schema compatibility checker did not detect changes to Minimum, Maximum, MinLength, MaxLength, MinItems, or MaxItems fields. When these markers were removed from a SimpleSchema, HasChanges() returned false and the CRD update was skipped entirely.

Add compareConstraints() with proper breaking/non-breaking semantics:
- Added or tightened constraints (min raised, max lowered) are breaking
- Removed or relaxed constraints (min lowered, max raised) are non-breaking

fix https://github.com/kubernetes-sigs/kro/issues/1275