### PR TITLE
Reapply "Emit instance condition telemetry"

### DIFF
--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -119,6 +119,10 @@ type Controller struct {
 
 	// eventRecorder emits K8s Events on condition transitions.
 	eventRecorder record.EventRecorder
+
+	// feature gate flags, captured once at construction time.
+	eventsEnabled  bool
+	metricsEnabled bool
 }
 
 // NewController constructs a new controller that resolves the newest issued
@@ -146,6 +150,8 @@ func NewController(
 		reconcileConfig:      reconcileConfig,
 		coordinator:          coord,
 		eventRecorder:        eventRecorder,
+		eventsEnabled:        features.FeatureGate.Enabled(features.InstanceConditionEvents),
+		metricsEnabled:       features.FeatureGate.Enabled(features.InstanceConditionMetrics),
 	}
 }
 
@@ -180,6 +186,9 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 	}
 	if apierrors.IsNotFound(err) {
 		log.Info("instance not found (likely deleted)")
+		if c.metricsEnabled {
+			metrics.DeleteInstanceMetrics(c.gvr, req.Namespace, req.Name)
+		}
 		return nil
 	}
 	if err != nil {
@@ -187,9 +196,11 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 		return err
 	}
 
-	// Emit condition events on every return path (behind feature gate).
+	// Snapshot initial conditions and emit telemetry on every return path.
+	// Events and metrics are gated behind separate feature flags so operators
+	// can enable them independently.
 	var rcx *ReconcileContext
-	if features.FeatureGate.Enabled(features.InstanceConditionEvents) {
+	if c.eventsEnabled || c.metricsEnabled {
 		initialConditions := conditionsFromInstance(inst)
 		defer func() {
 			obj := inst
@@ -197,7 +208,12 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 				obj = rcx.Instance
 			}
 			finalConditions := conditionsFromInstance(obj)
-			emitConditionEvents(c.eventRecorder, obj, initialConditions, finalConditions)
+			if c.eventsEnabled {
+				emitConditionEvents(c.eventRecorder, obj, initialConditions, finalConditions)
+			}
+			if c.metricsEnabled {
+				metrics.EmitConditionMetrics(log, c.gvr, obj, initialConditions, finalConditions)
+			}
 		}()
 	}
 

--- a/pkg/controller/instance/status.go
+++ b/pkg/controller/instance/status.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -179,6 +180,15 @@ func (c *Controller) updateStatus(rcx *ReconcileContext) error {
 			}
 			status[k] = v
 		}
+	}
+
+	// Skip the API server write if status hasn't changed. This prevents an
+	// infinite reconcile loop where every unconditional UpdateStatus bumps
+	// resourceVersion, which triggers a watch event, which re-enqueues the
+	// instance, which reconciles again.
+	oldStatus, _, _ := unstructured.NestedMap(rcx.Instance.Object, "status")
+	if equality.Semantic.DeepEqual(oldStatus, status) {
+		return nil
 	}
 
 	inst := rcx.Instance.DeepCopy()

--- a/pkg/controller/resourcegraphdefinition/controller_cleanup.go
+++ b/pkg/controller/resourcegraphdefinition/controller_cleanup.go
@@ -24,7 +24,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
+	"github.com/kubernetes-sigs/kro/pkg/metrics"
 )
 
 // cleanupResourceGraphDefinition handles the deletion of a ResourceGraphDefinition by shutting down its associated
