### PR TITLE
Bump upload-pages-artifact to v5 to fix SHA pinning violation

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -47,7 +47,7 @@ jobs:
         run: npm run build
 
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./website/build
 
@@ -69,4 +69,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # #v4.0.5
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
upload-pages-artifact v3.0.1 internally uses upload-artifact@v4 without
a pinned SHA, which the kubernetes-sigs org policy now rejects. Upgrade
to v5.0.0 which uses upload-artifact v7 with proper pinning.

[kubernetes org announcement](https://github.com/kubernetes/community/blob/main/github-management/github-actions-policy.md?trk=public_post_comment-text)