### PR TITLE
feat(graph): allow schema.* references in instance status expressions

### DIFF
--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -712,10 +712,17 @@ func buildInstanceNode(
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract dependencies from expression %q: %w", statusVariable.Expression, err)
 		}
-		if len(deps) == 0 {
-			return nil, fmt.Errorf("instance status field must refer to a resource: %s", statusVariable.Path)
+		// Status fields may reference resources, schema, or both.
+		referencesSchema := slices.Contains(statusVariable.Expression.References, SchemaVarName)
+		if len(deps) == 0 && !referencesSchema {
+			return nil, fmt.Errorf("instance status field must refer to a resource or schema: %s", statusVariable.Path)
 		}
 		instanceDeps = append(instanceDeps, deps...)
+		// If this expression references schema, include the instance node itself as a dep
+		// so the runtime wires it into instNode.deps for context building.
+		if referencesSchema && !slices.Contains(instanceDeps, InstanceNodeID) {
+			instanceDeps = append(instanceDeps, InstanceNodeID)
+		}
 
 		instanceStatusVariables = append(instanceStatusVariables, &variable.ResourceField{
 			FieldDescriptor: statusVariable,
@@ -805,13 +812,11 @@ func buildStatusSchema(
 		return nil, nil, nil, fmt.Errorf("status fields without expressions are not supported: %v", noExpressionFields)
 	}
 
-	// Instance status expressions can ONLY reference resources, not schema.
-	// At runtime, status is populated after resources are created.
-
-	// Verify status expressions don't reference schema and populate References
+	// Verify status expressions only reference known resources or schema, and populate References.
+	allowedStatusVars := append(nodeNames, SchemaVarName)
 	for _, fieldDescriptor := range fieldDescriptors {
 		expression := fieldDescriptor.Expression
-		result, err := inspectExpressionRestricted(inspector, expression.Original, nodeNames)
+		result, err := inspectExpressionRestricted(inspector, expression.Original, allowedStatusVars)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("status field %q expression %q: %w", fieldDescriptor.Path, expression.UserExpression(), err)
 		}

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -302,7 +302,7 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 	}
 
 	// Build instance status schema.
-	// Status expressions reference resources (validated to not reference schema).
+	// Status expressions reference resources and/or the instance's own schema.
 	// We infer the status field types from the CEL expression output types.
 	statusSchema, statusVariables, statusTemplate, err := buildStatusSchema(
 		bc,
@@ -813,7 +813,7 @@ func buildStatusSchema(
 	}
 
 	// Verify status expressions only reference known resources or schema, and populate References.
-	allowedStatusVars := append(nodeNames, SchemaVarName)
+	allowedStatusVars := slices.Concat(nodeNames, []string{SchemaVarName})
 	for _, fieldDescriptor := range fieldDescriptors {
 		expression := fieldDescriptor.Expression
 		result, err := inspectExpressionRestricted(inspector, expression.Original, allowedStatusVars)

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -620,6 +620,53 @@ func TestGraphBuilder_Validation(t *testing.T) {
 			errMsg:  "failed to create instance node",
 		},
 		{
+			name: "status expression can reference schema field",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]interface{}{
+						"host": "string",
+					},
+					map[string]interface{}{
+						"url": "${vpc.status.vpcID + '/' + schema.spec.host}",
+					},
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks": []interface{}{"10.0.0.0/16"},
+					},
+				}, nil, nil),
+			},
+			wantErr: false,
+		},
+		{
+			name: "status expression referencing only schema (no resource)",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]interface{}{
+						"host": "string",
+					},
+					map[string]interface{}{
+						"echoHost": "${schema.spec.host}",
+					},
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+				}, nil, nil),
+			},
+			wantErr: false,
+		},
+		{
 			name: "invalid field type in resource spec",
 			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -125,7 +125,10 @@ func FromGraph(g *graph.Graph, instance *unstructured.Unstructured, rgdConfig gr
 
 	// Wire up instance node dependencies.
 	for _, depID := range instNode.Spec.Meta.Dependencies {
-		if dep, ok := rt.nodes[depID]; ok {
+		if depID == graph.InstanceNodeID {
+			// Status expressions referencing schema need the instance node itself as a dep.
+			instNode.deps[graph.InstanceNodeID] = instNode
+		} else if dep, ok := rt.nodes[depID]; ok {
 			instNode.deps[depID] = dep
 		}
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -124,11 +124,11 @@ func FromGraph(g *graph.Graph, instance *unstructured.Unstructured, rgdConfig gr
 	}
 
 	// Wire up instance node dependencies.
+	// Status expressions may reference the instance's own schema, so the instance
+	// node is always wired as a dep of itself.
+	instNode.deps[graph.InstanceNodeID] = instNode
 	for _, depID := range instNode.Spec.Meta.Dependencies {
-		if depID == graph.InstanceNodeID {
-			// Status expressions referencing schema need the instance node itself as a dep.
-			instNode.deps[graph.InstanceNodeID] = instNode
-		} else if dep, ok := rt.nodes[depID]; ok {
+		if dep, ok := rt.nodes[depID]; ok {
 			instNode.deps[depID] = dep
 		}
 	}

--- a/test/integration/suites/core/status_schema_ref_test.go
+++ b/test/integration/suites/core/status_schema_ref_test.go
@@ -1,0 +1,263 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+var _ = Describe("Status schema references", func() {
+	var namespace string
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	It("should populate status from schema spec field only", func(ctx SpecContext) {
+		// Status expression references schema.spec directly — no resource needed in the expression.
+		rgd := generator.NewResourceGraphDefinition("test-status-schema-only",
+			generator.WithSchema(
+				"StatusSchemaOnly", "v1alpha1",
+				map[string]interface{}{
+					"host": "string",
+				},
+				map[string]interface{}{
+					"echoHost": "${schema.spec.host}",
+				},
+			),
+			generator.WithResource("cm", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.host}",
+				},
+			}, nil, nil),
+		)
+
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		instanceName := "test-schema-only"
+		instance := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+				"kind":       "StatusSchemaOnly",
+				"metadata": map[string]interface{}{
+					"name":      instanceName,
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"host": "example.com",
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+		})
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      instanceName,
+				Namespace: namespace,
+			}, instance)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			echoHost, found, err := unstructured.NestedString(instance.Object, "status", "echoHost")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue(), "status.echoHost should exist")
+			g.Expect(echoHost).To(Equal("example.com"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+
+	It("should populate status mixing resource field and schema spec field", func(ctx SpecContext) {
+		// Status expression combines a resource field with a schema spec field.
+		rgd := generator.NewResourceGraphDefinition("test-status-schema-mixed",
+			generator.WithSchema(
+				"StatusSchemaMixed", "v1alpha1",
+				map[string]interface{}{
+					"path": "string",
+				},
+				map[string]interface{}{
+					"url": "${configmap.metadata.name + '/' + schema.spec.path}",
+				},
+			),
+			generator.WithResource("configmap", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "my-configmap",
+				},
+				"data": map[string]interface{}{
+					"key": "value",
+				},
+			}, nil, nil),
+		)
+
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		instanceName := "test-schema-mixed"
+		instance := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+				"kind":       "StatusSchemaMixed",
+				"metadata": map[string]interface{}{
+					"name":      instanceName,
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"path": "api/v1",
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+		})
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      instanceName,
+				Namespace: namespace,
+			}, instance)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			url, found, err := unstructured.NestedString(instance.Object, "status", "url")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue(), "status.url should exist")
+			g.Expect(url).To(Equal("my-configmap/api/v1"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+
+	It("should reflect updated schema spec value in status", func(ctx SpecContext) {
+		// Verifies that when spec changes, the schema-referencing status field updates too.
+		rgd := generator.NewResourceGraphDefinition("test-status-schema-update",
+			generator.WithSchema(
+				"StatusSchemaUpdate", "v1alpha1",
+				map[string]interface{}{
+					"label": "string",
+				},
+				map[string]interface{}{
+					"echoLabel": "${schema.spec.label}",
+				},
+			),
+			generator.WithResource("cm", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "static-cm",
+				},
+			}, nil, nil),
+		)
+
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		instanceName := "test-schema-update"
+		instance := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+				"kind":       "StatusSchemaUpdate",
+				"metadata": map[string]interface{}{
+					"name":      instanceName,
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"label": "first",
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+		})
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      instanceName,
+				Namespace: namespace,
+			}, instance)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			echoLabel, found, err := unstructured.NestedString(instance.Object, "status", "echoLabel")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(echoLabel).To(Equal("first"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		// Update spec.label and verify status tracks it.
+		Expect(unstructured.SetNestedField(instance.Object, "second", "spec", "label")).To(Succeed())
+		Expect(env.Client.Update(ctx, instance)).To(Succeed())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      instanceName,
+				Namespace: namespace,
+			}, instance)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			echoLabel, found, err := unstructured.NestedString(instance.Object, "status", "echoLabel")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(echoLabel).To(Equal("second"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+})