@@ -35,15 +37,21 @@ import (
 func (r *ResourceGraphDefinitionReconciler) cleanupResourceGraphDefinition(ctx context.Context, rgd *v1alpha1.ResourceGraphDefinition) error {
 	ctrl.LoggerFrom(ctx).V(1).Info("cleaning up resource graph definition", "name", rgd.Name)
 
+	gvr := metadata.GetResourceGraphDefinitionInstanceGVR(rgd.Spec.Schema.Group, rgd.Spec.Schema.APIVersion, rgd.Spec.Schema.Kind)
+
 	// Check in-memory map to avoid stale status data
 	if _, registered := r.registeredControllers.Load(rgd.UID); registered {
 		// shutdown microcontroller
-		gvr := metadata.GetResourceGraphDefinitionInstanceGVR(rgd.Spec.Schema.Group, rgd.Spec.Schema.APIVersion, rgd.Spec.Schema.Kind)
 		if err := r.shutdownResourceGraphDefinitionMicroController(ctx, &gvr); err != nil {
 			return fmt.Errorf("failed to shutdown microcontroller: %w", err)
 		}
 	} else {
 		ctrl.LoggerFrom(ctx).V(1).Info("skipping controller shutdown, controller was never registered", "name", rgd.Name)
+	}
+
+	// Clean up all instance-level condition metrics for this GVR.
+	if features.FeatureGate.Enabled(features.InstanceConditionMetrics) {
+		metrics.DeleteGVRMetrics(gvr)
 	}
 
 	// Registry eviction is NOT done here. The GraphRevision controller evicts

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -19,11 +19,15 @@ import (
 )
 
 const (
-	// InstanceConditionEvents enables emitting Kubernetes Events on instance
-	// status condition transitions (e.g. ResourcesReady False → True). When
-	// enabled, every condition change is surfaced as an Event on the instance
-	// object, visible via `kubectl describe`.
+	// InstanceConditionEvents enables Kubernetes Events on instance condition
+	// transitions. When enabled, the controller emits a K8s Event (visible
+	// via `kubectl describe`) every time a status condition changes state.
+	// This is opt-in to avoid noisy event streams in large clusters.
 	InstanceConditionEvents featuregate.Feature = "InstanceConditionEvents"
+
+	// InstanceConditionMetrics enables a Prometheus duration gauge per
+	// instance condition and structured log lines on every status change.
+	InstanceConditionMetrics featuregate.Feature = "InstanceConditionMetrics"
 
 	// CELOmitFunction enables the omit() CEL function for conditional field
 	// omission in resource templates. When enabled, CEL expressions can return
@@ -37,8 +41,9 @@ const (
 // To add a new feature, define a Feature constant above and add it here with
 // its default state and maturity stage (Alpha, Beta, or GA).
 var defaultKroFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	InstanceConditionEvents: {Default: false, PreRelease: featuregate.Alpha},
-	CELOmitFunction:         {Default: false, PreRelease: featuregate.Alpha},
+	InstanceConditionEvents:  {Default: false, PreRelease: featuregate.Alpha},
+	InstanceConditionMetrics: {Default: false, PreRelease: featuregate.Alpha},
+	CELOmitFunction:          {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // FeatureGate is the shared global MutableFeatureGate for KRO.

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -27,6 +27,8 @@ import (
 func TestDefaultFeatureGatesAreDisabled(t *testing.T) {
 	assert.False(t, FeatureGate.Enabled(InstanceConditionEvents),
 		"InstanceConditionEvents should be disabled by default (Alpha)")
+	assert.False(t, FeatureGate.Enabled(InstanceConditionMetrics),
+		"InstanceConditionMetrics should be disabled by default (Alpha)")
 	assert.False(t, FeatureGate.Enabled(CELOmitFunction),
 		"CELOmitFunction should be disabled by default (Alpha)")
 }
@@ -49,6 +51,12 @@ func TestDisableFeatureViaSet(t *testing.T) {
 
 	require.NoError(t, gate.Set("InstanceConditionEvents=false"))
 	assert.False(t, gate.Enabled(InstanceConditionEvents))
+
+	require.NoError(t, gate.Set("InstanceConditionMetrics=true"))
+	assert.True(t, gate.Enabled(InstanceConditionMetrics))
+
+	require.NoError(t, gate.Set("InstanceConditionMetrics=false"))
+	assert.False(t, gate.Enabled(InstanceConditionMetrics))
 }
 
 // TestSetUnknownFeatureReturnsError verifies that specifying an unknown
@@ -66,5 +74,6 @@ func TestKnownFeaturesContainsAllRegistered(t *testing.T) {
 	knownStr := strings.Join(known, " ")
 
 	assert.Contains(t, knownStr, string(InstanceConditionEvents))
+	assert.Contains(t, knownStr, string(InstanceConditionMetrics))
 	assert.Contains(t, knownStr, string(CELOmitFunction))
 }

--- a/pkg/metrics/instance.go
+++ b/pkg/metrics/instance.go
@@ -14,7 +14,27 @@
 
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+
+	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+)
+
+// Condition-metric label keys.
+const (
+	labelGVR             = "gvr"
+	labelNamespace       = "namespace"
+	labelName            = "name"
+	labelConditionType   = "condition_type"
+	labelConditionStatus = "condition_status"
+	labelReason          = "reason"
+)
 
 var (
 	InstanceStateTransitionsTotal = prometheus.NewCounterVec(
@@ -73,4 +93,105 @@ var (
 		},
 		[]string{"gvr"},
 	)
+
+	// InstanceConditionCurrentStatusSeconds tracks the duration an instance condition
+	// has been in its current state. The value is computed at reconcile time
+	// as time.Since(lastTransitionTime). To get fresher gauge values, consider
+	// lowering --dynamic-controller-default-resync-period.
+	InstanceConditionCurrentStatusSeconds = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "instance_condition_current_status_seconds",
+			Help: "The current amount of time in seconds that an instance status condition has been in a specific state.",
+		},
+		[]string{labelGVR, labelNamespace, labelName, labelConditionType, labelConditionStatus, labelReason},
+	)
 )
+
+// emitConditionMetrics computes the diff between initial and final conditions,
+// emits gauge metrics for all current conditions, emits structured logs for
+// changed conditions, and cleans up gauges for disappeared conditions.
+func EmitConditionMetrics(
+	log logr.Logger,
+	gvr schema.GroupVersionResource,
+	inst *unstructured.Unstructured,
+	initialConditions []v1alpha1.Condition,
+	finalConditions []v1alpha1.Condition,
+) {
+	gvrKey := gvr.String()
+	ns := inst.GetNamespace()
+	name := inst.GetName()
+
+	initialByType := indexConditionsByType(initialConditions)
+
+	finalTypes := make(map[v1alpha1.ConditionType]struct{}, len(finalConditions))
+
+	for _, cond := range finalConditions {
+		finalTypes[cond.Type] = struct{}{}
+		reason := ptr.Deref(cond.Reason, "")
+
+		var durationSeconds float64
+		if cond.LastTransitionTime != nil {
+			durationSeconds = time.Since(cond.LastTransitionTime.Time).Seconds()
+		}
+		InstanceConditionCurrentStatusSeconds.WithLabelValues(
+			gvrKey, ns, name,
+			string(cond.Type), string(cond.Status), reason,
+		).Set(durationSeconds)
+
+		oldCond, existed := initialByType[cond.Type]
+		if !existed || oldCond.Status != cond.Status {
+			oldStatus := "none"
+			if existed {
+				oldStatus = string(oldCond.Status)
+			}
+			log.V(2).Info("condition transitioned",
+				"gvr", gvrKey,
+				"namespace", ns,
+				"name", name,
+				"condition_type", string(cond.Type),
+				"old_status", oldStatus,
+				"new_status", string(cond.Status),
+				"reason", reason,
+			)
+		}
+	}
+
+	// Clean up gauges for conditions that disappeared.
+	for _, oldCond := range initialConditions {
+		if _, stillPresent := finalTypes[oldCond.Type]; !stillPresent {
+			InstanceConditionCurrentStatusSeconds.DeletePartialMatch(prometheus.Labels{
+				labelGVR:           gvrKey,
+				labelNamespace:     ns,
+				labelName:          name,
+				labelConditionType: string(oldCond.Type),
+			})
+		}
+	}
+}
+
+// deleteInstanceMetrics removes all gauge metrics for a specific instance.
+// Called when an instance is deleted (not found).
+func DeleteInstanceMetrics(gvr schema.GroupVersionResource, namespace, name string) {
+	InstanceConditionCurrentStatusSeconds.DeletePartialMatch(prometheus.Labels{
+		labelGVR:       gvr.String(),
+		labelNamespace: namespace,
+		labelName:      name,
+	})
+}
+
+// DeleteGVRMetrics removes all gauge metrics for all instances of a GVR.
+// Called when an RGD is deregistered (deleted).
+func DeleteGVRMetrics(gvr schema.GroupVersionResource) {
+	InstanceConditionCurrentStatusSeconds.DeletePartialMatch(prometheus.Labels{
+		labelGVR: gvr.String(),
+	})
+}
+
+// indexConditionsByType builds a lookup map from condition type to condition.
+func indexConditionsByType(conditions []v1alpha1.Condition) map[v1alpha1.ConditionType]v1alpha1.Condition {
+	m := make(map[v1alpha1.ConditionType]v1alpha1.Condition, len(conditions))
+	for _, c := range conditions {
+		m[c.Type] = c
+	}
+	return m
+}

--- a/pkg/metrics/instance.go
+++ b/pkg/metrics/instance.go
@@ -133,12 +133,25 @@ func EmitConditionMetrics(
 		if cond.LastTransitionTime != nil {
 			durationSeconds = time.Since(cond.LastTransitionTime.Time).Seconds()
 		}
+
+		oldCond, existed := initialByType[cond.Type]
+
+		// Delete the old series when status or reason changed to avoid stale gauges.
+		if existed {
+			oldReason := ptr.Deref(oldCond.Reason, "")
+			if oldCond.Status != cond.Status || oldReason != reason {
+				InstanceConditionCurrentStatusSeconds.DeleteLabelValues(
+					gvrKey, ns, name,
+					string(oldCond.Type), string(oldCond.Status), oldReason,
+				)
+			}
+		}
+
 		InstanceConditionCurrentStatusSeconds.WithLabelValues(
 			gvrKey, ns, name,
 			string(cond.Type), string(cond.Status), reason,
 		).Set(durationSeconds)
 
-		oldCond, existed := initialByType[cond.Type]
 		if !existed || oldCond.Status != cond.Status {
 			oldStatus := "none"
 			if existed {

--- a/pkg/metrics/instance_test.go
+++ b/pkg/metrics/instance_test.go
@@ -1,0 +1,248 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+)
+
+func TestEmitConditionMetrics_NewCondition(t *testing.T) {
+	// Reset metrics for test isolation.
+	InstanceConditionCurrentStatusSeconds.Reset()
+
+	log := zap.New(zap.UseDevMode(true))
+	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
+	inst := &unstructured.Unstructured{}
+	inst.SetNamespace("default")
+	inst.SetName("my-app")
+
+	now := metav1.Now()
+	initial := []v1alpha1.Condition{}
+	final := []v1alpha1.Condition{
+		{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			Reason:             strPtr("AllReady"),
+			LastTransitionTime: &now,
+		},
+	}
+
+	EmitConditionMetrics(log, gvr, inst, initial, final)
+
+	// Gauge should have one series.
+	gaugeCount := testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds)
+	assert.Equal(t, 1, gaugeCount)
+}
+
+func TestEmitConditionMetrics_NoTransition(t *testing.T) {
+	InstanceConditionCurrentStatusSeconds.Reset()
+
+	log := zap.New(zap.UseDevMode(true))
+	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
+	inst := &unstructured.Unstructured{}
+	inst.SetNamespace("default")
+	inst.SetName("my-app")
+
+	now := metav1.Now()
+	conds := []v1alpha1.Condition{
+		{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			Reason:             strPtr("AllReady"),
+			LastTransitionTime: &now,
+		},
+	}
+
+	EmitConditionMetrics(log, gvr, inst, conds, conds)
+
+	// Gauge should still be set (updated duration).
+	gaugeCount := testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds)
+	assert.Equal(t, 1, gaugeCount)
+}
+
+func TestEmitConditionMetrics_StatusTransition(t *testing.T) {
+	InstanceConditionCurrentStatusSeconds.Reset()
+
+	log := zap.New(zap.UseDevMode(true))
+	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
+	inst := &unstructured.Unstructured{}
+	inst.SetNamespace("default")
+	inst.SetName("my-app")
+
+	now := metav1.Now()
+	initial := []v1alpha1.Condition{
+		{
+			Type:               "ResourcesReady",
+			Status:             metav1.ConditionFalse,
+			Reason:             strPtr("NotReady"),
+			LastTransitionTime: &now,
+		},
+	}
+	final := []v1alpha1.Condition{
+		{
+			Type:               "ResourcesReady",
+			Status:             metav1.ConditionTrue,
+			Reason:             strPtr("AllResourcesReady"),
+			LastTransitionTime: &now,
+		},
+	}
+
+	EmitConditionMetrics(log, gvr, inst, initial, final)
+
+	// Gauge should be updated with the new condition state.
+	gaugeCount := testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds)
+	assert.Equal(t, 1, gaugeCount)
+}
+
+func TestEmitConditionMetrics_DisappearedCondition(t *testing.T) {
+	InstanceConditionCurrentStatusSeconds.Reset()
+
+	log := zap.New(zap.UseDevMode(true))
+	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
+	inst := &unstructured.Unstructured{}
+	inst.SetNamespace("default")
+	inst.SetName("my-app")
+
+	now := metav1.Now()
+
+	// Pre-populate the gauge for the condition that will disappear.
+	InstanceConditionCurrentStatusSeconds.WithLabelValues(
+		gvr.String(), "default", "my-app", "ResourcesReady", "True", "AllResourcesReady",
+	).Set(10)
+
+	initial := []v1alpha1.Condition{
+		{
+			Type:               "ResourcesReady",
+			Status:             metav1.ConditionTrue,
+			Reason:             strPtr("AllResourcesReady"),
+			LastTransitionTime: &now,
+		},
+	}
+	final := []v1alpha1.Condition{} // condition disappeared
+
+	EmitConditionMetrics(log, gvr, inst, initial, final)
+
+	// Gauge should be cleaned up (no series left).
+	gaugeCount := testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds)
+	assert.Equal(t, 0, gaugeCount)
+}
+
+func TestDeleteInstanceMetrics(t *testing.T) {
+	InstanceConditionCurrentStatusSeconds.Reset()
+
+	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
+	gvrKey := gvr.String()
+
+	// Populate metrics for two instances.
+	InstanceConditionCurrentStatusSeconds.WithLabelValues(gvrKey, "default", "app-1", "Ready", "True", "AllReady").Set(5)
+	InstanceConditionCurrentStatusSeconds.WithLabelValues(gvrKey, "default", "app-2", "Ready", "True", "AllReady").Set(10)
+
+	assert.Equal(t, 2, testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds))
+
+	DeleteInstanceMetrics(gvr, "default", "app-1")
+
+	// Only app-2 should remain.
+	assert.Equal(t, 1, testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds))
+}
+
+func TestDeleteGVRMetrics(t *testing.T) {
+	InstanceConditionCurrentStatusSeconds.Reset()
+
+	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
+	gvrKey := gvr.String()
+
+	// Populate metrics for two instances.
+	InstanceConditionCurrentStatusSeconds.WithLabelValues(gvrKey, "default", "app-1", "Ready", "True", "AllReady").Set(5)
+	InstanceConditionCurrentStatusSeconds.WithLabelValues(gvrKey, "default", "app-2", "Ready", "True", "AllReady").Set(10)
+
+	assert.Equal(t, 2, testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds))
+
+	DeleteGVRMetrics(gvr)
+
+	// All metrics for this GVR should be gone.
+	assert.Equal(t, 0, testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds))
+}
+
+func TestEmitConditionMetrics_DurationIsPositive(t *testing.T) {
+	InstanceConditionCurrentStatusSeconds.Reset()
+
+	log := zap.New(zap.UseDevMode(true))
+	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
+	inst := &unstructured.Unstructured{}
+	inst.SetNamespace("default")
+	inst.SetName("my-app")
+
+	past := metav1.NewTime(time.Now().Add(-30 * time.Second))
+	initial := []v1alpha1.Condition{}
+	final := []v1alpha1.Condition{
+		{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			Reason:             strPtr("AllReady"),
+			LastTransitionTime: &past,
+		},
+	}
+
+	EmitConditionMetrics(log, gvr, inst, initial, final)
+
+	// The gauge value should be >= 30 seconds.
+	val := testutil_getGaugeValue(t, InstanceConditionCurrentStatusSeconds, gvr.String(), "default", "my-app", "Ready", "True", "AllReady")
+	assert.GreaterOrEqual(t, val, 30.0)
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+// testutil_countMetrics returns the number of active metric series in a collector.
+func testutil_countMetrics(t *testing.T, c prometheus.Collector) int {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 100)
+	c.Collect(ch)
+	close(ch)
+	count := 0
+	for range ch {
+		count++
+	}
+	return count
+}
+
+// testutil_getGaugeValue retrieves the value of a specific gauge series.
+func testutil_getGaugeValue(t *testing.T, gv *prometheus.GaugeVec, labels ...string) float64 {
+	t.Helper()
+	gauge, err := gv.GetMetricWithLabelValues(labels...)
+	require.NoError(t, err)
+
+	ch := make(chan prometheus.Metric, 1)
+	gauge.Collect(ch)
+	close(ch)
+
+	m := <-ch
+	var dto io_prometheus_client.Metric
+	require.NoError(t, m.Write(&dto))
+	return dto.GetGauge().GetValue()
+}

