### PR TITLE
Update `gcb-docker-gcloud `builder image to fix push-images job

### DIFF
--- a/dev/ci/builds/push-images/cloudbuild.yaml
+++ b/dev/ci/builds/push-images/cloudbuild.yaml
@@ -3,7 +3,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: E2_HIGHCPU_32
 steps:
-- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251110-7ccd542560
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
   entrypoint: dev/tasks/push-images
   env:
   - IMAGE_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/kro/


### PR DESCRIPTION
The previous image tag (`v20251110-7ccd542560`) was removed from the
registry, causing `kro-push-images` to fail with "manifest unknown".
Update to `v20260205-38cfa9523f` which is the current tag used across
`kubernetes/test-infra`.