### PR TITLE
Revert "Remove "v" prefix from Helm chart version"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ publish-debug-image: ## Publish kro controller debug image with pprof enabled.
 .PHONY: inject-helm-version
 inject-helm-version:
 	sed $(SED_INPLACE_FLAGS) 's/tag: .*/tag: "$(RELEASE_VERSION)"/' helm/values.yaml
-	sed $(SED_INPLACE_FLAGS) 's/version: .*/version: $(RELEASE_VERSION:v%=%)/' helm/Chart.yaml
+	sed $(SED_INPLACE_FLAGS) 's/version: .*/version: $(RELEASE_VERSION)/' helm/Chart.yaml
 	sed $(SED_INPLACE_FLAGS) 's/appVersion: .*/appVersion: "$(RELEASE_VERSION)"/' helm/Chart.yaml
 
 .PHONY: package-helm


### PR DESCRIPTION
This reverts commit 1c8db797a92f59fa67836164be583c7bfaf055f9.

Reverting this commit to unblock release of v0.9.2
Re-revert once we get this failure fixed: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/kro-push-images/2052459791791427584