--- a/pkg/metrics/instance_test.go
+++ b/pkg/metrics/instance_test.go
@@ -54,7 +54,7 @@ func TestEmitConditionMetrics_NewCondition(t *testing.T) {
 	EmitConditionMetrics(log, gvr, inst, initial, final)
 
 	// Gauge should have one series.
-	gaugeCount := testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds)
+	gaugeCount := testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds)
 	assert.Equal(t, 1, gaugeCount)
 }
 
@@ -80,7 +80,7 @@ func TestEmitConditionMetrics_NoTransition(t *testing.T) {
 	EmitConditionMetrics(log, gvr, inst, conds, conds)
 
 	// Gauge should still be set (updated duration).
-	gaugeCount := testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds)
+	gaugeCount := testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds)
 	assert.Equal(t, 1, gaugeCount)
 }
 
@@ -111,10 +111,16 @@ func TestEmitConditionMetrics_StatusTransition(t *testing.T) {
 		},
 	}
 
+	// Pre-populate the old series to verify it gets cleaned up.
+	InstanceConditionCurrentStatusSeconds.WithLabelValues(
+		gvr.String(), "default", "my-app", "ResourcesReady", "False", "NotReady",
+	).Set(42)
+	assert.Equal(t, 1, testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds))
+
 	EmitConditionMetrics(log, gvr, inst, initial, final)
 
