### PR TITLE
docs: correct links in overview to install and first deploy section

### DIFF
--- a/website/docs/docs/overview.mdx
+++ b/website/docs/docs/overview.mdx
@@ -162,8 +162,8 @@ in custom controller code.
 
 ## Get started
 
-- [Install kro](./getting-started/Installation) to run the controller in your cluster
-- [Deploy your first RGD](./getting-started/deploy-a-resource-graph-definition) to create a new API end to end
+- [Install kro](/docs/getting-started/Installation) to run the controller in your cluster
+- [Deploy your first RGD](/docs/getting-started/deploy-a-resource-graph-definition) to create a new API end to end
 - [Browse examples](../../examples/) to see more patterns
 
 Need help or want to contribute? Join [#kro on Kubernetes Slack](https://kubernetes.slack.com/archives/C081TMY9D6Y), browse [GitHub](https://github.com/kubernetes-sigs/kro), or read [Contributing](https://github.com/kubernetes-sigs/kro/blob/main/CONTRIBUTING.md).

--- a/website/versioned_docs/version-0.9.2/docs/overview.mdx
+++ b/website/versioned_docs/version-0.9.2/docs/overview.mdx
@@ -162,8 +162,8 @@ in custom controller code.
 
 ## Get started
 
-- [Install kro](./getting-started/Installation) to run the controller in your cluster
-- [Deploy your first RGD](./getting-started/deploy-a-resource-graph-definition) to create a new API end to end
+- [Install kro](/docs/getting-started/Installation) to run the controller in your cluster
+- [Deploy your first RGD](/docs/getting-started/deploy-a-resource-graph-definition) to create a new API end to end
 - [Browse examples](../../examples/) to see more patterns
 
 Need help or want to contribute? Join [#kro on Kubernetes Slack](https://kubernetes.slack.com/archives/C081TMY9D6Y), browse [GitHub](https://github.com/kubernetes-sigs/kro), or read [Contributing](https://github.com/kubernetes-sigs/kro/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
Correct the links to the install and and first deploy section


Closes #1288