### PR DESCRIPTION
## Summary

Status expressions previously only allowed references to resource IDs (e.g. `${deployment.status.replicas}`). Referencing `schema.spec.*` — the instance's own spec fields — was blocked at build time with no strong technical reason. This change lifts that restriction, consistent with how `includeWhen` already works.

**Use cases enabled:**
- Echo a spec field into status: `status.host: ${schema.spec.host}`
- Combine resource output with spec input: `status.url: ${svc.status.ip + '/' + schema.spec.path}`

## Changes

**`pkg/graph/builder.go`**
- `buildStatusSchema`: add `SchemaVarName` to the allowed-identifiers list passed to `inspectExpressionRestricted`
- `buildInstanceNode`: relax the zero-deps guard to permit schema-only expressions; wire `InstanceNodeID` into `instanceDeps` when schema is referenced so the runtime can resolve it at evaluation time

**`pkg/runtime/runtime.go`**
- Handle `InstanceNodeID` in the instance dep-wiring loop (`instNode.deps[InstanceNodeID] = instNode`) — previously only regular resource nodes were wired this way

**Tests**
- Two new unit test cases in `TestGraphBuilder_Validation`: schema-only and mixed resource+schema status expressions
- Three new integration tests in `test/integration/suites/core/status_schema_ref_test.go`: schema-only population, mixed resource+schema, and spec-update propagation