-	// Gauge should be updated with the new condition state.
-	gaugeCount := testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds)
+	// Only the new series should remain; the old False/NotReady series must be deleted.
+	gaugeCount := testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds)
 	assert.Equal(t, 1, gaugeCount)
 }
 
@@ -147,7 +153,7 @@ func TestEmitConditionMetrics_DisappearedCondition(t *testing.T) {
 	EmitConditionMetrics(log, gvr, inst, initial, final)
 
 	// Gauge should be cleaned up (no series left).
-	gaugeCount := testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds)
+	gaugeCount := testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds)
 	assert.Equal(t, 0, gaugeCount)
 }
 
@@ -161,12 +167,12 @@ func TestDeleteInstanceMetrics(t *testing.T) {
 	InstanceConditionCurrentStatusSeconds.WithLabelValues(gvrKey, "default", "app-1", "Ready", "True", "AllReady").Set(5)
 	InstanceConditionCurrentStatusSeconds.WithLabelValues(gvrKey, "default", "app-2", "Ready", "True", "AllReady").Set(10)
 
-	assert.Equal(t, 2, testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds))
+	assert.Equal(t, 2, testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds))
 
 	DeleteInstanceMetrics(gvr, "default", "app-1")
 
 	// Only app-2 should remain.
-	assert.Equal(t, 1, testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds))
+	assert.Equal(t, 1, testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds))
 }
 
 func TestDeleteGVRMetrics(t *testing.T) {
@@ -179,12 +185,12 @@ func TestDeleteGVRMetrics(t *testing.T) {
 	InstanceConditionCurrentStatusSeconds.WithLabelValues(gvrKey, "default", "app-1", "Ready", "True", "AllReady").Set(5)
 	InstanceConditionCurrentStatusSeconds.WithLabelValues(gvrKey, "default", "app-2", "Ready", "True", "AllReady").Set(10)
 
-	assert.Equal(t, 2, testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds))
+	assert.Equal(t, 2, testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds))
 
 	DeleteGVRMetrics(gvr)
 
 	// All metrics for this GVR should be gone.
-	assert.Equal(t, 0, testutil_countMetrics(t, InstanceConditionCurrentStatusSeconds))
+	assert.Equal(t, 0, testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds))
 }
 
 func TestEmitConditionMetrics_DurationIsPositive(t *testing.T) {
@@ -210,7 +216,7 @@ func TestEmitConditionMetrics_DurationIsPositive(t *testing.T) {
 	EmitConditionMetrics(log, gvr, inst, initial, final)
 
 	// The gauge value should be >= 30 seconds.
-	val := testutil_getGaugeValue(t, InstanceConditionCurrentStatusSeconds, gvr.String(), "default", "my-app", "Ready", "True", "AllReady")
+	val := testutilGetGaugeValue(t, InstanceConditionCurrentStatusSeconds, gvr.String(), "default", "my-app", "Ready", "True", "AllReady")
 	assert.GreaterOrEqual(t, val, 30.0)
 }
 
@@ -218,8 +224,8 @@ func strPtr(s string) *string {
 	return &s
 }
 
-// testutil_countMetrics returns the number of active metric series in a collector.
-func testutil_countMetrics(t *testing.T, c prometheus.Collector) int {
+// testutilCountMetrics returns the number of active metric series in a collector.
+func testutilCountMetrics(t *testing.T, c prometheus.Collector) int {
 	t.Helper()
 	ch := make(chan prometheus.Metric, 100)
 	c.Collect(ch)
@@ -231,8 +237,8 @@ func testutil_countMetrics(t *testing.T, c prometheus.Collector) int {
 	return count
 }
 
-// testutil_getGaugeValue retrieves the value of a specific gauge series.
-func testutil_getGaugeValue(t *testing.T, gv *prometheus.GaugeVec, labels ...string) float64 {
+// testutilGetGaugeValue retrieves the value of a specific gauge series.
+func testutilGetGaugeValue(t *testing.T, gv *prometheus.GaugeVec, labels ...string) float64 {
 	t.Helper()
 	gauge, err := gv.GetMetricWithLabelValues(labels...)
 	require.NoError(t, err)

--- a/pkg/metrics/register.go
+++ b/pkg/metrics/register.go
@@ -65,6 +65,7 @@ func Register(registry prometheus.Registerer) {
 		InstanceGraphResolutionSuccessTotal,
 		InstanceGraphResolutionFailuresTotal,
 		InstanceGraphResolutionPendingTotal,
+		InstanceConditionCurrentStatusSeconds,
 
 		// RGD controller
 		RGDGraphBuildTotal,


### PR DESCRIPTION
Fixes since the original land:
- Delete stale gauge series when a condition's `reason` changes
- Short-circuit `updateStatus` when status is unchanged to prevent infinite reconcile loops
- Restore `InstanceConditionEvents` test coverage in `TestDisableFeatureViaSet`
