### PR TITLE
KREP-024: Graph — atomic composition primitive

### DIFF
--- a/docs/design/proposals/graph.md
+++ b/docs/design/proposals/graph.md
@@ -19,6 +19,49 @@ composition rather than imperative Go code. This implementation passes 23 of 36 
 compatibility test files, with remaining gaps due to prototype immaturity rather than structural
 limitations (see [examples/graph/rgd.yaml](../../../examples/graph/rgd.yaml)).
 
+Beyond the RGD proof, Graph enables patterns that are simpler than what RGD can express today:
+- [Namespace decorator](../../../examples/graph/namespace-decorator.yaml) — watch namespaces, create
+  NetworkPolicies. No CRD, no schema, no instance. (The decorator pattern from KREP-003.)
+- [Ingress fan-in](../../../examples/graph/ingress-fanin.yaml) — aggregate Services into a single
+  Ingress with dynamic routes. (The aggregated-resource pattern from KREP-003.)
+- [KRO installation](../../../examples/graph/kro-install.yaml) — install kro itself as a Graph.
+  The static-bundle pattern: dependency-ordered, health-aware, one object replaces a Helm chart.
+- [Singleton](../../../examples/graph/singleton.yaml) — fan-in with priority-based resolution
+  when multiple actors claim the same resource.
+
+### What this KREP covers
+
+**Proposed:** The Graph Kind — node types (`template`, `patch`, `ref`, `watch`, `def`), dependency
+inference from CEL expressions, status conditions (`Compiled`, `Ready`), self-references, and nested
+composition. These are new primitives that do not exist in KRO today.
+
+**Inherited unchanged from RGD:** `includeWhen`, `forEach`, and CEL expression syntax. These
+mechanisms carry forward with the same semantics and are not redefined by this KREP.
+
+**Directional (defers to respective KREPs):** `propagateWhen` semantics (KREP-006), collection-level
+rollout budgets (KREP-006), and `readyWhen` behavioral differences from the current RGD
+implementation. Sections in this document illustrate how these features compose with Graph's
+recursive structure, but their final API and semantics are defined by their respective KREPs.
+
+**Relationship to RGD:** Graph is proposed as a sibling primitive. RGD continues to work unchanged.
+We have the option to implement RGD's internals on top of Graph in the future, but for the immediate
+term both implementations live as siblings sharing significant code in the underlying graph engine.
+Graph is additive — it does not replace or deprecate RGD.
+
+**Security posture:** Creating a Graph gives its author full control over everything KRO can do —
+creating, patching, deleting, and watching arbitrary Kubernetes resources within the permissions
+granted to the KRO controller's service account. A Graph author operates at the same privilege level
+as today's RGD author: the "infrastructure author" persona who defines what resources exist and how
+they relate.
+
+KRO's dual-persona model is preserved at higher layers. Authors (broad permissions) write
+RGDs/Graphs; consumers (narrow permissions scoped to the CRD the author created) interact only with
+the Kinds those Graphs implement, never with Graph objects directly. Graph is author-facing — end
+users never create or modify Graphs. Future work on credential scoping — short-lived tokens, caller
+credentials (analogous to how CloudFormation uses the caller's IAM role rather than the service's),
+or per-Graph service accounts — applies uniformly to all KRO primitives and is out of scope for this
+KREP.
+
 ## Motivation: Graph as Scope
 
 A Graph is an **isolated scope**. Its nodes form a flat namespace — private, visible only within the
@@ -230,6 +273,10 @@ available). `readyWhen` determines:
 
 ### propagateWhen
 
+> *This section defines `propagateWhen`'s core gating semantics within Graph. Rate-limited rollouts,
+> reactive controls, and manual approval gates are proposed separately in KREP-006. The examples
+> here illustrate composability but do not prescribe the final rollout API.*
+
 `propagateWhen` is the complement to `readyWhen`. Where `readyWhen` signals when a node is healthy,
 `propagateWhen` gates when a node may be evaluated at all. Together they bookend a node's lifecycle:
 `propagateWhen` controls when mutation _can start_; `readyWhen` signals when it is _complete_.
@@ -299,6 +346,9 @@ the effects of items earlier — this is how propagation budgets tighten within 
 pass.
 
 This makes collection-level propagation budgets expressible:
+
+> *The budget pattern below illustrates how `propagateWhen` composes with `forEach`. The rollout
+> API — including built-in strategies and budget syntax — is defined by KREP-006.*
 
 ```yaml
 # Exponential rollout — budget doubles each wave

--- a/docs/design/proposals/graph.md
+++ b/docs/design/proposals/graph.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-Graph is a new `kro.run/v1alpha1` Kind — the atomic runtime primitive for composing Kubernetes
-resources. A Graph is a set of nodes evaluated in topological order. Create it and its resources
-converge; delete it and they cascade away. It is the simplest possible unit of composition in kro.
+Graph is a new `kro.run/v1alpha1` Kind — the atomic primitive for composing Kubernetes resources. A
+Graph is a set of nodes evaluated in topological order. Create it and its resources converge; delete
+it and they cascade away. It is the simplest possible unit of composition in kro.
 
-RGD today combines Kind definition, instance management, and resource composition into one object.
+RGD today combines CRD management, instance management, and resource composition into one object.
 Graph separates these — providing resource composition alone — making each concern independently
 usable. This enables patterns RGD cannot express: static resource bundles (no CRD needed),
 singletons (multiple contributors, one resource), and decorators (react to existing resources
@@ -60,26 +60,15 @@ the Kinds those Graphs implement, never with Graph objects directly. Future work
 scoping (short-lived tokens, caller credentials, per-Graph service accounts) applies uniformly to
 all KRO primitives and is out of scope for this KREP.
 
-## Motivation: Graph as Scope
+## Graph as a Scope
 
-A Graph is an **isolated scope**. Its nodes form a flat namespace — private, visible only within the
-Graph — with spec as input and status as output. Nothing inside a Graph is reachable from outside
-except through the Kubernetes resource boundary: the Graph object's own spec and status fields.
-
-This isolation has three structural effects:
-
-1. **Concurrency is a consequence of scope boundaries.** A `forEach` over 1000 instances stamps 1000
-   independent Graphs, each with its own scope and lifecycle, each reconciled independently.
-   Parallelism isn't a feature of the evaluation loop — it emerges from the isolation.
-
-2. **Propagation is scope-local.** A `propagateWhen` gate within a child Graph is invisible to the
-   parent. The parent sees only the child's `Ready` condition. Rollout control composes without
-   leaking — a canary strategy inside one instance doesn't slow or block sibling instances.
-
-3. **Communication is explicit.** Graphs talk to each other only through the resources that bind
-   them: the spec of a child Graph stamped by a parent, a `ref` to a resource managed by another
-   Graph, or a `watch` on a Kind whose instances are managed elsewhere. There is no shared memory,
-   no implicit coupling, no cross-scope references.
+A Graph is analogous to a **scope** in traditional programming languages. Its nodes form a flat
+namespace — private, visible only within the Graph — with spec as input and status as output.
+Nothing inside a Graph is reachable from outside except through the Kubernetes resource boundary:
+the Graph object's own spec and status fields. Concurrency is a structural consequence of this
+isolation: a `forEach` over 1000 instances stamps 1000 independent Graphs, each reconciled
+independently. Parallelism isn't a feature of the evaluation loop — it emerges from the scope
+boundary.
 
 ## Proposed API
 
@@ -203,14 +192,11 @@ Pure computation — no Kubernetes resource created or read. The result enters s
       app: ${deployment.metadata.labels['app']}
 ```
 
-#### Everything is a CEL expression
+#### Dynamic GVKs
 
-Every string field in a node body — including `apiVersion`, `kind`, `metadata.name`, and selector
-values — can be a CEL expression. Dynamic evaluation is the general case; statically-known GVKs are
-an optimization that enables compile-time type checking. When the compiler encounters a dynamic GVK,
-it uses a deferred-type path: the node compiles permissively (untyped) until the first reconcile
-resolves the concrete GVK. This is what makes the RGD-from-Graph pattern possible — the user's Kind
-isn't known at compile time.
+A node's `apiVersion`, `kind`, and `metadata.name` can be CEL expressions. This enables patterns
+where the target resource type isn't known at author time — for example, watching instances of a
+Kind defined by an RGD whose schema is only known at runtime:
 
 ```yaml
 - id: watchInstances
@@ -228,11 +214,11 @@ isn't known at compile time.
 stamps a node once per item in a collection. Both retain the same semantics as in today's RGD and
 are not redefined here — see KREP-008 and KREP-002 respectively.
 
-| Modifier | Question it answers | When false | Defined in |
-| --- | --- | --- | --- |
-| `includeWhen` | Should this node exist? | Prune — resource deleted | KREP-008 |
-| `propagateWhen` | May this node mutate now? | Freeze — last-applied state persists | KREP-006 |
-| `readyWhen` | Is this node healthy? | Signal only — Graph not Ready | (inherited from RGD) |
+| Modifier        | Question it answers       | When false                           | Defined in           |
+| --------------- | ------------------------- | ------------------------------------ | -------------------- |
+| `includeWhen`   | Should this node exist?   | Prune — resource deleted             | KREP-008             |
+| `propagateWhen` | May this node mutate now? | Freeze — last-applied state persists | KREP-006             |
+| `readyWhen`     | Is this node healthy?     | Signal only — Graph not Ready        | (inherited from RGD) |
 
 ### Dependencies
 
@@ -287,12 +273,11 @@ KREP-006 for semantics, strategies, and collection-level defaults.
 ### Nested Graphs
 
 A `template:` node can contain any Kind — including Graph itself. Nesting isn't an opt-in feature;
-it emerges from the Kubernetes API. This KREP defines deferral and recursive-compilation semantics
-because nesting cannot be prevented, only left undefined.
+it emerges from the Kubernetes API and Graph semantics.
 
 When a node's template is a Graph, you get nested composition: a parent Graph that stamps a child
-Graph as a real cluster object. The child is persisted, reconciled independently, and carries its own
-conditions and revision history — providing full debuggability via `kubectl get graph`. The
+Graph as a real cluster object. The child is persisted, reconciled independently, and carries its
+own conditions and revision history — providing full debuggability via `kubectl get graph`. The
 combination of `forEach` + template:{kind: Graph} stamps one child Graph per item in a collection.
 This is how an RGD-equivalent is expressed — a per-RGD Graph stamps a per-instance Graph, each with
 its own scope, its own revisions, and its own lifecycle.
@@ -366,33 +351,33 @@ intervention.
 If compilation fails, Ready is False with reason NotCompiled. A single alarm on Ready covers both
 compilation failures and runtime issues.
 
-| Ready Reason | Status  | Meaning                           |
-| ------------ | ------- | --------------------------------- |
-| Ready        | True    | All nodes applied and ready       |
-| NotReady     | Unknown | readyWhen not yet met             |
-| Pending      | Unknown | Waiting for upstream data         |
-| NotCompiled  | False   | Spec is invalid                   |
-| Conflict     | False   | SSA field ownership contested     |
-| Error        | False   | Client request failed (4xx)       |
-| SystemError  | False   | Infrastructure failure (5xx)      |
+| Ready Reason | Status  | Meaning                       |
+| ------------ | ------- | ----------------------------- |
+| Ready        | True    | All nodes applied and ready   |
+| NotReady     | Unknown | readyWhen not yet met         |
+| Pending      | Unknown | Waiting for upstream data     |
+| NotCompiled  | False   | Spec is invalid               |
+| Conflict     | False   | SSA field ownership contested |
+| Error        | False   | Client request failed (4xx)   |
+| SystemError  | False   | Infrastructure failure (5xx)  |
 
 User-defined status does not live on the Graph object. It lives on custom resources and is written
 via `patch:` nodes. The Graph's status contains only controller-managed conditions.
 
 ## Relationship to Existing KREPs
 
-| KREP | Relationship |
-| --- | --- |
-| KREP-001 (Status Conditions) | System conditions (`Compiled`, `Ready`) exist on Graph objects — never on user resources. Users define their own status via `patch:` nodes. |
-| KREP-002 (Collections) | Adopted unchanged. Graph extends it: when a forEach node's template is a Graph, you get recursive composition. |
-| KREP-003 (Decorators) | A Decorator is naturally a Graph with `watch:` + `forEach`. No special runtime support needed. |
-| KREP-006 (Propagation Control) | Graph adopts KREP-006's lifecycle signals and `propagateWhen` gating. Because Graph is recursive, propagation composes at every nesting level. KREP-006 defines the API. |
-| KREP-008 (includeWhen) | Graph implements `includeWhen` as a first-class modifier. Dependency inference works naturally — no special handling needed. |
-| KREP-011 (Variables) | `def:` is Graph's implementation. Same semantics. |
-| KREP-013 (Graph Revisions) | Applies unchanged. Each nested Graph gets independent revisions. |
-| KREP-014 (Resource Lifecycles) | Graph's node types implicitly define lifecycle: `template:` = delete-on-prune, `patch:` = release-fields-on-prune. Per-node lifecycle policies are a natural follow-on. |
-| KREP-018 (Partial Dependencies) | Soft dependencies (`?.`) address the taken-branch problem — the untaken branch uses optional chaining rather than creating a hard gate. |
-| KREP-019 (Deferred Fields) | Graph's `?.` optional chaining is the implementation of this KREP. |
+| KREP                            | Relationship                                                                                                                                                             |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| KREP-001 (Status Conditions)    | System conditions (`Compiled`, `Ready`) exist on Graph objects — never on user resources. Users define their own status via `patch:` nodes.                              |
+| KREP-002 (Collections)          | Adopted unchanged. Graph extends it: when a forEach node's template is a Graph, you get recursive composition.                                                           |
+| KREP-003 (Decorators)           | A Decorator is naturally a Graph with `watch:` + `forEach`. No special runtime support needed.                                                                           |
+| KREP-006 (Propagation Control)  | Graph adopts KREP-006's lifecycle signals and `propagateWhen` gating. Because Graph is recursive, propagation composes at every nesting level. KREP-006 defines the API. |
+| KREP-008 (includeWhen)          | Graph implements `includeWhen` as a first-class modifier. Dependency inference works naturally — no special handling needed.                                             |
+| KREP-011 (Variables)            | `def:` is Graph's implementation. Same semantics.                                                                                                                        |
+| KREP-013 (Graph Revisions)      | Applies unchanged. Each nested Graph gets independent revisions.                                                                                                         |
+| KREP-014 (Resource Lifecycles)  | Graph's node types implicitly define lifecycle: `template:` = delete-on-prune, `patch:` = release-fields-on-prune. Per-node lifecycle policies are a natural follow-on.  |
+| KREP-018 (Partial Dependencies) | Soft dependencies (`?.`) address the taken-branch problem — the untaken branch uses optional chaining rather than creating a hard gate.                                  |
+| KREP-019 (Deferred Fields)      | Graph's `?.` optional chaining is the implementation of this KREP.                                                                                                       |
 
 ## Future Work
 

--- a/docs/design/proposals/graph.md
+++ b/docs/design/proposals/graph.md
@@ -54,17 +54,6 @@ We have the option to implement RGD's internals on top of Graph in the future, b
 term both implementations live as siblings sharing significant code in the underlying graph engine.
 Graph is additive — it does not replace or deprecate RGD.
 
-**Security posture:** A Graph author operates at the same privilege level as today's RGD author: the
-"infrastructure author" persona who defines what resources exist and how they relate. Graph authors
-have full control over everything KRO can do within the permissions granted to the KRO controller's
-service account.
-
-KRO's dual-persona model is preserved at higher layers. Authors (broad permissions) write
-RGDs/Graphs; consumers (narrow permissions scoped to the CRD the author created) interact only with
-the Kinds those Graphs implement, never with Graph objects directly. Future work on credential
-scoping (short-lived tokens, caller credentials, per-Graph service accounts) applies uniformly to
-all KRO primitives and is out of scope for this KREP.
-
 ## Proposed API
 
 ### The Graph Kind
@@ -115,10 +104,9 @@ cannot evaluate until the Deployment has been applied and its observed state is 
 
 ### Node Types
 
-Graph has five node types. Each is declared by a keyword on the node object. The types are split
-along two axes: **operation** (own, contribute, read, compute) and **scope shape** (single object
-vs. list). We choose explicit keywords over fewer types with strategy flags so that a reader knows
-what a node does — and what type it produces in scope — at a glance from the top-level keyword.
+Graph has five node types. Each is declared by a keyword on the node object. We choose explicit
+keywords over fewer types with strategy flags so that a reader knows what a node does — and what
+type it produces in scope — at a glance from the top-level keyword.
 
 #### `template:`
 
@@ -190,14 +178,13 @@ Pure computation — no Kubernetes resource created or read. The result enters s
 #### Dynamic GVKs
 
 A node's `apiVersion`, `kind`, and `metadata.name` can be CEL expressions. This enables patterns
-where the target resource type isn't known at author time — for example, watching instances of a
-Kind defined by an RGD whose schema is only known at runtime:
+where the target resource type isn't known at author time:
 
 ```yaml
 - id: watchInstances
   watch:
-    apiVersion: ${'${schema.spec.schema.group}'}/${'${schema.spec.schema.apiVersion}'}
-    kind: ${'${schema.spec.schema.kind}'}
+    apiVersion: ${crd.spec.group}/${crd.spec.versions[0].name}
+    kind: ${crd.spec.names.kind}
     selector:
       matchLabels: {}
 ```
@@ -221,8 +208,8 @@ Dependencies are inferred from CEL expressions. If node B's template contains `$
 depends on A. The compiler builds a DAG from these references and computes topological order. Cycles
 are compile-time errors.
 
-Before evaluating a node, kro reads its current state from the API server. This observed state
-enters scope under the node's `id`, making upstream fields available to downstream expressions.
+Each node's observed state (from a GET before apply) enters scope under its `id`. Downstream nodes
+reference these scope entries via CEL.
 
 #### Hard Dependencies
 
@@ -267,10 +254,12 @@ the Instance to pass health checks. Ready-gating forces sequential convergence; 
 the graph flow as fast as data allows, with `propagateWhen` available for cases where explicit
 health gates are needed.
 
-This enables RGD-as-Graph's status writeback via soft dependencies: a `patch:` node can reference
-all managed resources and run on every reconcile pass, progressively filling in available fields
-without deadlocking on readiness.
+This is what enables status writeback in the RGD-as-Graph implementation: a `patch:` node can
+reference all managed resources and run on every reconcile pass, progressively filling in available
+fields without deadlocking on readiness.
 
+Within a single Graph, nodes evaluate serially in topological order. Across Graphs, reconciliation
+is fully parallel: each Graph object is an independent work item in the controller's queue.
 `propagateWhen` (KREP-006) provides explicit gating when authors need to sequence mutations on
 health or other conditions. `readyWhen` determines the Graph's overall Ready condition and powers
 the `.ready()` lifecycle signal (also KREP-006). Both compose with Graph's recursive structure — see
@@ -286,10 +275,7 @@ Graph as a real cluster object. The child is persisted, reconciled independently
 own conditions and revision history — providing full debuggability via `kubectl get graph`. The
 combination of `forEach` + template:{kind: Graph} stamps one child Graph per item in a collection.
 This is how an RGD-equivalent is expressed — a per-RGD Graph stamps a per-instance Graph, each with
-its own scope, its own revisions, and its own lifecycle. Within a single Graph, nodes evaluate
-serially in topological order — one API call per node per reconcile pass. Across Graphs,
-reconciliation is fully parallel: each Graph object is an independent work item in the controller's
-queue.
+its own scope, its own revisions, and its own lifecycle.
 
 #### Deferral Boundaries
 
@@ -372,6 +358,19 @@ compilation failures and runtime issues.
 
 User-defined status does not live on the Graph object. It lives on custom resources and is written
 via `patch:` nodes. The Graph's status contains only controller-managed conditions.
+
+## Security Posture
+
+Graph does not introduce new privilege boundaries. A Graph author operates at the same privilege
+level as today's RGD author: the "infrastructure author" persona who defines what resources exist
+and how they relate. Graph authors have full control over everything KRO can do within the
+permissions granted to the KRO controller's service account.
+
+KRO's dual-persona model is preserved at higher layers. Authors (broad permissions) write
+RGDs/Graphs; consumers (narrow permissions scoped to the CRD the author created) interact only with
+the Kinds those Graphs implement, never with Graph objects directly. Future work on credential
+scoping (short-lived tokens, caller credentials, per-Graph service accounts) applies uniformly to
+all KRO primitives and is out of scope for this KREP.
 
 ## Relationship to Existing KREPs
 

--- a/docs/design/proposals/graph.md
+++ b/docs/design/proposals/graph.md
@@ -10,8 +10,8 @@ RGD today conflates Kind definition, instance management, and resource compositi
 Graph separates these — providing resource composition alone — making each concern independently
 usable. This enables patterns RGD cannot express: static resource bundles (no CRD needed),
 singletons (multiple contributors, one resource), and decorators (react to existing resources
-without defining a new Kind). Higher-level abstractions like RGD are built _from_ Graph, not
-alongside it; every feature added to Graph automatically benefits every abstraction layered on top.
+without defining a new Kind). Higher-level abstractions like RGD can be built _from_ Graph; every
+feature added to Graph automatically benefits every abstraction layered on top.
 
 Graph was validated by building the full RGD system from it. A single Graph implements the RGD
 controller — creating CRDs, watching instances, managing resources, writing status — all through
@@ -24,7 +24,7 @@ Beyond the RGD proof, Graph enables patterns that are simpler than what RGD can 
   NetworkPolicies. No CRD, no schema, no instance. (The decorator pattern from KREP-003.)
 - [Ingress fan-in](../../../examples/graph/ingress-fanin.yaml) — aggregate Services into a single
   Ingress with dynamic routes. (The aggregated-resource pattern from KREP-003.)
-- [KRO installation](../../../examples/graph/kro-install.yaml) — install kro itself as a Graph.
+- [CoreDNS installation](../../../examples/graph/coredns.yaml) — install CoreDNS as a Graph.
   The static-bundle pattern: dependency-ordered, health-aware, one object replaces a Helm chart.
 - [Singleton](../../../examples/graph/singleton.yaml) — fan-in with priority-based resolution
   when multiple actors claim the same resource.
@@ -215,12 +215,12 @@ computation. The result enters scope under the node's `id` like any other node.
 at scale — like the RGD implementation — require named intermediate computations to remain
 maintainable; `def:` provides them without creating cluster resources.
 
-#### `includeWhen` and `forEach`
+### Node Modifiers
 
-Graph retains `includeWhen` and `forEach` as node-level modifiers with the same semantics as in
-today's RGD. `includeWhen` conditionally excludes a node (making it a prune candidate when false).
-`forEach` stamps a node once per item in a collection. These are not redefined here — see KREP-008
-and KREP-002 respectively.
+`includeWhen` and `forEach` are node-level modifiers — they can be applied to any node type.
+`includeWhen` conditionally excludes a node (making it a prune candidate when false). `forEach`
+stamps a node once per item in a collection. Both retain the same semantics as in today's RGD and
+are not redefined here — see KREP-008 and KREP-002 respectively.
 
 #### Why ref and watch replace externalRef
 
@@ -245,6 +245,41 @@ When the compiler encounters a dynamic GVK, it uses a deferred-type path: the no
 permissively (untyped) until the first reconcile resolves the concrete GVK. This is what makes the
 RGD-from-Graph pattern possible — the user's Kind isn't known at compile time.
 
+### Dependencies
+
+Dependencies are inferred from CEL expressions. If node B's template contains `${A.field}`, B
+depends on A. The compiler builds a DAG from these references and computes topological order. Cycles
+are compile-time errors.
+
+#### Hard Dependencies
+
+A bare field reference creates a hard dependency:
+
+```cel
+${deployment.status.availableReplicas}
+```
+
+Node B cannot evaluate until node A has been applied and its observed state is in scope. This is the
+standard behavior — identical to today's RGD.
+
+#### Soft Dependencies
+
+Optional chaining creates a soft dependency:
+
+```cel
+${deployment.?status.?loadBalancer.orValue("pending")}
+```
+
+A soft dependency is _never_ gated. If the dependency hasn't been evaluated yet, the expression
+resolves to `optional.none()` — the field is omitted from the apply, not set to a zero value.
+`.orValue()` provides an explicit fallback when absence isn't acceptable. If the dependency has been
+evaluated, the full observed state is available.
+
+**Why soft dependencies exist:** Status writeback creates a dependency cycle: the `patch:` node
+references all managed resources, but can't hard-depend on all of them without blocking itself.
+Optional chaining breaks the cycle — the status node runs on every pass, filling in whatever is
+available, progressively transitioning from `IN_PROGRESS` to `ACTIVE`.
+
 ### readyWhen
 
 `readyWhen` is a list of CEL boolean expressions evaluated against the node's live state in the
@@ -262,10 +297,15 @@ cluster. When all are true, the node is considered _ready_.
 
 **readyWhen is a health signal. It does not gate downstream nodes.**
 
-This is an important behavioral difference from today's RGD. In the current implementation, a
-downstream node cannot evaluate until all its dependencies pass `readyWhen`. In Graph, evaluation
-proceeds as soon as dependencies are _in scope_ (have been applied and their observed state is
-available). `readyWhen` determines:
+This is a behavioral difference from today's RGD. In the current implementation, a downstream node
+cannot evaluate until all its dependencies pass `readyWhen`. In Graph, evaluation proceeds as soon as
+dependencies are _in scope_ (have been applied and their observed state is available). This means
+resources that don't need to wait — like a Service referencing a Deployment's labels — can apply
+immediately rather than blocking until the Deployment is fully rolled out. When you do want ordering,
+`propagateWhen` provides explicit gating (see below). The separation gives authors control over what
+waits and what doesn't, rather than coupling all ordering to health checks.
+
+`readyWhen` determines:
 
 1. Whether `.ready()` returns true for this node in CEL expressions
 2. Whether the **Graph itself** is Ready — the Graph's Ready condition is the conjunction of all
@@ -370,48 +410,14 @@ gate propagation to child Graphs, and each child Graph can independently gate pr
 resources — all from the same mechanism, no special-casing per layer. See KREP-006 for the broader
 motivation and design discussion.
 
-### Dependencies
-
-Dependencies are inferred from CEL expressions. If node B's template contains `${A.field}`, B
-depends on A. The compiler builds a DAG from these references and computes topological order. Cycles
-are compile-time errors.
-
-#### Hard Dependencies
-
-A bare field reference creates a hard dependency:
-
-```cel
-${deployment.status.availableReplicas}
-```
-
-Node B cannot evaluate until node A has been applied and its observed state is in scope. This is the
-standard behavior — identical to today's RGD.
-
-#### Soft Dependencies
-
-Optional chaining creates a soft dependency:
-
-```cel
-${deployment.?status.?loadBalancer.orValue("pending")}
-```
-
-A soft dependency is _never_ gated. If the dependency hasn't been evaluated yet, the expression
-resolves to `optional.none()` — the field is omitted from the apply, not set to a zero value.
-`.orValue()` provides an explicit fallback when absence isn't acceptable. If the dependency has been
-evaluated, the full observed state is available.
-
-**Why soft dependencies exist:** Status writeback creates a dependency cycle: the `patch:` node
-references all managed resources, but can't hard-depend on all of them without blocking itself.
-Optional chaining breaks the cycle — the status node runs on every pass, filling in whatever is
-available, progressively transitioning from `IN_PROGRESS` to `ACTIVE`.
-
 ### Nested Graphs
 
 When a node's template is itself a Graph, you get nested composition: a parent Graph that stamps a
 child Graph. You don't strictly need `forEach` for this — a single template node can create one
 child Graph — but the combination of `forEach` + template:{kind: Graph} is the powerful pattern. It
-stamps one child Graph per item in the collection. This is how RGD emerges — a per-RGD Graph stamps
-a per-instance Graph, each with its own scope, its own revisions, and its own lifecycle.
+stamps one child Graph per item in the collection. This is how an RGD-equivalent is expressed — a
+per-RGD Graph stamps a per-instance Graph, each with its own scope, its own revisions, and its own
+lifecycle.
 
 #### Deferral Boundaries
 
@@ -440,7 +446,7 @@ and runs the full compilation pipeline on it. A typo in a child expression, a ty
 child template, or a cycle in a child's dependency graph are all reported on the parent at compile
 time — not deferred until the child CR is created.
 
-## How RGD Emerges from Graph
+## Expressing RGD as Graph
 
 The RGD system is three levels of nested Graphs:
 
@@ -520,7 +526,8 @@ primitive extends. Beyond the core API proposed here, the prototype implements:
 - **`Kind` — a simplified RGD with graph-like semantics.** Defines a new Kubernetes Kind (CRD +
   per-instance Graphs) in a single object. Unlike RGD, Kind uses `readyWhen` and `propagateWhen`
   directly at the spec level, giving instance-level rollout control with no additional machinery.
-  Kind is the intended successor to RGD; the RGD compatibility layer is built on top of Kind.
+  Kind demonstrates how a higher-level abstraction composes Graph primitives; the RGD compatibility
+  layer in the prototype is built on top of Kind.
 - **Propagation control** — rate-limited rollouts, time-based gates, reactive controls (KREP-006
   covers the design; the prototype validates it composes with nested Graphs)
 - **Prometheus metric emission** (`metric:`) — emit gauges driven by CEL expressions

--- a/docs/design/proposals/graph.md
+++ b/docs/design/proposals/graph.md
@@ -20,49 +20,45 @@ compatibility test files, with remaining gaps due to prototype immaturity rather
 limitations (see [examples/graph/rgd.yaml](../../../examples/graph/rgd.yaml)).
 
 Beyond the RGD proof, Graph enables patterns that are simpler than what RGD can express today:
+
 - [Namespace decorator](../../../examples/graph/namespace-decorator.yaml) — watch namespaces, create
   NetworkPolicies. No CRD, no schema, no instance. (The decorator pattern from KREP-003.)
 - [Ingress fan-in](../../../examples/graph/ingress-fanin.yaml) — aggregate Services into a single
   Ingress with dynamic routes. (The aggregated-resource pattern from KREP-003.)
-- [CoreDNS installation](../../../examples/graph/coredns.yaml) — install CoreDNS as a Graph.
-  The static-bundle pattern: dependency-ordered, health-aware, one object replaces a Helm chart.
-- [Singleton](../../../examples/graph/singleton.yaml) — fan-in with priority-based resolution
-  when multiple actors claim the same resource.
+- [CoreDNS installation](../../../examples/graph/coredns.yaml) — install CoreDNS as a Graph. The
+  static-bundle pattern: dependency-ordered, health-aware, one object replaces a Helm chart.
+- [Singleton](../../../examples/graph/singleton.yaml) — fan-in with priority-based resolution when
+  multiple actors claim the same resource.
 
 ### What this KREP covers
 
 **Proposed:** The Graph Kind — node types (`template`, `patch`, `ref`, `watch`, `def`), dependency
-inference from CEL expressions, status conditions (`Compiled`, `Ready`), self-references, nested
-composition, and the decoupling of `readyWhen` from dependency gating (consistent with KREP-006's
-design discussion). In Graph, `readyWhen` is a health signal — it does not block downstream nodes.
-RGD's existing gating-on-readiness behavior is unchanged.
+inference from CEL expressions, the evaluation model (nodes evaluate when dependencies are in scope,
+not when they are ready), status conditions (`Compiled`, `Ready`), and nested composition. These are
+new primitives that do not exist in KRO today.
 
-**Inherited unchanged from RGD:** `includeWhen`, `forEach`, and CEL expression syntax. These
-mechanisms carry forward with the same semantics and are not redefined by this KREP.
+**Inherited unchanged from RGD:** `includeWhen`, `forEach`, `readyWhen`, and CEL expression syntax.
+These mechanisms carry forward with the same semantics and are not redefined by this KREP.
 
-**Adopted from KREP-006:** The `.ready()` and `.updated()` lifecycle signals, and the core semantics
-of `propagateWhen` as an explicit evaluation gate. Sections in this document define how these compose
-with Graph's recursive structure. Rollout strategies (`exponentiallyUpdated`, `linearlyUpdated`),
-collection-level defaults, and budget syntax are KREP-006's to define.
+**Defers to KREP-006:** `propagateWhen` gating semantics, `.ready()` and `.updated()` lifecycle
+signals, collection-level rollout strategies, and budget syntax. Graph supports all of these; their
+API and behavior are defined by KREP-006.
 
 **Relationship to RGD:** Graph is proposed as a sibling primitive. RGD continues to work unchanged.
 We have the option to implement RGD's internals on top of Graph in the future, but for the immediate
 term both implementations live as siblings sharing significant code in the underlying graph engine.
 Graph is additive — it does not replace or deprecate RGD.
 
-**Security posture:** Creating a Graph gives its author full control over everything KRO can do —
-creating, patching, deleting, and watching arbitrary Kubernetes resources within the permissions
-granted to the KRO controller's service account. A Graph author operates at the same privilege level
-as today's RGD author: the "infrastructure author" persona who defines what resources exist and how
-they relate.
+**Security posture:** A Graph author operates at the same privilege level as today's RGD author: the
+"infrastructure author" persona who defines what resources exist and how they relate. Graph authors
+have full control over everything KRO can do within the permissions granted to the KRO controller's
+service account.
 
 KRO's dual-persona model is preserved at higher layers. Authors (broad permissions) write
 RGDs/Graphs; consumers (narrow permissions scoped to the CRD the author created) interact only with
-the Kinds those Graphs implement, never with Graph objects directly. Graph is author-facing — end
-users never create or modify Graphs. Future work on credential scoping — short-lived tokens, caller
-credentials (analogous to how CloudFormation uses the caller's IAM role rather than the service's),
-or per-Graph service accounts — applies uniformly to all KRO primitives and is out of scope for this
-KREP.
+the Kinds those Graphs implement, never with Graph objects directly. Future work on credential
+scoping (short-lived tokens, caller credentials, per-Graph service accounts) applies uniformly to
+all KRO primitives and is out of scope for this KREP.
 
 ## Motivation: Graph as Scope
 
@@ -74,9 +70,7 @@ This isolation has three structural effects:
 
 1. **Concurrency is a consequence of scope boundaries.** A `forEach` over 1000 instances stamps 1000
    independent Graphs, each with its own scope and lifecycle, each reconciled independently.
-   Parallelism isn't a feature of the evaluation loop — it emerges from the isolation. Within a
-   single scope, serial evaluation is correct and sufficient: CEL evaluates in microseconds, each
-   node is one API call, and the API server — not the graph — is the throughput constraint.
+   Parallelism isn't a feature of the evaluation loop — it emerges from the isolation.
 
 2. **Propagation is scope-local.** A `propagateWhen` gate within a child Graph is invisible to the
    parent. The parent sees only the child's `Ready` condition. Rollout control composes without
@@ -137,23 +131,20 @@ cannot evaluate until the Deployment has been applied and its observed state is 
 
 ### Node Types
 
-Graph has five node types. Each is declared by a keyword on the node object.
+Graph has five node types. Each is declared by a keyword on the node object. The types are split
+along two axes: **operation** (own, contribute, read, compute) and **scope shape** (single object
+vs. list). We choose explicit keywords over fewer types with strategy flags so that a reader knows
+what a node does — and what type it produces in scope — at a glance from the top-level keyword.
 
 #### `template:`
 
-Creates and manages a Kubernetes resource. On creation the resource is applied via server-side
-apply. On deletion of the Graph, the resource is deleted. This is the direct equivalent of a
-`template:` resource in today's RGD.
+Creates and owns a Kubernetes resource via server-side apply. On deletion of the Graph, the resource
+is deleted.
 
 #### `patch:`
 
-Contributes fields to a resource you don't own. The resource must already exist — `patch:` does not
-create it. Fields are applied via server-side apply with a distinct field manager. On prune, the
-field claims are released (the field manager is removed), but the resource is not deleted.
-
-Common patterns: writing status back to a user-created instance, multiple writers to the same object
-(like HPA scaling a Deployment alongside a Graph managing its template), or any case where you
-express a partial claim on an existing resource.
+Contributes fields to a resource you don't own. The resource must already exist. On prune, your
+fields are released — the resource itself is not deleted.
 
 ```yaml
 - id: instanceStatus
@@ -169,9 +160,7 @@ express a partial claim on an existing resource.
 
 #### `ref:`
 
-Reads a single named resource into scope. No write, no ownership, no cleanup. The resource is
-identified by apiVersion, kind, and metadata (name/namespace). It enters scope as an object —
-downstream nodes can reference its fields via CEL.
+Reads a single named resource into scope as an object. No write, no ownership, no cleanup.
 
 ```yaml
 - id: config
@@ -185,8 +174,8 @@ downstream nodes can reference its fields via CEL.
 
 #### `watch:`
 
-Reads all resources of a GroupVersionKind matching a label selector into scope as a list. No write,
-no ownership, no cleanup.
+Reads all resources matching a label selector into scope as a list. No write, no ownership, no
+cleanup.
 
 ```yaml
 - id: allPods
@@ -203,8 +192,8 @@ Downstream nodes use standard CEL list operations:
 
 #### `def:`
 
-Defines raw data for use by other nodes. No Kubernetes resource is created or read — `def:` is pure
-computation. The result enters scope under the node's `id` like any other node.
+Pure computation — no Kubernetes resource created or read. The result enters scope under the node's
+`id`. This is Graph's implementation of the variables concept proposed in KREP-011.
 
 ```yaml
 - id: naming
@@ -214,20 +203,14 @@ computation. The result enters scope under the node's `id` like any other node.
       app: ${deployment.metadata.labels['app']}
 ```
 
-`def:` is Graph's implementation of the variables concept proposed in KREP-011. Graphs that compose
-at scale — like the RGD implementation — require named intermediate computations to remain
-maintainable; `def:` provides them without creating cluster resources.
-
-#### Why ref and watch replace externalRef
-
-`externalRef` in today's RGD overloads a single field to mean "read one named resource" and "watch a
-collection by selector." `ref:` and `watch:` make the operation — and the scope type (object vs
-list) — visible at a glance from the top-level keyword.
-
 #### Everything is a CEL expression
 
 Every string field in a node body — including `apiVersion`, `kind`, `metadata.name`, and selector
-values — can be a CEL expression. This enables dynamic GVKs:
+values — can be a CEL expression. Dynamic evaluation is the general case; statically-known GVKs are
+an optimization that enables compile-time type checking. When the compiler encounters a dynamic GVK,
+it uses a deferred-type path: the node compiles permissively (untyped) until the first reconcile
+resolves the concrete GVK. This is what makes the RGD-from-Graph pattern possible — the user's Kind
+isn't known at compile time.
 
 ```yaml
 - id: watchInstances
@@ -238,10 +221,6 @@ values — can be a CEL expression. This enables dynamic GVKs:
       matchLabels: {}
 ```
 
-When the compiler encounters a dynamic GVK, it uses a deferred-type path: the node compiles
-permissively (untyped) until the first reconcile resolves the concrete GVK. This is what makes the
-RGD-from-Graph pattern possible — the user's Kind isn't known at compile time.
-
 ### Node Modifiers
 
 `includeWhen` and `forEach` are node-level modifiers — they can be applied to any node type.
@@ -249,11 +228,20 @@ RGD-from-Graph pattern possible — the user's Kind isn't known at compile time.
 stamps a node once per item in a collection. Both retain the same semantics as in today's RGD and
 are not redefined here — see KREP-008 and KREP-002 respectively.
 
+| Modifier | Question it answers | When false | Defined in |
+| --- | --- | --- | --- |
+| `includeWhen` | Should this node exist? | Prune — resource deleted | KREP-008 |
+| `propagateWhen` | May this node mutate now? | Freeze — last-applied state persists | KREP-006 |
+| `readyWhen` | Is this node healthy? | Signal only — Graph not Ready | (inherited from RGD) |
+
 ### Dependencies
 
 Dependencies are inferred from CEL expressions. If node B's template contains `${A.field}`, B
 depends on A. The compiler builds a DAG from these references and computes topological order. Cycles
 are compile-time errors.
+
+Before evaluating a node, kro reads its current state from the API server. This observed state
+enters scope under the node's `id`, making upstream fields available to downstream expressions.
 
 #### Hard Dependencies
 
@@ -276,162 +264,38 @@ ${deployment.?status.?loadBalancer.orValue("pending")}
 
 A soft dependency is _never_ gated. If the dependency hasn't been evaluated yet, the expression
 resolves to `optional.none()` — the field is omitted from the apply, not set to a zero value.
-`.orValue()` provides an explicit fallback when absence isn't acceptable. If the dependency has been
-evaluated, the full observed state is available.
+`.orValue()` provides an explicit fallback when absence isn't acceptable.
 
 **Why soft dependencies exist:** Status writeback creates a dependency cycle: the `patch:` node
 references all managed resources, but can't hard-depend on all of them without blocking itself.
 Optional chaining breaks the cycle — the status node runs on every pass, filling in whatever is
-available, progressively transitioning from `IN_PROGRESS` to `ACTIVE`.
+available.
 
-### Self-References
+#### Evaluation Model
 
-Before evaluating a node's expressions, kro GETs the target resource from the API server. The live
-object — including `metadata` and `status` — enters scope under the node's `id`. This is the
-observed state: what exists before the node acts. On first create (GET returns 404), the scope entry
-is an empty map — expressions use optional chaining (`.?`, `.orValue()`) to provide defaults. After
-apply, the apply response replaces the scope entry — downstream nodes see post-apply state, not the
-pre-apply observation.
+A node evaluates as soon as its hard dependencies are in scope — meaning they have been applied and
+their observed state is available from the cluster. Nodes do not wait for dependencies to pass
+`readyWhen`. This is what enables status writeback via soft dependencies: a `patch:` node can
+reference all managed resources and run on every reconcile pass, progressively filling in available
+fields without deadlocking on readiness.
 
-Because observation precedes evaluation, a node can reference its own `id` in expressions to read
-its current state. This enables patterns that require continuity across reconciles:
-
-- **Condition transitions** — read existing `lastTransitionTime` and preserve it when status hasn't
-  changed, stamp `time.now()` only on actual transitions
-- **Latching and rotation** — don't regenerate a private key if one already exists in the Secret;
-  rotate by checking the existing key's age against a policy threshold
-- **Generation awareness** — compare `metadata.generation` against `status.observedGeneration` to
-  detect whether a resource has processed its latest spec
-
-Two derived signals expose node state for use in CEL expressions (adopted from KREP-006):
-
-```cel
-deployment.ready()    // true when readyWhen conditions are satisfied
-deployment.updated()  // true when evaluated against the current graph.metadata.generation
-```
-
-`.ready()` is syntactic sugar over self-reference — it evaluates the node's `readyWhen` against its
-observed state. `.updated()` reflects whether the node has been applied in the current generation
-(`graph.metadata.generation`, which increments on spec changes): its value is persisted as an
-annotation on the managed resource, so it survives controller restarts and is visible on GET.
-
-### Propagation
-
-Today's RGD gates downstream nodes on upstream readiness — a node cannot evaluate until its
-dependencies pass `readyWhen`. This is implicit propagation control: readiness and ordering are
-coupled. KREP-006 argues these should be separate concerns: `readyWhen` signals when a node is
-_healthy_; `propagateWhen` gates when a node may _mutate_. Graph implements this decoupling.
-
-#### `readyWhen`
-
-`readyWhen` is a list of CEL boolean expressions evaluated against the node's live state. When all
-are true, the node is considered _ready_.
-
-```yaml
-- id: deployment
-  readyWhen:
-    - ${deployment.status.availableReplicas == deployment.spec.replicas}
-  template:
-    apiVersion: apps/v1
-    kind: Deployment
-    ...
-```
-
-In Graph, `readyWhen` is purely a health signal. Downstream nodes proceed as soon as their
-dependencies are _in scope_ (applied, observed state available) — they do not wait for readiness.
-This means resources that don't need to wait — like a Service referencing a Deployment's labels —
-can apply immediately rather than blocking until the Deployment is fully rolled out.
-
-`readyWhen` determines:
-
-1. Whether `.ready()` returns true for this node in CEL expressions
-2. Whether the **Graph itself** is Ready — the Graph's Ready condition is the conjunction of all
-   nodes' `readyWhen` results
-
-#### `propagateWhen`
-
-When you _do_ want to gate on readiness (or any other condition), `propagateWhen` makes the ordering
-explicit and author-controlled:
-
-```yaml
-- id: migration
-  propagateWhen:
-    - ${database.ready()}
-  template:
-    apiVersion: batch/v1
-    kind: Job
-    metadata:
-      name: schema-migration
-    spec:
-      template:
-        spec:
-          containers:
-            - name: migrate
-              image: myapp/migrate:latest
-          restartPolicy: Never
-```
-
-When any `propagateWhen` expression evaluates to false, the node retains its last-applied state —
-it is not re-evaluated. When all expressions are true, evaluation proceeds normally. The default is
-`[]` (no gate — evaluate immediately). Where `includeWhen: false` prunes a node (deleting its
-resource), `propagateWhen: false` freezes it — the resource persists in its last-applied state.
-
-The separation gives authors control over what waits and what doesn't, rather than coupling all
-ordering to health checks. Most nodes need no gate at all — they apply as soon as their
-dependencies are in scope. The few that need sequencing declare it explicitly.
-
-#### Collections
-
-A forEach node is a single node in the DAG. Downstream nodes depend on it atomically — they see only
-the final state after all items are processed.
-
-Self-reference extends naturally to collections. A forEach node can reference its own collection in
-`propagateWhen` because it reads observed state, not evaluation output. Before iterating, the
-controller computes each item's resource identity from the iteration variable and batch-GETs all
-items. The collection enters scope as a list of observed states, each carrying `.updated()` and
-`.ready()` from the cluster.
-
-Items are then processed serially. For each item: evaluate `propagateWhen` against the current
-collection scope. If satisfied, evaluate the template, apply, and replace that item's scope slot
-with the apply response (which now carries the generation stamp). Items later in the iteration see
-the effects of items earlier — this is how propagation budgets tighten within a single reconcile
-pass.
-
-This makes collection-level propagation budgets expressible:
-
-> *The budget pattern below illustrates how `propagateWhen` composes with `forEach`. The rollout
-> API — including built-in strategies, budget syntax, and collection defaults — is defined by
-> KREP-006.*
-
-```yaml
-# Exponential rollout — budget doubles each wave
-- id: deployments
-  forEach:
-    - app: ${apps}
-  propagateWhen:
-    - >-
-      ${deployments.filter(d, d.updated() && !d.ready()).size()
-       < max(1, deployments.filter(d, d.updated() && d.ready()).size())}
-```
-
-The budget counts in-flight items (updated but not yet ready) against landed items (updated and
-ready). On first evaluation nothing is updated — the budget allows one item through. As items land,
-the budget grows, doubling capacity with each wave.
-
-Because Graph is recursive, `propagateWhen` composes at every level of nesting. A parent Graph can
-gate propagation to child Graphs, and each child Graph can independently gate propagation to its own
-resources — all from the same mechanism, no special-casing per layer. See KREP-006 for the broader
-motivation and design discussion.
+`propagateWhen` (KREP-006) provides explicit gating when authors need to sequence mutations on
+health or other conditions. `readyWhen` determines the Graph's overall Ready condition and powers
+the `.ready()` lifecycle signal (also KREP-006). Both compose with Graph's recursive structure — see
+KREP-006 for semantics, strategies, and collection-level defaults.
 
 ### Nested Graphs
 
-When a node's template is itself a Graph, you get nested composition: a parent Graph that stamps a
-child Graph as a real cluster object. The child Graph is persisted, reconciled independently, and
-carries its own conditions and revision history — providing full debuggability via `kubectl get
-graph`. You don't strictly need `forEach` for this — a single template node can create one child
-Graph — but the combination of `forEach` + template:{kind: Graph} is the powerful pattern. It stamps
-one child Graph per item in the collection. This is how an RGD-equivalent is expressed — a per-RGD
-Graph stamps a per-instance Graph, each with its own scope, its own revisions, and its own lifecycle.
+A `template:` node can contain any Kind — including Graph itself. Nesting isn't an opt-in feature;
+it emerges from the Kubernetes API. This KREP defines deferral and recursive-compilation semantics
+because nesting cannot be prevented, only left undefined.
+
+When a node's template is a Graph, you get nested composition: a parent Graph that stamps a child
+Graph as a real cluster object. The child is persisted, reconciled independently, and carries its own
+conditions and revision history — providing full debuggability via `kubectl get graph`. The
+combination of `forEach` + template:{kind: Graph} stamps one child Graph per item in a collection.
+This is how an RGD-equivalent is expressed — a per-RGD Graph stamps a per-instance Graph, each with
+its own scope, its own revisions, and its own lifecycle.
 
 #### Deferral Boundaries
 
@@ -452,8 +316,8 @@ name: ${rgd.metadata.name}
 group: ${'${rgd.spec.schema.group}'}
 ```
 
-This composes to arbitrary depth. `${'${"${...}"}'}` defers two levels — each layer evaluates one
-string literal, peeling off one level of quoting.
+This composes to arbitrary depth. Each layer evaluates one string literal, peeling off one level of
+quoting.
 
 #### Recursive Compilation
 
@@ -489,82 +353,65 @@ with detailed commentary on each level.
 
 ## Status
 
-Two conditions on orthogonal axes. Both use standard Kubernetes condition fields;
-`lastTransitionTime` is preserved when status is unchanged; `observedGeneration` advances
-independently per condition.
+A Graph has two conditions:
 
-**`Compiled`** — is the spec valid? Set once when the spec is processed, permanent until the spec
-changes. True on success; False on expression errors, dependency cycles, or malformed node
-declarations.
+**Compiled** — is the spec valid? Set once when the spec is processed. True on success; False on
+expression errors, dependency cycles, or malformed node declarations. Permanent until the spec
+changes.
 
-**`Ready`** — has the graph converged? `True` means all nodes are applied and their `readyWhen`
-conditions pass. `Unknown` means the controller is still making progress. `False` means something
-requires human intervention.
+**Ready** — has the graph converged? True means all nodes are applied and their readyWhen conditions
+pass. Unknown means the controller is still making progress. False means something requires human
+intervention.
 
-Compiled rolls into Ready: if the spec fails compilation, Ready is `False` with reason
-`NotCompiled`. A single alarm on `Ready` covers both compilation failures and runtime issues — there
-is no need to monitor Compiled separately.
+If compilation fails, Ready is False with reason NotCompiled. A single alarm on Ready covers both
+compilation failures and runtime issues.
 
-| Ready Reason | Status  | Meaning                                    |
-| ------------ | ------- | ------------------------------------------ |
-| Ready        | True    | All nodes applied and ready                |
-| NotReady     | Unknown | readyWhen not yet met                      |
-| Pending      | Unknown | Waiting for upstream data                  |
-| NotCompiled  | False   | Spec is invalid (rollup of Compiled=False) |
-| Conflict     | False   | SSA field ownership contested              |
-| Error        | False   | Client request failed (4xx)                |
-| SystemError  | False   | Infrastructure failure (5xx)               |
+| Ready Reason | Status  | Meaning                           |
+| ------------ | ------- | --------------------------------- |
+| Ready        | True    | All nodes applied and ready       |
+| NotReady     | Unknown | readyWhen not yet met             |
+| Pending      | Unknown | Waiting for upstream data         |
+| NotCompiled  | False   | Spec is invalid                   |
+| Conflict     | False   | SSA field ownership contested     |
+| Error        | False   | Client request failed (4xx)       |
+| SystemError  | False   | Infrastructure failure (5xx)      |
 
 User-defined status does not live on the Graph object. It lives on custom resources and is written
-via `patch:` nodes. The Graph's status contains only controller-managed fields — system conditions
-like `Compiled` never appear on user resources.
+via `patch:` nodes. The Graph's status contains only controller-managed conditions.
 
 ## Relationship to Existing KREPs
 
-| KREP                                       | Relationship                                                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| KREP-001 (Status Conditions)               | Graph changes where conditions live. System conditions (`Compiled`, `Ready`) exist on Graph objects — never on user resources. Users define their own status via `patch:` nodes. This separates system health (observable on Graph objects) from user-facing status (controlled by the graph author).                                                                                      |
-| KREP-002 (Collections)                     | Adopted unchanged. Graph extends it: when a forEach node's template is a Graph, you get recursive composition.                                                                                                                                                                                                                                                                             |
-| KREP-003 (Decorators)                      | A Decorator is naturally a Graph with `watch:` + `forEach`. No special runtime support needed. Graph also resolves the Singleton problem KREP-003 identified — a Graph needs no schema or CRD to self-instantiate.                                                                                                                                                                         |
-| KREP-006 (Propagation Control)             | Graph adopts KREP-006's lifecycle signals (`.ready()`, `.updated()`) and core `propagateWhen` gating semantics. KREP-006 provides the broader motivation (rate controls, reactive controls, manual controls), rollout strategies, and collection defaults. Because Graph is recursive, propagateWhen composes at every level of nesting — an RGD gets propagation control over instances, and each instance gets propagation control over resources, from a single mechanism. |
-| KREP-008 (includeWhen Resource References) | Graph implements `includeWhen` as a first-class modifier — when false, the node is excluded and becomes a prune candidate. This is distinct from `propagateWhen` (which freezes in place). In RGD, KREP-008 added complexity to make includeWhen reference upstream resources; in Graph, that works naturally because all modifiers participate in dependency inference.                   |
-| KREP-011 (Variables)                       | `def:` is Graph's implementation. Same semantics.                                                                                                                                                                                                                                                                                                                                          |
-| KREP-013 (Graph Revisions)                 | Applies to Graph unchanged. Because Graph is recursive, each nested Graph gets independent revisions. An RGD spec change revisions the L1 Graph; an instance spec change revisions L2. These are distinct — rolling back an RGD change does not require rolling back every instance.                                                                                                       |
-| KREP-014 (Resource Lifecycles)             | Graph's node types implicitly define lifecycle: `template:` = delete-on-prune, `patch:` = release-fields-on-prune. A per-node `lifecycle.apply: Force` flag was explored in prototyping to handle contested field ownership. Per-node lifecycle policies (Orphan, Retain) are a natural follow-on.                                                                                         |
-| KREP-018 (Partial Dependencies)            | CEL branching (`${cond ? A.field : B.field}`) and Graph's soft dependency mechanism (`?.`) together address partial dependency scenarios. Soft deps allow referencing a node without creating a hard gate — the taken-branch problem becomes less acute when the untaken branch uses optional chaining.                                                                                    |
-| KREP-019 (Deferred Fields & Soft Deps)     | Graph's `?.` optional chaining is the implementation of this KREP. Soft deps allow progressive field population across reconcile passes.                                                                                                                                                                                                                                                   |
+| KREP | Relationship |
+| --- | --- |
+| KREP-001 (Status Conditions) | System conditions (`Compiled`, `Ready`) exist on Graph objects — never on user resources. Users define their own status via `patch:` nodes. |
+| KREP-002 (Collections) | Adopted unchanged. Graph extends it: when a forEach node's template is a Graph, you get recursive composition. |
+| KREP-003 (Decorators) | A Decorator is naturally a Graph with `watch:` + `forEach`. No special runtime support needed. |
+| KREP-006 (Propagation Control) | Graph adopts KREP-006's lifecycle signals and `propagateWhen` gating. Because Graph is recursive, propagation composes at every nesting level. KREP-006 defines the API. |
+| KREP-008 (includeWhen) | Graph implements `includeWhen` as a first-class modifier. Dependency inference works naturally — no special handling needed. |
+| KREP-011 (Variables) | `def:` is Graph's implementation. Same semantics. |
+| KREP-013 (Graph Revisions) | Applies unchanged. Each nested Graph gets independent revisions. |
+| KREP-014 (Resource Lifecycles) | Graph's node types implicitly define lifecycle: `template:` = delete-on-prune, `patch:` = release-fields-on-prune. Per-node lifecycle policies are a natural follow-on. |
+| KREP-018 (Partial Dependencies) | Soft dependencies (`?.`) address the taken-branch problem — the untaken branch uses optional chaining rather than creating a hard gate. |
+| KREP-019 (Deferred Fields) | Graph's `?.` optional chaining is the implementation of this KREP. |
 
 ## Future Work
 
 Graph was validated through an extensive prototyping effort (Krocodile) that explored how far the
 primitive extends. Beyond the core API proposed here, the prototype implements:
 
-- **`Kind` — a simplified RGD with graph-like semantics.** Defines a new Kubernetes Kind (CRD +
-  per-instance Graphs) in a single object. Unlike RGD, Kind uses `readyWhen` and `propagateWhen`
-  directly at the spec level, giving instance-level rollout control with no additional machinery.
-  Kind demonstrates how a higher-level abstraction composes Graph primitives; the RGD compatibility
-  layer in the prototype is built on top of Kind.
+- **`Kind`** — a simplified RGD with graph-like semantics. Defines a new Kubernetes Kind (CRD +
+  per-instance Graphs) in a single object. Kind demonstrates how a higher-level abstraction composes
+  Graph primitives.
 - **Propagation control** — rate-limited rollouts, time-based gates, reactive controls (KREP-006
   covers the design; the prototype validates it composes with nested Graphs)
 - **Prometheus metric emission** (`metric:`) — emit gauges driven by CEL expressions
-- **Finalizer coordination** (`finalizes:`) — cross-resource cleanup ordering; finalizer nodes
-  materialize only when their target becomes a prune candidate
+- **Finalizer coordination** (`finalizes:`) — cross-resource cleanup ordering
 - **Time-based scheduling** — `time.now()` evaluated once per reconcile pass; the system solves for
-  the exact requeue deadline rather than polling.
-- **SSA ownership protocol** — field-level ownership tracking via server-side apply field managers,
-  with a per-node `lifecycle.apply: Force` flag for contested ownership.
-- **Reconciliation algorithm** — wavefront evaluation with topological ordering and prune in reverse
-  order
-- **CEL lifecycle functions** — `.dependencies()` returns a node's upstream dependency list;
-  `.condition()` encapsulates the Kubernetes status condition pattern with `lastTransitionTime`
-  preservation and `observedGeneration` tracking
-- **Cryptographic CEL functions** — `rsa.generateKey`, `ecdsa.generateKey`, `ed25519.generateKey`,
-  and `x509.createCertificateRequest` enable TLS bootstrapping inline in a Graph, eliminating the
-  need for cert-manager in simple certificate use cases
+  the exact requeue deadline rather than polling
+- **Cryptographic CEL functions** — `rsa.generateKey`, `x509.createCertificateRequest`, etc. enable
+  TLS bootstrapping inline in a Graph
 
 These features compose naturally with Graph but are separate design concerns, proposable
 incrementally. The key finding from Krocodile is that Graph's recursive structure means each feature
-added at one level automatically applies at every level of nesting. propagateWhen at L1 controls
-instance-level rollouts; the same mechanism at L2 controls per-resource rollouts. Graph Revisions at
-L1 track RGD spec changes; the same mechanism at L2 tracks instance changes independently. Nothing
-is special-cased per layer.
+added at one level automatically applies at every level of nesting. Nothing is special-cased per
+layer.

--- a/docs/design/proposals/graph.md
+++ b/docs/design/proposals/graph.md
@@ -6,11 +6,12 @@ Graph is a new `kro.run/v1alpha1` Kind — the atomic runtime primitive for comp
 resources. A Graph is a set of nodes evaluated in topological order. Create it and its resources
 converge; delete it and they cascade away. It is the simplest possible unit of composition in kro.
 
-ResourceGraphDefinition is a molecule built from this atom. RGD bundles together Kind definition,
-instance management, and resource composition into a single convenient abstraction. Graph separates
-these concerns, making each independently usable and enabling patterns that RGD cannot express:
-static resource bundles (no CRD needed), singletons (multiple contributors, one resource), and
-decorators (react to existing resources without defining a new Kind).
+RGD today conflates Kind definition, instance management, and resource composition into one object.
+Graph separates these — providing resource composition alone — making each concern independently
+usable. This enables patterns RGD cannot express: static resource bundles (no CRD needed),
+singletons (multiple contributors, one resource), and decorators (react to existing resources without
+defining a new Kind). Higher-level abstractions like RGD are built _from_ Graph, not alongside it;
+every feature added to Graph automatically benefits every abstraction layered on top.
 
 Graph was validated by building the full RGD system from it. A single Graph implements the RGD
 controller — creating CRDs, watching instances, managing resources, writing status — all through
@@ -18,22 +19,28 @@ composition rather than imperative Go code. This implementation passes 23 of 36 
 compatibility test files, with remaining gaps due to prototype immaturity rather than structural
 limitations (see [examples/graph/rgd.yaml](../../../examples/graph/rgd.yaml)).
 
-## Motivation
+## Motivation: Graph as Scope
 
-RGD conflates three concerns:
+A Graph is an **isolated scope**. Its nodes form a flat namespace — private, visible only within the
+Graph — with spec as input and status as output. Nothing inside a Graph is reachable from outside
+except through the Kubernetes resource boundary: the Graph object's own spec and status fields.
 
-1. **Kind definition** — creating a CRD with a schema
-2. **Instance management** — watching instances and reconciling them
-3. **Resource composition** — evaluating templates, managing dependencies
+This isolation is load-bearing in three ways:
 
-These are separable. An operator may want to compose resources without defining a new Kind (a static
-bundle, like a Helm release). A platform may want to watch existing resources and react to them
-without owning a CRD (a decorator). A system may want multiple actors to coordinate ownership of a
-single resource (a singleton).
+1. **Concurrency is a consequence of scope boundaries.** A `forEach` over 1000 instances stamps 1000
+   independent Graphs, each with its own scope and lifecycle, each reconciled independently.
+   Parallelism isn't a feature of the evaluation loop — it emerges from the isolation. Within a
+   single scope, serial evaluation is correct and sufficient: CEL evaluates in microseconds, each
+   node is one API call, and the API server — not the graph — is the throughput constraint.
 
-Graph provides (3) alone. Higher-level abstractions like RGD combine Graph with (1) and (2) — but
-they are built _from_ Graph, not alongside it. This means every feature added to Graph automatically
-benefits every abstraction layered on top.
+2. **Propagation is scope-local.** A `propagateWhen` gate within a child Graph is invisible to the
+   parent. The parent sees only the child's `Ready` condition. Rollout control composes without
+   leaking — a canary strategy inside one instance doesn't slow or block sibling instances.
+
+3. **Communication is explicit.** Graphs talk to each other only through the resources that bind
+   them: the spec of a child Graph stamped by a parent, a `ref` to a resource managed by another
+   Graph, or a `watch` on a Kind whose instances are managed elsewhere. There is no shared memory, no
+   implicit coupling, no cross-scope references.
 
 ## Proposed API
 

--- a/docs/design/proposals/graph.md
+++ b/docs/design/proposals/graph.md
@@ -9,9 +9,9 @@ converge; delete it and they cascade away. It is the simplest possible unit of c
 RGD today conflates Kind definition, instance management, and resource composition into one object.
 Graph separates these — providing resource composition alone — making each concern independently
 usable. This enables patterns RGD cannot express: static resource bundles (no CRD needed),
-singletons (multiple contributors, one resource), and decorators (react to existing resources without
-defining a new Kind). Higher-level abstractions like RGD are built _from_ Graph, not alongside it;
-every feature added to Graph automatically benefits every abstraction layered on top.
+singletons (multiple contributors, one resource), and decorators (react to existing resources
+without defining a new Kind). Higher-level abstractions like RGD are built _from_ Graph, not
+alongside it; every feature added to Graph automatically benefits every abstraction layered on top.
 
 Graph was validated by building the full RGD system from it. A single Graph implements the RGD
 controller — creating CRDs, watching instances, managing resources, writing status — all through
@@ -25,7 +25,7 @@ A Graph is an **isolated scope**. Its nodes form a flat namespace — private, v
 Graph — with spec as input and status as output. Nothing inside a Graph is reachable from outside
 except through the Kubernetes resource boundary: the Graph object's own spec and status fields.
 
-This isolation is load-bearing in three ways:
+This isolation has three structural effects:
 
 1. **Concurrency is a consequence of scope boundaries.** A `forEach` over 1000 instances stamps 1000
    independent Graphs, each with its own scope and lifecycle, each reconciled independently.
@@ -39,8 +39,8 @@ This isolation is load-bearing in three ways:
 
 3. **Communication is explicit.** Graphs talk to each other only through the resources that bind
    them: the spec of a child Graph stamped by a parent, a `ref` to a resource managed by another
-   Graph, or a `watch` on a Kind whose instances are managed elsewhere. There is no shared memory, no
-   implicit coupling, no cross-scope references.
+   Graph, or a `watch` on a Kind whose instances are managed elsewhere. There is no shared memory,
+   no implicit coupling, no cross-scope references.
 
 ## Proposed API
 
@@ -168,9 +168,9 @@ computation. The result enters scope under the node's `id` like any other node.
       app: ${deployment.metadata.labels['app']}
 ```
 
-`def:` is Graph's implementation of the variables concept proposed in KREP-011. It satisfies the same
-requirements — named intermediate computations, deduplication of repeated expressions, and composing
-with `forEach` to build computed lists (e.g., a container list assembled from a spec field).
+`def:` is Graph's implementation of the variables concept proposed in KREP-011. Graphs that compose
+at scale — like the RGD implementation — require named intermediate computations to remain
+maintainable; `def:` provides them without creating cluster resources.
 
 #### `includeWhen` and `forEach`
 
@@ -202,29 +202,10 @@ When the compiler encounters a dynamic GVK, it uses a deferred-type path: the no
 permissively (untyped) until the first reconcile resolves the concrete GVK. This is what makes the
 RGD-from-Graph pattern possible — the user's Kind isn't known at compile time.
 
-### Observed State
-
-Before evaluating a node's expressions, kro GETs the target resource from the API server. The live
-object — including `metadata` and `status` — enters scope under the node's `id`. This is the
-observed state: what exists before the node acts.
-
-On first create (GET returns 404), the scope entry is an empty map. Expressions use optional
-chaining (`.?`, `.orValue()`) to provide defaults. After apply, the apply response replaces the
-scope entry — downstream nodes see post-apply state, not the pre-apply observation.
-
-**Self-reference:** A node can reference its own `id` in its expressions to read its current state.
-This enables patterns that require continuity across reconciles:
-
-- **Condition transitions** — read existing `lastTransitionTime` and preserve it when status hasn't
-  changed, stamp `time.now()` only on actual transitions
-- **Latching** — don't regenerate a private key if one already exists in the Secret
-- **Generation awareness** — compare `metadata.generation` against `status.observedGeneration` to
-  detect whether a resource has processed its latest spec
-
 ### readyWhen
 
-`readyWhen` is a list of CEL boolean expressions evaluated against a node's observed state. When all
-are true, the node is considered _ready_.
+`readyWhen` is a list of CEL boolean expressions evaluated against the node's live state in the
+cluster. When all are true, the node is considered _ready_.
 
 ```yaml
 - id: deployment
@@ -247,10 +228,6 @@ available). `readyWhen` determines:
 2. Whether the **Graph itself** is Ready — the Graph's Ready condition is the conjunction of all
    nodes' `readyWhen` results
 
-This is analogous to how Helm determines release readiness: the release is "ready" when all its
-resources pass their health checks, but resources are not blocked from being created by the health
-state of other resources.
-
 ### propagateWhen
 
 `propagateWhen` is the complement to `readyWhen`. Where `readyWhen` signals when a node is healthy,
@@ -269,21 +246,59 @@ state of other resources.
 
 When any `propagateWhen` expression evaluates to false, the node and all its dependents are not
 re-evaluated — they remain in their previous state. When all expressions are true, evaluation
-proceeds normally. The default is `[]` (no gate — evaluate immediately).
+proceeds normally. The default is `[]` (no gate — evaluate immediately). Where `includeWhen: false`
+prunes a node (deleting its resource), `propagateWhen: false` freezes it — the resource persists in
+its last-applied state.
 
-This is the mechanism for users who want the current RGD behavior where readyWhen gates dependents.
-In Graph, that behavior is opt-in: add `propagateWhen: [${dep.ready()}]` to get explicit gating.
+### Self-References
 
-#### Lifecycle Methods
+Before evaluating a node's expressions, kro GETs the target resource from the API server. The live
+object — including `metadata` and `status` — enters scope under the node's `id`. This is the
+observed state: what exists before the node acts. On first create (GET returns 404), the scope entry
+is an empty map — expressions use optional chaining (`.?`, `.orValue()`) to provide defaults. After
+apply, the apply response replaces the scope entry — downstream nodes see post-apply state, not the
+pre-apply observation.
 
-Two lifecycle methods expose node state for use in `propagateWhen` and other CEL expressions:
+Because observation precedes evaluation, a node can reference its own `id` in expressions to read
+its current state. This enables patterns that require continuity across reconciles:
+
+- **Condition transitions** — read existing `lastTransitionTime` and preserve it when status hasn't
+  changed, stamp `time.now()` only on actual transitions
+- **Latching and rotation** — don't regenerate a private key if one already exists in the Secret;
+  rotate by checking the existing key's age against a policy threshold
+- **Generation awareness** — compare `metadata.generation` against `status.observedGeneration` to
+  detect whether a resource has processed its latest spec
+
+Two derived signals expose node state for use in CEL expressions:
 
 ```cel
 deployment.ready()    // true when readyWhen conditions are satisfied
-deployment.updated()  // true when evaluated against the current graph generation
+deployment.updated()  // true when evaluated against the current graph.metadata.generation
 ```
 
-These enable propagation patterns:
+`.ready()` is syntactic sugar over self-reference — it evaluates the node's `readyWhen` against its
+observed state. `.updated()` reflects whether the node has been applied in the current generation
+(`graph.metadata.generation`, which increments on spec changes): its value is persisted as an
+annotation on the managed resource, so it survives controller restarts and is visible on GET.
+
+#### Collections
+
+A forEach node is a single node in the DAG. Downstream nodes depend on it atomically — they see only
+the final state after all items are processed.
+
+Self-reference extends naturally to collections. A forEach node can reference its own collection in
+`propagateWhen` because it reads observed state, not evaluation output. Before iterating, the
+controller computes each item's resource identity from the iteration variable and batch-GETs all
+items. The collection enters scope as a list of observed states, each carrying `.updated()` and
+`.ready()` from the cluster.
+
+Items are then processed serially. For each item: evaluate `propagateWhen` against the current
+collection scope. If satisfied, evaluate the template, apply, and replace that item's scope slot
+with the apply response (which now carries the generation stamp). Items later in the iteration see
+the effects of items earlier — this is how propagation budgets tighten within a single reconcile
+pass.
+
+This makes collection-level propagation budgets expressible:
 
 ```yaml
 # Exponential rollout — budget doubles each wave
@@ -296,8 +311,12 @@ These enable propagation patterns:
        < max(1, deployments.filter(d, d.updated() && d.ready()).size())}
 ```
 
-Because Graph is recursive, `propagateWhen` composes at every level of nesting. In the RGD
-implementation: L1 can gate propagation to instances, and L2 can gate propagation to individual
+The budget counts in-flight items (updated but not yet ready) against landed items (updated and
+ready). On first evaluation nothing is updated — the budget allows one item through. As items land,
+the budget grows, doubling capacity with each wave.
+
+Because Graph is recursive, `propagateWhen` composes at every level of nesting. A parent Graph can
+gate propagation to child Graphs, and each child Graph can independently gate propagation to its own
 resources — all from the same mechanism, no special-casing per layer. See KREP-006 for the broader
 motivation and design discussion.
 
@@ -327,7 +346,8 @@ ${deployment.?status.?loadBalancer.orValue("pending")}
 ```
 
 A soft dependency is _never_ gated. If the dependency hasn't been evaluated yet, the expression
-resolves to `optional.none()`, and `.orValue()` provides the fallback. If the dependency has been
+resolves to `optional.none()` — the field is omitted from the apply, not set to a zero value.
+`.orValue()` provides an explicit fallback when absence isn't acceptable. If the dependency has been
 evaluated, the full observed state is available.
 
 **Why soft dependencies exist:** Status writeback creates a dependency cycle: the `patch:` node
@@ -365,51 +385,10 @@ This composes to arbitrary depth. `${${${...}}}` defers two levels.
 
 #### Recursive Compilation
 
-Recursive compilation enables parent-time error detection for child Graph expressions. When the
-compiler detects nested `${${...}}` patterns, it type-checks inner expressions against the child's
-statically known node list. When the child template is literally a Graph (the apiVersion/kind is
-`kro.run/v1alpha1 Graph`), the compiler extracts the child spec, strips one deferral level, and runs
-the full compilation pipeline on it.
-
-This means: a typo in a child expression, a type mismatch in a child template, or a cycle in a
-child's dependency graph are all reported on the parent at compile time. Without this, errors in
-child expressions would only surface after the child CR is created and its controller attempts
-compilation — a delayed feedback loop. Recursive compilation makes it immediate.
-
-#### Lifecycle Coupling
-
-Nested Graphs use `ownerReferences` to tie child lifecycle to parent. When the owner is deleted,
-Kubernetes cascades the delete to the child Graph, triggering its ordered teardown. But Kubernetes
-cascade is asynchronous — without coordination, the owner can complete deletion while teardown is
-still running, orphaning managed resources. To prevent this, the child Graph places a finalizer on
-the owner via a `patch:` node:
-
-```yaml
-metadata:
-  ownerReferences:
-    - apiVersion: apps.example.com/v1
-      kind: WebApp
-      name: my-instance
-      uid: ...
-spec:
-  nodes:
-    - id: lifecycle
-      patch:
-        apiVersion: apps.example.com/v1
-        kind: WebApp
-        metadata:
-          name: my-instance
-          finalizers:
-            - kro.run/graph
-    - id: deployment
-      template: ...
-```
-
-The ownerReference triggers self-deletion when the instance enters Terminating. The `patch:` node
-holds the instance until teardown completes — all template resources are pruned in reverse DAG
-order, then the patch releases the finalizer as its last act, and the instance finishes deletion.
-This pattern is load-bearing for the RGD implementation: each per-instance Graph (L2) holds a
-finalizer on its instance, ensuring no managed resources are orphaned on deletion.
+When the child template is a Graph, the compiler extracts the child spec, strips one deferral level,
+and runs the full compilation pipeline on it. A typo in a child expression, a type mismatch in a
+child template, or a cycle in a child's dependency graph are all reported on the parent at compile
+time — not deferred until the child CR is created.
 
 ## How RGD Emerges from Graph
 
@@ -451,18 +430,18 @@ conditions pass. `Unknown` means the controller is still making progress. `False
 requires human intervention.
 
 Compiled rolls into Ready: if the spec fails compilation, Ready is `False` with reason
-`NotCompiled`. A single alarm on `Ready` covers both compilation failures and runtime issues —
-there is no need to monitor Compiled separately.
+`NotCompiled`. A single alarm on `Ready` covers both compilation failures and runtime issues — there
+is no need to monitor Compiled separately.
 
-| Ready Reason  | Status    | Meaning                            |
-|---------------|-----------|------------------------------------|
-| Ready         | True      | All nodes applied and ready        |
-| NotReady      | Unknown   | readyWhen not yet met              |
-| Pending       | Unknown   | Waiting for upstream data          |
-| NotCompiled   | False     | Spec is invalid (rollup of Compiled=False) |
-| Conflict      | False     | SSA field ownership contested      |
-| Error         | False     | Client request failed (4xx)        |
-| SystemError   | False     | Infrastructure failure (5xx)       |
+| Ready Reason | Status  | Meaning                                    |
+| ------------ | ------- | ------------------------------------------ |
+| Ready        | True    | All nodes applied and ready                |
+| NotReady     | Unknown | readyWhen not yet met                      |
+| Pending      | Unknown | Waiting for upstream data                  |
+| NotCompiled  | False   | Spec is invalid (rollup of Compiled=False) |
+| Conflict     | False   | SSA field ownership contested              |
+| Error        | False   | Client request failed (4xx)                |
+| SystemError  | False   | Infrastructure failure (5xx)               |
 
 User-defined status does not live on the Graph object. It lives on custom resources and is written
 via `patch:` nodes. The Graph's status contains only controller-managed fields — system conditions
@@ -473,11 +452,11 @@ like `Compiled` never appear on user resources.
 | KREP                                       | Relationship                                                                                                                                                                                                                                                                                                                                                                               |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | KREP-001 (Status Conditions)               | Graph changes where conditions live. System conditions (`Compiled`, `Ready`) exist on Graph objects — never on user resources. Users define their own status via `patch:` nodes. This separates system health (observable on Graph objects) from user-facing status (controlled by the graph author).                                                                                      |
-| KREP-002 (Collections)                     | Adopted unchanged. Graph extends it: when a forEach node's template is a Graph, you get recursive composition.                                                                                                                                                                                                                                                                              |
+| KREP-002 (Collections)                     | Adopted unchanged. Graph extends it: when a forEach node's template is a Graph, you get recursive composition.                                                                                                                                                                                                                                                                             |
 | KREP-003 (Decorators)                      | A Decorator is naturally a Graph with `watch:` + `forEach`. No special runtime support needed. Graph also resolves the Singleton problem KREP-003 identified — a Graph needs no schema or CRD to self-instantiate.                                                                                                                                                                         |
 | KREP-006 (Propagation Control)             | This KREP defines `propagateWhen`'s core semantics. KREP-006 provides the broader motivation (rate controls, reactive controls, manual controls) and design discussion. Because Graph is recursive, propagateWhen composes at every level of nesting — an RGD gets propagation control over instances, and each instance gets propagation control over resources, from a single mechanism. |
 | KREP-008 (includeWhen Resource References) | Graph implements `includeWhen` as a first-class modifier — when false, the node is excluded and becomes a prune candidate. This is distinct from `propagateWhen` (which freezes in place). In RGD, KREP-008 added complexity to make includeWhen reference upstream resources; in Graph, that works naturally because all modifiers participate in dependency inference.                   |
-| KREP-011 (Variables)                       | `def:` is Graph's implementation. Same semantics.                                                                                                                                                                                                                                                                                                                                            |
+| KREP-011 (Variables)                       | `def:` is Graph's implementation. Same semantics.                                                                                                                                                                                                                                                                                                                                          |
 | KREP-013 (Graph Revisions)                 | Applies to Graph unchanged. Because Graph is recursive, each nested Graph gets independent revisions. An RGD spec change revisions the L1 Graph; an instance spec change revisions L2. These are distinct — rolling back an RGD change does not require rolling back every instance.                                                                                                       |
 | KREP-014 (Resource Lifecycles)             | Graph's node types implicitly define lifecycle: `template:` = delete-on-prune, `patch:` = release-fields-on-prune. A per-node `lifecycle.apply: Force` flag was explored in prototyping to handle contested field ownership. Per-node lifecycle policies (Orphan, Retain) are a natural follow-on.                                                                                         |
 | KREP-018 (Partial Dependencies)            | CEL branching (`${cond ? A.field : B.field}`) and Graph's soft dependency mechanism (`?.`) together address partial dependency scenarios. Soft deps allow referencing a node without creating a hard gate — the taken-branch problem becomes less acute when the untaken branch uses optional chaining.                                                                                    |
@@ -497,16 +476,15 @@ primitive extends. Beyond the core API proposed here, the prototype implements:
 - **Prometheus metric emission** (`metric:`) — emit gauges driven by CEL expressions
 - **Finalizer coordination** (`finalizes:`) — cross-resource cleanup ordering; finalizer nodes
   materialize only when their target becomes a prune candidate
-- **Time-based scheduling** — `time.now()` comparisons that solve for the exact future timestamp and
-  enqueue reconciliation precisely
+- **Time-based scheduling** — `time.now()` evaluated once per reconcile pass; the system solves for
+  the exact requeue deadline rather than polling.
 - **SSA ownership protocol** — field-level ownership tracking via server-side apply field managers,
-  with a per-node `lifecycle.apply: Force` flag for contested ownership. On deletion, templates are
-  fully pruned before patch field claims are released (ordering invariant).
+  with a per-node `lifecycle.apply: Force` flag for contested ownership.
 - **Reconciliation algorithm** — wavefront evaluation with topological ordering and prune in reverse
   order
-- **CEL lifecycle functions** — `.dependencies()` returns a node's upstream dependency list (enables
-  `${node.dependencies().all(d, d.ready())}`); `.condition()` encapsulates the Kubernetes status
-  condition pattern with `lastTransitionTime` preservation and `observedGeneration` tracking
+- **CEL lifecycle functions** — `.dependencies()` returns a node's upstream dependency list;
+  `.condition()` encapsulates the Kubernetes status condition pattern with `lastTransitionTime`
+  preservation and `observedGeneration` tracking
 - **Cryptographic CEL functions** — `rsa.generateKey`, `ecdsa.generateKey`, `ed25519.generateKey`,
   and `x509.createCertificateRequest` enable TLS bootstrapping inline in a Graph, eliminating the
   need for cert-manager in simple certificate use cases

--- a/docs/design/proposals/graph.md
+++ b/docs/design/proposals/graph.md
@@ -6,6 +6,11 @@ Graph is a new `kro.run/v1alpha1` Kind — the atomic primitive for composing Ku
 Graph is a set of nodes evaluated in topological order. Create it and its resources converge; delete
 it and they cascade away. It is the simplest possible unit of composition in kro.
 
+A Graph is analogous to a **scope** in traditional programming languages. Its nodes form a flat
+namespace — private, visible only within the Graph — with spec as input and status as output.
+Nothing inside a Graph is reachable from outside except through the Kubernetes resource boundary:
+the Graph object's own spec and status fields. Graphs are reconciled independently and in parallel.
+
 RGD today combines CRD management, instance management, and resource composition into one object.
 Graph separates these — providing resource composition alone — making each concern independently
 usable. This enables patterns RGD cannot express: static resource bundles (no CRD needed),
@@ -59,16 +64,6 @@ RGDs/Graphs; consumers (narrow permissions scoped to the CRD the author created)
 the Kinds those Graphs implement, never with Graph objects directly. Future work on credential
 scoping (short-lived tokens, caller credentials, per-Graph service accounts) applies uniformly to
 all KRO primitives and is out of scope for this KREP.
-
-## Graph as a Scope
-
-A Graph is analogous to a **scope** in traditional programming languages. Its nodes form a flat
-namespace — private, visible only within the Graph — with spec as input and status as output.
-Nothing inside a Graph is reachable from outside except through the Kubernetes resource boundary:
-the Graph object's own spec and status fields. Concurrency is a structural consequence of this
-isolation: a `forEach` over 1000 instances stamps 1000 independent Graphs, each reconciled
-independently. Parallelism isn't a feature of the evaluation loop — it emerges from the scope
-boundary.
 
 ## Proposed API
 
@@ -210,9 +205,9 @@ Kind defined by an RGD whose schema is only known at runtime:
 ### Node Modifiers
 
 `includeWhen` and `forEach` are node-level modifiers — they can be applied to any node type.
-`includeWhen` conditionally excludes a node (making it a prune candidate when false). `forEach`
-stamps a node once per item in a collection. Both retain the same semantics as in today's RGD and
-are not redefined here — see KREP-008 and KREP-002 respectively.
+`includeWhen` conditionally includes a node — when false, the node becomes a prune candidate.
+`forEach` stamps a node once per item in a collection. Both retain the same semantics as in today's
+RGD and are not redefined here — see KREP-008 and KREP-002 respectively.
 
 | Modifier        | Question it answers       | When false                           | Defined in           |
 | --------------- | ------------------------- | ------------------------------------ | -------------------- |
@@ -261,9 +256,20 @@ available.
 
 A node evaluates as soon as its hard dependencies are in scope — meaning they have been applied and
 their observed state is available from the cluster. Nodes do not wait for dependencies to pass
-`readyWhen`. This is what enables status writeback via soft dependencies: a `patch:` node can
-reference all managed resources and run on every reconcile pass, progressively filling in available
-fields without deadlocking on readiness.
+`readyWhen`.
+
+Consider a Deployment and a Service: the Service's selector references the Deployment's labels.
+Under ready-gating, the Service cannot be created until the Deployment's replicas are available —
+minutes of unnecessary waiting. Under scope-gating, the Service is created as soon as the Deployment
+exists and its labels are observable (seconds). The same pattern appears broadly: an EC2
+NetworkInterface can attach to an Instance as soon as the Instance ID is known, without waiting for
+the Instance to pass health checks. Ready-gating forces sequential convergence; scope-gating lets
+the graph flow as fast as data allows, with `propagateWhen` available for cases where explicit
+health gates are needed.
+
+This enables RGD-as-Graph's status writeback via soft dependencies: a `patch:` node can reference
+all managed resources and run on every reconcile pass, progressively filling in available fields
+without deadlocking on readiness.
 
 `propagateWhen` (KREP-006) provides explicit gating when authors need to sequence mutations on
 health or other conditions. `readyWhen` determines the Graph's overall Ready condition and powers
@@ -280,7 +286,10 @@ Graph as a real cluster object. The child is persisted, reconciled independently
 own conditions and revision history — providing full debuggability via `kubectl get graph`. The
 combination of `forEach` + template:{kind: Graph} stamps one child Graph per item in a collection.
 This is how an RGD-equivalent is expressed — a per-RGD Graph stamps a per-instance Graph, each with
-its own scope, its own revisions, and its own lifecycle.
+its own scope, its own revisions, and its own lifecycle. Within a single Graph, nodes evaluate
+serially in topological order — one API call per node per reconcile pass. Across Graphs,
+reconciliation is fully parallel: each Graph object is an independent work item in the controller's
+queue.
 
 #### Deferral Boundaries
 

--- a/docs/design/proposals/graph.md
+++ b/docs/design/proposals/graph.md
@@ -6,7 +6,7 @@ Graph is a new `kro.run/v1alpha1` Kind — the atomic runtime primitive for comp
 resources. A Graph is a set of nodes evaluated in topological order. Create it and its resources
 converge; delete it and they cascade away. It is the simplest possible unit of composition in kro.
 
-RGD today conflates Kind definition, instance management, and resource composition into one object.
+RGD today combines Kind definition, instance management, and resource composition into one object.
 Graph separates these — providing resource composition alone — making each concern independently
 usable. This enables patterns RGD cannot express: static resource bundles (no CRD needed),
 singletons (multiple contributors, one resource), and decorators (react to existing resources
@@ -32,16 +32,18 @@ Beyond the RGD proof, Graph enables patterns that are simpler than what RGD can 
 ### What this KREP covers
 
 **Proposed:** The Graph Kind — node types (`template`, `patch`, `ref`, `watch`, `def`), dependency
-inference from CEL expressions, status conditions (`Compiled`, `Ready`), self-references, and nested
-composition. These are new primitives that do not exist in KRO today.
+inference from CEL expressions, status conditions (`Compiled`, `Ready`), self-references, nested
+composition, and the decoupling of `readyWhen` from dependency gating (consistent with KREP-006's
+design discussion). In Graph, `readyWhen` is a health signal — it does not block downstream nodes.
+RGD's existing gating-on-readiness behavior is unchanged.
 
 **Inherited unchanged from RGD:** `includeWhen`, `forEach`, and CEL expression syntax. These
 mechanisms carry forward with the same semantics and are not redefined by this KREP.
 
-**Directional (defers to respective KREPs):** `propagateWhen` semantics (KREP-006), collection-level
-rollout budgets (KREP-006), and `readyWhen` behavioral differences from the current RGD
-implementation. Sections in this document illustrate how these features compose with Graph's
-recursive structure, but their final API and semantics are defined by their respective KREPs.
+**Adopted from KREP-006:** The `.ready()` and `.updated()` lifecycle signals, and the core semantics
+of `propagateWhen` as an explicit evaluation gate. Sections in this document define how these compose
+with Graph's recursive structure. Rollout strategies (`exponentiallyUpdated`, `linearlyUpdated`),
+collection-level defaults, and budget syntax are KREP-006's to define.
 
 **Relationship to RGD:** Graph is proposed as a sibling primitive. RGD continues to work unchanged.
 We have the option to implement RGD's internals on top of Graph in the future, but for the immediate
@@ -128,10 +130,10 @@ spec:
             - port: 80
 ```
 
-A Graph is namespaced. Its `spec.nodes` is an ordered list where each node has an `id` and exactly
-one type keyword. The `${deployment.metadata.name}` expression in the Service creates a dependency
-edge: the Service cannot evaluate until the Deployment has been applied and its observed state is
-available.
+A Graph is namespaced. Its `spec.nodes` is a list where each node has an `id` and exactly one type
+keyword. Evaluation order is derived from dependencies, not list position. The
+`${deployment.metadata.name}` expression in the Service creates a dependency edge: the Service
+cannot evaluate until the Deployment has been applied and its observed state is available.
 
 ### Node Types
 
@@ -192,7 +194,8 @@ no ownership, no cleanup.
     apiVersion: v1
     kind: Pod
     selector:
-      app: my-app
+      matchLabels:
+        app: my-app
 ```
 
 Downstream nodes use standard CEL list operations:
@@ -215,13 +218,6 @@ computation. The result enters scope under the node's `id` like any other node.
 at scale — like the RGD implementation — require named intermediate computations to remain
 maintainable; `def:` provides them without creating cluster resources.
 
-### Node Modifiers
-
-`includeWhen` and `forEach` are node-level modifiers — they can be applied to any node type.
-`includeWhen` conditionally excludes a node (making it a prune candidate when false). `forEach`
-stamps a node once per item in a collection. Both retain the same semantics as in today's RGD and
-are not redefined here — see KREP-008 and KREP-002 respectively.
-
 #### Why ref and watch replace externalRef
 
 `externalRef` in today's RGD overloads a single field to mean "read one named resource" and "watch a
@@ -236,14 +232,22 @@ values — can be a CEL expression. This enables dynamic GVKs:
 ```yaml
 - id: watchInstances
   watch:
-    apiVersion: ${${schema.spec.schema.group}}/${${schema.spec.schema.apiVersion}}
-    kind: ${${schema.spec.schema.kind}}
-    selector: {}
+    apiVersion: ${'${schema.spec.schema.group}'}/${'${schema.spec.schema.apiVersion}'}
+    kind: ${'${schema.spec.schema.kind}'}
+    selector:
+      matchLabels: {}
 ```
 
 When the compiler encounters a dynamic GVK, it uses a deferred-type path: the node compiles
 permissively (untyped) until the first reconcile resolves the concrete GVK. This is what makes the
 RGD-from-Graph pattern possible — the user's Kind isn't known at compile time.
+
+### Node Modifiers
+
+`includeWhen` and `forEach` are node-level modifiers — they can be applied to any node type.
+`includeWhen` conditionally excludes a node (making it a prune candidate when false). `forEach`
+stamps a node once per item in a collection. Both retain the same semantics as in today's RGD and
+are not redefined here — see KREP-008 and KREP-002 respectively.
 
 ### Dependencies
 
@@ -280,63 +284,6 @@ references all managed resources, but can't hard-depend on all of them without b
 Optional chaining breaks the cycle — the status node runs on every pass, filling in whatever is
 available, progressively transitioning from `IN_PROGRESS` to `ACTIVE`.
 
-### readyWhen
-
-`readyWhen` is a list of CEL boolean expressions evaluated against the node's live state in the
-cluster. When all are true, the node is considered _ready_.
-
-```yaml
-- id: deployment
-  readyWhen:
-    - ${deployment.status.availableReplicas == deployment.spec.replicas}
-  template:
-    apiVersion: apps/v1
-    kind: Deployment
-    ...
-```
-
-**readyWhen is a health signal. It does not gate downstream nodes.**
-
-This is a behavioral difference from today's RGD. In the current implementation, a downstream node
-cannot evaluate until all its dependencies pass `readyWhen`. In Graph, evaluation proceeds as soon as
-dependencies are _in scope_ (have been applied and their observed state is available). This means
-resources that don't need to wait — like a Service referencing a Deployment's labels — can apply
-immediately rather than blocking until the Deployment is fully rolled out. When you do want ordering,
-`propagateWhen` provides explicit gating (see below). The separation gives authors control over what
-waits and what doesn't, rather than coupling all ordering to health checks.
-
-`readyWhen` determines:
-
-1. Whether `.ready()` returns true for this node in CEL expressions
-2. Whether the **Graph itself** is Ready — the Graph's Ready condition is the conjunction of all
-   nodes' `readyWhen` results
-
-### propagateWhen
-
-> *This section defines `propagateWhen`'s core gating semantics within Graph. Rate-limited rollouts,
-> reactive controls, and manual approval gates are proposed separately in KREP-006. The examples
-> here illustrate composability but do not prescribe the final rollout API.*
-
-`propagateWhen` is the complement to `readyWhen`. Where `readyWhen` signals when a node is healthy,
-`propagateWhen` gates when a node may be evaluated at all. Together they bookend a node's lifecycle:
-`propagateWhen` controls when mutation _can start_; `readyWhen` signals when it is _complete_.
-
-```yaml
-- id: service
-  propagateWhen:
-    - ${deployment.ready()}
-  template:
-    apiVersion: v1
-    kind: Service
-    ...
-```
-
-When any `propagateWhen` expression evaluates to false, the node and all its dependents are not
-re-evaluated — they remain in their previous state. When all expressions are true, evaluation
-proceeds normally. The default is `[]` (no gate — evaluate immediately). Where `includeWhen: false`
-prunes a node (deleting its resource), `propagateWhen: false` freezes it — the resource persists in
-its last-applied state.
-
 ### Self-References
 
 Before evaluating a node's expressions, kro GETs the target resource from the API server. The live
@@ -356,7 +303,7 @@ its current state. This enables patterns that require continuity across reconcil
 - **Generation awareness** — compare `metadata.generation` against `status.observedGeneration` to
   detect whether a resource has processed its latest spec
 
-Two derived signals expose node state for use in CEL expressions:
+Two derived signals expose node state for use in CEL expressions (adopted from KREP-006):
 
 ```cel
 deployment.ready()    // true when readyWhen conditions are satisfied
@@ -367,6 +314,71 @@ deployment.updated()  // true when evaluated against the current graph.metadata.
 observed state. `.updated()` reflects whether the node has been applied in the current generation
 (`graph.metadata.generation`, which increments on spec changes): its value is persisted as an
 annotation on the managed resource, so it survives controller restarts and is visible on GET.
+
+### Propagation
+
+Today's RGD gates downstream nodes on upstream readiness — a node cannot evaluate until its
+dependencies pass `readyWhen`. This is implicit propagation control: readiness and ordering are
+coupled. KREP-006 argues these should be separate concerns: `readyWhen` signals when a node is
+_healthy_; `propagateWhen` gates when a node may _mutate_. Graph implements this decoupling.
+
+#### `readyWhen`
+
+`readyWhen` is a list of CEL boolean expressions evaluated against the node's live state. When all
+are true, the node is considered _ready_.
+
+```yaml
+- id: deployment
+  readyWhen:
+    - ${deployment.status.availableReplicas == deployment.spec.replicas}
+  template:
+    apiVersion: apps/v1
+    kind: Deployment
+    ...
+```
+
+In Graph, `readyWhen` is purely a health signal. Downstream nodes proceed as soon as their
+dependencies are _in scope_ (applied, observed state available) — they do not wait for readiness.
+This means resources that don't need to wait — like a Service referencing a Deployment's labels —
+can apply immediately rather than blocking until the Deployment is fully rolled out.
+
+`readyWhen` determines:
+
+1. Whether `.ready()` returns true for this node in CEL expressions
+2. Whether the **Graph itself** is Ready — the Graph's Ready condition is the conjunction of all
+   nodes' `readyWhen` results
+
+#### `propagateWhen`
+
+When you _do_ want to gate on readiness (or any other condition), `propagateWhen` makes the ordering
+explicit and author-controlled:
+
+```yaml
+- id: migration
+  propagateWhen:
+    - ${database.ready()}
+  template:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: schema-migration
+    spec:
+      template:
+        spec:
+          containers:
+            - name: migrate
+              image: myapp/migrate:latest
+          restartPolicy: Never
+```
+
+When any `propagateWhen` expression evaluates to false, the node retains its last-applied state —
+it is not re-evaluated. When all expressions are true, evaluation proceeds normally. The default is
+`[]` (no gate — evaluate immediately). Where `includeWhen: false` prunes a node (deleting its
+resource), `propagateWhen: false` freezes it — the resource persists in its last-applied state.
+
+The separation gives authors control over what waits and what doesn't, rather than coupling all
+ordering to health checks. Most nodes need no gate at all — they apply as soon as their
+dependencies are in scope. The few that need sequencing declare it explicitly.
 
 #### Collections
 
@@ -388,7 +400,8 @@ pass.
 This makes collection-level propagation budgets expressible:
 
 > *The budget pattern below illustrates how `propagateWhen` composes with `forEach`. The rollout
-> API — including built-in strategies and budget syntax — is defined by KREP-006.*
+> API — including built-in strategies, budget syntax, and collection defaults — is defined by
+> KREP-006.*
 
 ```yaml
 # Exponential rollout — budget doubles each wave
@@ -413,38 +426,41 @@ motivation and design discussion.
 ### Nested Graphs
 
 When a node's template is itself a Graph, you get nested composition: a parent Graph that stamps a
-child Graph. You don't strictly need `forEach` for this — a single template node can create one
-child Graph — but the combination of `forEach` + template:{kind: Graph} is the powerful pattern. It
-stamps one child Graph per item in the collection. This is how an RGD-equivalent is expressed — a
-per-RGD Graph stamps a per-instance Graph, each with its own scope, its own revisions, and its own
-lifecycle.
+child Graph as a real cluster object. The child Graph is persisted, reconciled independently, and
+carries its own conditions and revision history — providing full debuggability via `kubectl get
+graph`. You don't strictly need `forEach` for this — a single template node can create one child
+Graph — but the combination of `forEach` + template:{kind: Graph} is the powerful pattern. It stamps
+one child Graph per item in the collection. This is how an RGD-equivalent is expressed — a per-RGD
+Graph stamps a per-instance Graph, each with its own scope, its own revisions, and its own lifecycle.
 
 #### Deferral Boundaries
 
-Child Graph CEL expressions live as literal strings inside the parent's template. The parent
-compiler sees them as opaque data, not as CEL. The evaluation model uses a nesting convention to
-manage this:
+Child Graph CEL expressions live as literal strings inside the parent's template. Deferral is not a
+special syntax or preprocessing step — it falls out of CEL string semantics. To produce a literal
+`${expr}` in the child's spec, the parent writes a CEL string expression whose value is that
+literal:
 
-- `${...}` — evaluated at the current level
-- `${${...}}` — the outer `${}` is stripped (producing a literal `${...}` string), evaluated one
-  level down by the child's controller
+- `${...}` — evaluated by the current Graph
+- `${'${...}'}` — a CEL string literal; the parent evaluates it to produce the text `${...}`, which
+  the child Graph then evaluates at its own scope
 
 ```yaml
 # Parent Graph (L0) evaluates this — bakes the RGD name into the child spec:
 name: ${rgd.metadata.name}
 
-# Parent strips outer ${}, child Graph (L1) evaluates the inner expression:
-group: ${${rgd.spec.schema.group}}
+# Parent produces literal "${rgd.spec.schema.group}" — child Graph (L1) evaluates it:
+group: ${'${rgd.spec.schema.group}'}
 ```
 
-This composes to arbitrary depth. `${${${...}}}` defers two levels.
+This composes to arbitrary depth. `${'${"${...}"}'}` defers two levels — each layer evaluates one
+string literal, peeling off one level of quoting.
 
 #### Recursive Compilation
 
-When the child template is a Graph, the compiler extracts the child spec, strips one deferral level,
-and runs the full compilation pipeline on it. A typo in a child expression, a type mismatch in a
-child template, or a cycle in a child's dependency graph are all reported on the parent at compile
-time — not deferred until the child CR is created.
+When the child template is a Graph, the compiler extracts the child spec, resolves the parent-level
+string literals to recover the child's expressions, and runs the full compilation pipeline on it. A
+typo in a child expression, a type mismatch in a child template, or a cycle in a child's dependency
+graph are all reported on the parent at compile time — not deferred until the child CR is created.
 
 ## Expressing RGD as Graph
 
@@ -510,7 +526,7 @@ like `Compiled` never appear on user resources.
 | KREP-001 (Status Conditions)               | Graph changes where conditions live. System conditions (`Compiled`, `Ready`) exist on Graph objects — never on user resources. Users define their own status via `patch:` nodes. This separates system health (observable on Graph objects) from user-facing status (controlled by the graph author).                                                                                      |
 | KREP-002 (Collections)                     | Adopted unchanged. Graph extends it: when a forEach node's template is a Graph, you get recursive composition.                                                                                                                                                                                                                                                                             |
 | KREP-003 (Decorators)                      | A Decorator is naturally a Graph with `watch:` + `forEach`. No special runtime support needed. Graph also resolves the Singleton problem KREP-003 identified — a Graph needs no schema or CRD to self-instantiate.                                                                                                                                                                         |
-| KREP-006 (Propagation Control)             | This KREP defines `propagateWhen`'s core semantics. KREP-006 provides the broader motivation (rate controls, reactive controls, manual controls) and design discussion. Because Graph is recursive, propagateWhen composes at every level of nesting — an RGD gets propagation control over instances, and each instance gets propagation control over resources, from a single mechanism. |
+| KREP-006 (Propagation Control)             | Graph adopts KREP-006's lifecycle signals (`.ready()`, `.updated()`) and core `propagateWhen` gating semantics. KREP-006 provides the broader motivation (rate controls, reactive controls, manual controls), rollout strategies, and collection defaults. Because Graph is recursive, propagateWhen composes at every level of nesting — an RGD gets propagation control over instances, and each instance gets propagation control over resources, from a single mechanism. |
 | KREP-008 (includeWhen Resource References) | Graph implements `includeWhen` as a first-class modifier — when false, the node is excluded and becomes a prune candidate. This is distinct from `propagateWhen` (which freezes in place). In RGD, KREP-008 added complexity to make includeWhen reference upstream resources; in Graph, that works naturally because all modifiers participate in dependency inference.                   |
 | KREP-011 (Variables)                       | `def:` is Graph's implementation. Same semantics.                                                                                                                                                                                                                                                                                                                                          |
 | KREP-013 (Graph Revisions)                 | Applies to Graph unchanged. Because Graph is recursive, each nested Graph gets independent revisions. An RGD spec change revisions the L1 Graph; an instance spec change revisions L2. These are distinct — rolling back an RGD change does not require rolling back every instance.                                                                                                       |

--- a/docs/design/proposals/graph.md
+++ b/docs/design/proposals/graph.md
@@ -1,0 +1,512 @@
+# KREP-024: Graph
+
+## Summary
+
+Graph is a new `kro.run/v1alpha1` Kind — the atomic runtime primitive for composing Kubernetes
+resources. A Graph is a set of nodes evaluated in topological order. Create it and its resources
+converge; delete it and they cascade away. It is the simplest possible unit of composition in kro.
+
+ResourceGraphDefinition is a molecule built from this atom. RGD bundles together Kind definition,
+instance management, and resource composition into a single convenient abstraction. Graph separates
+these concerns, making each independently usable and enabling patterns that RGD cannot express:
+static resource bundles (no CRD needed), singletons (multiple contributors, one resource), and
+decorators (react to existing resources without defining a new Kind).
+
+Graph was validated by building the full RGD system from it. A single Graph implements the RGD
+controller — creating CRDs, watching instances, managing resources, writing status — all through
+composition rather than imperative Go code. This implementation passes 23 of 36 upstream kro
+compatibility test files, with remaining gaps due to prototype immaturity rather than structural
+limitations (see [examples/graph/rgd.yaml](../../../examples/graph/rgd.yaml)).
+
+## Motivation
+
+RGD conflates three concerns:
+
+1. **Kind definition** — creating a CRD with a schema
+2. **Instance management** — watching instances and reconciling them
+3. **Resource composition** — evaluating templates, managing dependencies
+
+These are separable. An operator may want to compose resources without defining a new Kind (a static
+bundle, like a Helm release). A platform may want to watch existing resources and react to them
+without owning a CRD (a decorator). A system may want multiple actors to coordinate ownership of a
+single resource (a singleton).
+
+Graph provides (3) alone. Higher-level abstractions like RGD combine Graph with (1) and (2) — but
+they are built _from_ Graph, not alongside it. This means every feature added to Graph automatically
+benefits every abstraction layered on top.
+
+## Proposed API
+
+### The Graph Kind
+
+```yaml
+apiVersion: kro.run/v1alpha1
+kind: Graph
+metadata:
+  name: my-app
+spec:
+  nodes:
+    - id: deployment
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: my-app
+        spec:
+          replicas: 3
+          selector:
+            matchLabels:
+              app: my-app
+          template:
+            metadata:
+              labels:
+                app: my-app
+            spec:
+              containers:
+                - name: app
+                  image: nginx
+
+    - id: service
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${deployment.metadata.name}-svc
+        spec:
+          selector: ${deployment.spec.selector.matchLabels}
+          ports:
+            - port: 80
+```
+
+A Graph is namespaced. Its `spec.nodes` is an ordered list where each node has an `id` and exactly
+one type keyword. The `${deployment.metadata.name}` expression in the Service creates a dependency
+edge: the Service cannot evaluate until the Deployment has been applied and its observed state is
+available.
+
+### Node Types
+
+Graph has five node types. Each is declared by a keyword on the node object.
+
+#### `template:`
+
+Creates and manages a Kubernetes resource. On creation the resource is applied via server-side
+apply. On deletion of the Graph, the resource is deleted. This is the direct equivalent of a
+`template:` resource in today's RGD.
+
+#### `patch:`
+
+Contributes fields to a resource you don't own. The resource must already exist — `patch:` does not
+create it. Fields are applied via server-side apply with a distinct field manager. On prune, the
+field claims are released (the field manager is removed), but the resource is not deleted.
+
+Common patterns: writing status back to a user-created instance, multiple writers to the same object
+(like HPA scaling a Deployment alongside a Graph managing its template), or any case where you
+express a partial claim on an existing resource.
+
+```yaml
+- id: instanceStatus
+  patch:
+    apiVersion: apps.example.com/v1
+    kind: WebApp
+    metadata:
+      name: my-webapp
+    status:
+      endpoint: ${service.status.loadBalancer.ingress[0].hostname}
+      ready: ${deployment.status.availableReplicas > 0}
+```
+
+#### `ref:`
+
+Reads a single named resource into scope. No write, no ownership, no cleanup. The resource is
+identified by apiVersion, kind, and metadata (name/namespace). It enters scope as an object —
+downstream nodes can reference its fields via CEL.
+
+```yaml
+- id: config
+  ref:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: app-config
+      namespace: default
+```
+
+#### `watch:`
+
+Reads all resources of a GroupVersionKind matching a label selector into scope as a list. No write,
+no ownership, no cleanup.
+
+```yaml
+- id: allPods
+  watch:
+    apiVersion: v1
+    kind: Pod
+    selector:
+      app: my-app
+```
+
+Downstream nodes use standard CEL list operations:
+`${allPods.filter(p, p.status.phase == 'Running').size()}`.
+
+#### `def:`
+
+Defines raw data for use by other nodes. No Kubernetes resource is created or read — `def:` is pure
+computation. The result enters scope under the node's `id` like any other node.
+
+```yaml
+- id: naming
+  def:
+    prefix: ${deployment.metadata.name + '-' + deployment.metadata.namespace}
+    labels:
+      app: ${deployment.metadata.labels['app']}
+```
+
+`def:` is Graph's implementation of the variables concept proposed in KREP-011. It satisfies the same
+requirements — named intermediate computations, deduplication of repeated expressions, and composing
+with `forEach` to build computed lists (e.g., a container list assembled from a spec field).
+
+#### `includeWhen` and `forEach`
+
+Graph retains `includeWhen` and `forEach` as node-level modifiers with the same semantics as in
+today's RGD. `includeWhen` conditionally excludes a node (making it a prune candidate when false).
+`forEach` stamps a node once per item in a collection. These are not redefined here — see KREP-008
+and KREP-002 respectively.
+
+#### Why ref and watch replace externalRef
+
+`externalRef` in today's RGD overloads a single field to mean "read one named resource" and "watch a
+collection by selector." `ref:` and `watch:` make the operation — and the scope type (object vs
+list) — visible at a glance from the top-level keyword.
+
+#### Everything is a CEL expression
+
+Every string field in a node body — including `apiVersion`, `kind`, `metadata.name`, and selector
+values — can be a CEL expression. This enables dynamic GVKs:
+
+```yaml
+- id: watchInstances
+  watch:
+    apiVersion: ${${schema.spec.schema.group}}/${${schema.spec.schema.apiVersion}}
+    kind: ${${schema.spec.schema.kind}}
+    selector: {}
+```
+
+When the compiler encounters a dynamic GVK, it uses a deferred-type path: the node compiles
+permissively (untyped) until the first reconcile resolves the concrete GVK. This is what makes the
+RGD-from-Graph pattern possible — the user's Kind isn't known at compile time.
+
+### Observed State
+
+Before evaluating a node's expressions, kro GETs the target resource from the API server. The live
+object — including `metadata` and `status` — enters scope under the node's `id`. This is the
+observed state: what exists before the node acts.
+
+On first create (GET returns 404), the scope entry is an empty map. Expressions use optional
+chaining (`.?`, `.orValue()`) to provide defaults. After apply, the apply response replaces the
+scope entry — downstream nodes see post-apply state, not the pre-apply observation.
+
+**Self-reference:** A node can reference its own `id` in its expressions to read its current state.
+This enables patterns that require continuity across reconciles:
+
+- **Condition transitions** — read existing `lastTransitionTime` and preserve it when status hasn't
+  changed, stamp `time.now()` only on actual transitions
+- **Latching** — don't regenerate a private key if one already exists in the Secret
+- **Generation awareness** — compare `metadata.generation` against `status.observedGeneration` to
+  detect whether a resource has processed its latest spec
+
+### readyWhen
+
+`readyWhen` is a list of CEL boolean expressions evaluated against a node's observed state. When all
+are true, the node is considered _ready_.
+
+```yaml
+- id: deployment
+  readyWhen:
+    - ${deployment.status.availableReplicas == deployment.spec.replicas}
+  template:
+    apiVersion: apps/v1
+    kind: Deployment
+    ...
+```
+
+**readyWhen is a health signal. It does not gate downstream nodes.**
+
+This is an important behavioral difference from today's RGD. In the current implementation, a
+downstream node cannot evaluate until all its dependencies pass `readyWhen`. In Graph, evaluation
+proceeds as soon as dependencies are _in scope_ (have been applied and their observed state is
+available). `readyWhen` determines:
+
+1. Whether `.ready()` returns true for this node in CEL expressions
+2. Whether the **Graph itself** is Ready — the Graph's Ready condition is the conjunction of all
+   nodes' `readyWhen` results
+
+This is analogous to how Helm determines release readiness: the release is "ready" when all its
+resources pass their health checks, but resources are not blocked from being created by the health
+state of other resources.
+
+### propagateWhen
+
+`propagateWhen` is the complement to `readyWhen`. Where `readyWhen` signals when a node is healthy,
+`propagateWhen` gates when a node may be evaluated at all. Together they bookend a node's lifecycle:
+`propagateWhen` controls when mutation _can start_; `readyWhen` signals when it is _complete_.
+
+```yaml
+- id: service
+  propagateWhen:
+    - ${deployment.ready()}
+  template:
+    apiVersion: v1
+    kind: Service
+    ...
+```
+
+When any `propagateWhen` expression evaluates to false, the node and all its dependents are not
+re-evaluated — they remain in their previous state. When all expressions are true, evaluation
+proceeds normally. The default is `[]` (no gate — evaluate immediately).
+
+This is the mechanism for users who want the current RGD behavior where readyWhen gates dependents.
+In Graph, that behavior is opt-in: add `propagateWhen: [${dep.ready()}]` to get explicit gating.
+
+#### Lifecycle Methods
+
+Two lifecycle methods expose node state for use in `propagateWhen` and other CEL expressions:
+
+```cel
+deployment.ready()    // true when readyWhen conditions are satisfied
+deployment.updated()  // true when evaluated against the current graph generation
+```
+
+These enable propagation patterns:
+
+```yaml
+# Exponential rollout — budget doubles each wave
+- id: deployments
+  forEach:
+    - app: ${apps}
+  propagateWhen:
+    - >-
+      ${deployments.filter(d, d.updated() && !d.ready()).size()
+       < max(1, deployments.filter(d, d.updated() && d.ready()).size())}
+```
+
+Because Graph is recursive, `propagateWhen` composes at every level of nesting. In the RGD
+implementation: L1 can gate propagation to instances, and L2 can gate propagation to individual
+resources — all from the same mechanism, no special-casing per layer. See KREP-006 for the broader
+motivation and design discussion.
+
+### Dependencies
+
+Dependencies are inferred from CEL expressions. If node B's template contains `${A.field}`, B
+depends on A. The compiler builds a DAG from these references and computes topological order. Cycles
+are compile-time errors.
+
+#### Hard Dependencies
+
+A bare field reference creates a hard dependency:
+
+```cel
+${deployment.status.availableReplicas}
+```
+
+Node B cannot evaluate until node A has been applied and its observed state is in scope. This is the
+standard behavior — identical to today's RGD.
+
+#### Soft Dependencies
+
+Optional chaining creates a soft dependency:
+
+```cel
+${deployment.?status.?loadBalancer.orValue("pending")}
+```
+
+A soft dependency is _never_ gated. If the dependency hasn't been evaluated yet, the expression
+resolves to `optional.none()`, and `.orValue()` provides the fallback. If the dependency has been
+evaluated, the full observed state is available.
+
+**Why soft dependencies exist:** Status writeback creates a dependency cycle: the `patch:` node
+references all managed resources, but can't hard-depend on all of them without blocking itself.
+Optional chaining breaks the cycle — the status node runs on every pass, filling in whatever is
+available, progressively transitioning from `IN_PROGRESS` to `ACTIVE`.
+
+### Nested Graphs
+
+When a node's template is itself a Graph, you get nested composition: a parent Graph that stamps a
+child Graph. You don't strictly need `forEach` for this — a single template node can create one
+child Graph — but the combination of `forEach` + template:{kind: Graph} is the powerful pattern. It
+stamps one child Graph per item in the collection. This is how RGD emerges — a per-RGD Graph stamps
+a per-instance Graph, each with its own scope, its own revisions, and its own lifecycle.
+
+#### Deferral Boundaries
+
+Child Graph CEL expressions live as literal strings inside the parent's template. The parent
+compiler sees them as opaque data, not as CEL. The evaluation model uses a nesting convention to
+manage this:
+
+- `${...}` — evaluated at the current level
+- `${${...}}` — the outer `${}` is stripped (producing a literal `${...}` string), evaluated one
+  level down by the child's controller
+
+```yaml
+# Parent Graph (L0) evaluates this — bakes the RGD name into the child spec:
+name: ${rgd.metadata.name}
+
+# Parent strips outer ${}, child Graph (L1) evaluates the inner expression:
+group: ${${rgd.spec.schema.group}}
+```
+
+This composes to arbitrary depth. `${${${...}}}` defers two levels.
+
+#### Recursive Compilation
+
+Recursive compilation enables parent-time error detection for child Graph expressions. When the
+compiler detects nested `${${...}}` patterns, it type-checks inner expressions against the child's
+statically known node list. When the child template is literally a Graph (the apiVersion/kind is
+`kro.run/v1alpha1 Graph`), the compiler extracts the child spec, strips one deferral level, and runs
+the full compilation pipeline on it.
+
+This means: a typo in a child expression, a type mismatch in a child template, or a cycle in a
+child's dependency graph are all reported on the parent at compile time. Without this, errors in
+child expressions would only surface after the child CR is created and its controller attempts
+compilation — a delayed feedback loop. Recursive compilation makes it immediate.
+
+#### Lifecycle Coupling
+
+Nested Graphs use `ownerReferences` to tie child lifecycle to parent. When the owner is deleted,
+Kubernetes cascades the delete to the child Graph, triggering its ordered teardown. But Kubernetes
+cascade is asynchronous — without coordination, the owner can complete deletion while teardown is
+still running, orphaning managed resources. To prevent this, the child Graph places a finalizer on
+the owner via a `patch:` node:
+
+```yaml
+metadata:
+  ownerReferences:
+    - apiVersion: apps.example.com/v1
+      kind: WebApp
+      name: my-instance
+      uid: ...
+spec:
+  nodes:
+    - id: lifecycle
+      patch:
+        apiVersion: apps.example.com/v1
+        kind: WebApp
+        metadata:
+          name: my-instance
+          finalizers:
+            - kro.run/graph
+    - id: deployment
+      template: ...
+```
+
+The ownerReference triggers self-deletion when the instance enters Terminating. The `patch:` node
+holds the instance until teardown completes — all template resources are pruned in reverse DAG
+order, then the patch releases the finalizer as its last act, and the instance finishes deletion.
+This pattern is load-bearing for the RGD implementation: each per-instance Graph (L2) holds a
+finalizer on its instance, ensuring no managed resources are orphaned on deletion.
+
+## How RGD Emerges from Graph
+
+The RGD system is three levels of nested Graphs:
+
+```
+L0: rgd-controller
+├── Creates the ResourceGraphDefinition CRD
+├── Watches all RGD objects
+└── forEach RGD → creates L1 Graph
+    │
+    L1: per-RGD (one per ResourceGraphDefinition)
+    ├── ref: reads the specific RGD object
+    ├── Creates the user's Kind CRD from RGD schema
+    ├── Watches all instances of the user's Kind
+    └── forEach instance → creates L2 Graph
+        │
+        L2: per-instance (one per user CR)
+        ├── ref: reads the specific instance
+        ├── User's resources (from rgd.spec.resources)
+        └── patch: writes status back to the instance
+```
+
+See [examples/graph/rgd.yaml](../../../examples/graph/rgd.yaml) for the full working implementation
+with detailed commentary on each level.
+
+## Status
+
+Two conditions on orthogonal axes. Both use standard Kubernetes condition fields;
+`lastTransitionTime` is preserved when status is unchanged; `observedGeneration` advances
+independently per condition.
+
+**`Compiled`** — is the spec valid? Set once when the spec is processed, permanent until the spec
+changes. True on success; False on expression errors, dependency cycles, or malformed node
+declarations.
+
+**`Ready`** — has the graph converged? `True` means all nodes are applied and their `readyWhen`
+conditions pass. `Unknown` means the controller is still making progress. `False` means something
+requires human intervention.
+
+Compiled rolls into Ready: if the spec fails compilation, Ready is `False` with reason
+`NotCompiled`. A single alarm on `Ready` covers both compilation failures and runtime issues —
+there is no need to monitor Compiled separately.
+
+| Ready Reason  | Status    | Meaning                            |
+|---------------|-----------|------------------------------------|
+| Ready         | True      | All nodes applied and ready        |
+| NotReady      | Unknown   | readyWhen not yet met              |
+| Pending       | Unknown   | Waiting for upstream data          |
+| NotCompiled   | False     | Spec is invalid (rollup of Compiled=False) |
+| Conflict      | False     | SSA field ownership contested      |
+| Error         | False     | Client request failed (4xx)        |
+| SystemError   | False     | Infrastructure failure (5xx)       |
+
+User-defined status does not live on the Graph object. It lives on custom resources and is written
+via `patch:` nodes. The Graph's status contains only controller-managed fields — system conditions
+like `Compiled` never appear on user resources.
+
+## Relationship to Existing KREPs
+
+| KREP                                       | Relationship                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| KREP-001 (Status Conditions)               | Graph changes where conditions live. System conditions (`Compiled`, `Ready`) exist on Graph objects — never on user resources. Users define their own status via `patch:` nodes. This separates system health (observable on Graph objects) from user-facing status (controlled by the graph author).                                                                                      |
+| KREP-002 (Collections)                     | Adopted unchanged. Graph extends it: when a forEach node's template is a Graph, you get recursive composition.                                                                                                                                                                                                                                                                              |
+| KREP-003 (Decorators)                      | A Decorator is naturally a Graph with `watch:` + `forEach`. No special runtime support needed. Graph also resolves the Singleton problem KREP-003 identified — a Graph needs no schema or CRD to self-instantiate.                                                                                                                                                                         |
+| KREP-006 (Propagation Control)             | This KREP defines `propagateWhen`'s core semantics. KREP-006 provides the broader motivation (rate controls, reactive controls, manual controls) and design discussion. Because Graph is recursive, propagateWhen composes at every level of nesting — an RGD gets propagation control over instances, and each instance gets propagation control over resources, from a single mechanism. |
+| KREP-008 (includeWhen Resource References) | Graph implements `includeWhen` as a first-class modifier — when false, the node is excluded and becomes a prune candidate. This is distinct from `propagateWhen` (which freezes in place). In RGD, KREP-008 added complexity to make includeWhen reference upstream resources; in Graph, that works naturally because all modifiers participate in dependency inference.                   |
+| KREP-011 (Variables)                       | `def:` is Graph's implementation. Same semantics.                                                                                                                                                                                                                                                                                                                                            |
+| KREP-013 (Graph Revisions)                 | Applies to Graph unchanged. Because Graph is recursive, each nested Graph gets independent revisions. An RGD spec change revisions the L1 Graph; an instance spec change revisions L2. These are distinct — rolling back an RGD change does not require rolling back every instance.                                                                                                       |
+| KREP-014 (Resource Lifecycles)             | Graph's node types implicitly define lifecycle: `template:` = delete-on-prune, `patch:` = release-fields-on-prune. A per-node `lifecycle.apply: Force` flag was explored in prototyping to handle contested field ownership. Per-node lifecycle policies (Orphan, Retain) are a natural follow-on.                                                                                         |
+| KREP-018 (Partial Dependencies)            | CEL branching (`${cond ? A.field : B.field}`) and Graph's soft dependency mechanism (`?.`) together address partial dependency scenarios. Soft deps allow referencing a node without creating a hard gate — the taken-branch problem becomes less acute when the untaken branch uses optional chaining.                                                                                    |
+| KREP-019 (Deferred Fields & Soft Deps)     | Graph's `?.` optional chaining is the implementation of this KREP. Soft deps allow progressive field population across reconcile passes.                                                                                                                                                                                                                                                   |
+
+## Future Work
+
+Graph was validated through an extensive prototyping effort (Krocodile) that explored how far the
+primitive extends. Beyond the core API proposed here, the prototype implements:
+
+- **`Kind` — a simplified RGD with graph-like semantics.** Defines a new Kubernetes Kind (CRD +
+  per-instance Graphs) in a single object. Unlike RGD, Kind uses `readyWhen` and `propagateWhen`
+  directly at the spec level, giving instance-level rollout control with no additional machinery.
+  Kind is the intended successor to RGD; the RGD compatibility layer is built on top of Kind.
+- **Propagation control** — rate-limited rollouts, time-based gates, reactive controls (KREP-006
+  covers the design; the prototype validates it composes with nested Graphs)
+- **Prometheus metric emission** (`metric:`) — emit gauges driven by CEL expressions
+- **Finalizer coordination** (`finalizes:`) — cross-resource cleanup ordering; finalizer nodes
+  materialize only when their target becomes a prune candidate
+- **Time-based scheduling** — `time.now()` comparisons that solve for the exact future timestamp and
+  enqueue reconciliation precisely
+- **SSA ownership protocol** — field-level ownership tracking via server-side apply field managers,
+  with a per-node `lifecycle.apply: Force` flag for contested ownership. On deletion, templates are
+  fully pruned before patch field claims are released (ordering invariant).
+- **Reconciliation algorithm** — wavefront evaluation with topological ordering and prune in reverse
+  order
+- **CEL lifecycle functions** — `.dependencies()` returns a node's upstream dependency list (enables
+  `${node.dependencies().all(d, d.ready())}`); `.condition()` encapsulates the Kubernetes status
+  condition pattern with `lastTransitionTime` preservation and `observedGeneration` tracking
+- **Cryptographic CEL functions** — `rsa.generateKey`, `ecdsa.generateKey`, `ed25519.generateKey`,
+  and `x509.createCertificateRequest` enable TLS bootstrapping inline in a Graph, eliminating the
+  need for cert-manager in simple certificate use cases
+
+These features compose naturally with Graph but are separate design concerns, proposable
+incrementally. The key finding from Krocodile is that Graph's recursive structure means each feature
+added at one level automatically applies at every level of nesting. propagateWhen at L1 controls
+instance-level rollouts; the same mechanism at L2 controls per-resource rollouts. Graph Revisions at
+L1 track RGD spec changes; the same mechanism at L2 tracks instance changes independently. Nothing
+is special-cased per layer.

--- a/examples/graph/coredns.yaml
+++ b/examples/graph/coredns.yaml
@@ -1,0 +1,150 @@
+# KREP-024 Example: CoreDNS Installation
+#
+# Install CoreDNS as a single Graph — the static-bundle pattern. One object
+# replaces a Helm chart: dependency-ordered, health-aware, fully declarative.
+# Delete the Graph and the entire stack is cleaned up in reverse order.
+#
+# Resources are evaluated in dependency order inferred from CEL references:
+#   ServiceAccount → ClusterRole → ClusterRoleBinding → ConfigMap → Deployment → Service
+# ---------------------------------------------------------------------------
+apiVersion: kro.run/v1alpha1
+kind: Graph
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  nodes:
+    - id: sa
+      template:
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: coredns
+
+    - id: role
+      template:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: system:coredns
+        rules:
+          - apiGroups: [""]
+            resources: [endpoints, services, pods, namespaces]
+            verbs: [list, watch]
+          - apiGroups: [discovery.k8s.io]
+            resources: [endpointslices]
+            verbs: [list, watch]
+
+    - id: binding
+      template:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: system:coredns
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: ${role.metadata.name}
+        subjects:
+          - kind: ServiceAccount
+            name: ${sa.metadata.name}
+            namespace: kube-system
+
+    - id: corefile
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: coredns
+        data:
+          Corefile: |
+            .:53 {
+                errors
+                health { lameduck 5s }
+                ready
+                kubernetes cluster.local in-addr.arpa ip6.arpa {
+                    pods insecure
+                    fallthrough in-addr.arpa ip6.arpa
+                    ttl 30
+                }
+                prometheus :9153
+                forward . /etc/resolv.conf { max_concurrent 1000 }
+                cache 30
+                loop
+                reload
+                loadbalance
+            }
+
+    - id: deployment
+      readyWhen:
+        - ${deployment.status.availableReplicas == deployment.spec.replicas}
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: coredns
+          labels:
+            k8s-app: kube-dns
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              k8s-app: kube-dns
+          template:
+            metadata:
+              labels:
+                k8s-app: kube-dns
+            spec:
+              serviceAccountName: ${sa.metadata.name}
+              containers:
+                - name: coredns
+                  image: registry.k8s.io/coredns/coredns:v1.11.1
+                  args: ["-conf", "/etc/coredns/Corefile"]
+                  ports:
+                    - containerPort: 53
+                      name: dns
+                      protocol: UDP
+                    - containerPort: 53
+                      name: dns-tcp
+                      protocol: TCP
+                    - containerPort: 9153
+                      name: metrics
+                      protocol: TCP
+                  volumeMounts:
+                    - name: config
+                      mountPath: /etc/coredns
+                      readOnly: true
+                  readinessProbe:
+                    httpGet:
+                      path: /ready
+                      port: 8181
+                  livenessProbe:
+                    httpGet:
+                      path: /health
+                      port: 8080
+              volumes:
+                - name: config
+                  configMap:
+                    name: ${corefile.metadata.name}
+
+    - id: service
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: kube-dns
+          labels:
+            k8s-app: kube-dns
+        spec:
+          clusterIP: 10.96.0.10
+          selector: ${deployment.spec.selector.matchLabels}
+          ports:
+            - name: dns
+              port: 53
+              protocol: UDP
+            - name: dns-tcp
+              port: 53
+              protocol: TCP
+            - name: metrics
+              port: 9153
+              protocol: TCP

--- a/examples/graph/ingress-fanin.yaml
+++ b/examples/graph/ingress-fanin.yaml
@@ -1,0 +1,47 @@
+# KREP-024 Example: Ingress Fan-In
+#
+# Watch all Services labeled "expose: true" in a namespace and aggregate them
+# into a single Ingress resource with one rule per Service. Add a Service with
+# the label and a route appears; remove it and the route disappears.
+#
+# This is the aggregated-resource pattern from KREP-003: multiple independent
+# actors contribute to a shared resource without coordinating with each other.
+# ---------------------------------------------------------------------------
+apiVersion: kro.run/v1alpha1
+kind: Graph
+metadata:
+  name: ingress-fanin
+  namespace: default
+spec:
+  nodes:
+    - id: services
+      watch:
+        apiVersion: v1
+        kind: Service
+        selector:
+          matchLabels:
+            expose: "true"
+
+    - id: ingress
+      template:
+        apiVersion: networking.k8s.io/v1
+        kind: Ingress
+        metadata:
+          name: shared-ingress
+        spec:
+          rules: >-
+            ${services.map(svc, {
+              "host": svc.metadata.name + ".example.com",
+              "http": {
+                "paths": [{
+                  "path": "/",
+                  "pathType": "Prefix",
+                  "backend": {
+                    "service": {
+                      "name": svc.metadata.name,
+                      "port": {"number": svc.spec.ports[0].port}
+                    }
+                  }
+                }]
+              }
+            })}

--- a/examples/graph/namespace-decorator.yaml
+++ b/examples/graph/namespace-decorator.yaml
@@ -1,0 +1,38 @@
+# KREP-024 Example: Namespace Decorator
+#
+# Watch all namespaces labeled "policy: enforced" and create a default-deny
+# NetworkPolicy in each one. No CRD, no schema, no instance — just a Graph
+# that reacts to existing resources.
+#
+# Add or remove the label on a namespace and the policy appears or disappears.
+# Delete the Graph and all managed NetworkPolicies are cleaned up.
+# ---------------------------------------------------------------------------
+apiVersion: kro.run/v1alpha1
+kind: Graph
+metadata:
+  name: namespace-decorator
+  namespace: kro-system
+spec:
+  nodes:
+    - id: namespaces
+      watch:
+        apiVersion: v1
+        kind: Namespace
+        selector:
+          matchLabels:
+            policy: enforced
+
+    - id: policies
+      forEach:
+        - ns: ${namespaces}
+      template:
+        apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: default-deny
+          namespace: ${ns.metadata.name}
+        spec:
+          podSelector: {}
+          policyTypes:
+            - Ingress
+            - Egress

--- a/examples/graph/rgd.yaml
+++ b/examples/graph/rgd.yaml
@@ -1,0 +1,428 @@
+# KREP-024 Example: ResourceGraphDefinition implemented as a Graph
+#
+# This demonstrates that RGD is a molecule built entirely from Graph primitives.
+# A single Graph (L0) implements the full RGD controller — CRD creation, instance
+# management, resource reconciliation, and status writeback — through composition.
+#
+# Compatibility: 23/36 upstream kro test files passing
+# (see: experimental/Makefile `make compat-count` for current numbers)
+#
+# Note: This example uses def: nodes (KREP-011, Variables) for validation logic
+# and propagateWhen (KREP-006) for conditional status updates. These are proposed
+# separately but shown here to demonstrate the complete system.
+#
+# ─── Architecture ─────────────────────────────────────────────────────────────
+#
+#   L0 (this Graph)                — creates the RGD CRD, watches all RGDs
+#   └─ L1 (per-RGD Graph)         — validates, creates Kind CRD, watches instances
+#      └─ L2 (per-instance Graph)  — manages resources, writes instance status
+#
+# ─── L0 → L1: Graph Per RGD ──────────────────────────────────────────────────
+#
+#   L0 uses watch: to observe all RGD objects, then forEach stamps one child
+#   Graph per RGD. The child Graph's name is derived from the RGD name,
+#   creating a stable 1:1 mapping. Each child gets an ownerReference back to
+#   its RGD for garbage collection.
+#
+# ─── L1: Validation, CRD Creation, Instance Watching ─────────────────────────
+#
+#   The per-RGD Graph reads the RGD spec via ref:, validates it using pure CEL
+#   (def: nodes check reserved words, naming conventions, duplicate IDs, and
+#   schema validity), creates the Kind's CRD (gated on validation passing), and
+#   watches instances of the user's Kind. The CRD's OpenAPI schema is
+#   synthesized from the RGD's spec.schema using simpleSchema.toOpenAPI().
+#
+#   The rgdStatus node writes Ready/state/conditions back to the RGD via patch:.
+#   It is the single writer for these fields, keeping the status pipeline to
+#   one hop for fast convergence.
+#
+# ─── L1 → L2: Graph Per Instance ─────────────────────────────────────────────
+#
+#   L1 uses forEach over watched instances to stamp one child Graph per
+#   instance. The child's node list is constructed programmatically via CEL
+#   list concatenation:
+#
+#     [{schema ref}]
+#     + externalRefs translated to ref:/watch: nodes
+#     + user's resource templates (with labels merged)
+#     + [{status patch}]
+#
+#   The user's resource definitions (with their ${schema.spec.*} expressions)
+#   pass through L1 as opaque string data and are evaluated by L2's controller
+#   in the per-instance scope.
+#
+# ─── L2: Resource Management and Status ──────────────────────────────────────
+#
+#   The per-instance Graph has "schema" (the user's CR) in scope via ref:,
+#   applies each user-defined resource template, and writes status back via
+#   patch:. The Graph's own readyWhen propagates upward — when all resources
+#   are ready, the instance's status condition becomes Ready and state
+#   transitions from IN_PROGRESS to ACTIVE.
+#
+# ─── Escaping Convention ─────────────────────────────────────────────────────
+#
+#   ${...}       — evaluated by L0
+#   ${${...}}    — deferred to L1 (stripped by L0, evaluated by L1's controller)
+#   Expressions inside L2's CEL-constructed node list survive as opaque strings
+#   and are evaluated by L2's controller.
+#
+# ---------------------------------------------------------------------------
+---
+apiVersion: kro.run/v1alpha1
+kind: Graph
+metadata:
+  name: rgd
+  namespace: kro-system
+spec:
+  nodes:
+    # ─── L0: Create the ResourceGraphDefinition CRD ──────────────────────────
+    - id: rgdCrd
+      template:
+        apiVersion: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        metadata:
+          name: resourcegraphdefinitions.kro.run
+        spec:
+          group: kro.run
+          names:
+            plural: resourcegraphdefinitions
+            singular: resourcegraphdefinition
+            kind: ResourceGraphDefinition
+            listKind: ResourceGraphDefinitionList
+          scope: Cluster
+          versions:
+            - name: v1alpha1
+              served: true
+              storage: true
+              schema:
+                openAPIV3Schema: >-
+                  ${simpleSchema.toOpenAPI({"types": {"ExternalRefMetadata": {"name": "string", "namespace": "string", "selector": "object"}, "ExternalRef": {"apiVersion": "string", "kind": "string", "metadata": "ExternalRefMetadata"}, "Resource": {"id": "string | required=true", "template": "any", "patch": "any", "ref": "any", "watch": "any", "def": "any", "externalRef": "ExternalRef", "readyWhen": "[]string", "includeWhen": "[]string", "propagateWhen": "[]string", "forEach": "[]map[string]string"}, "PrinterColumn": {"name": "string | required=true", "type": "string | required=true", "jsonPath": "string | required=true", "description": "string", "format": "string", "priority": "integer"}, "CRDMetadata": {"labels": "map[string]string", "annotations": "map[string]string"}}, "spec": {"schema": {"kind": "string | required=true pattern=\"^[A-Z][a-zA-Z0-9]{0,62}$\"", "apiVersion": "string", "group": "string | default=kro.run", "scope": "string | default=Namespaced", "spec": "object", "types": "object", "status": "object", "metadata": "CRDMetadata", "additionalPrinterColumns": "[]PrinterColumn"}, "resources": "[]Resource"}, "status": {"state": "string", "topologicalOrder": "[]string"}}, [])}
+              subresources:
+                status: {}
+              additionalPrinterColumns:
+                - name: APIVERSION
+                  type: string
+                  jsonPath: .spec.schema.apiVersion
+                - name: KIND
+                  type: string
+                  jsonPath: .spec.schema.kind
+                - name: STATE
+                  type: string
+                  jsonPath: .status.state
+                - name: TOPOLOGICALORDER
+                  type: string
+                  priority: 1
+                  jsonPath: .status.topologicalOrder
+                - name: AGE
+                  type: date
+                  jsonPath: .metadata.creationTimestamp
+
+    # ─── L0: Watch all RGD objects (gated on CRD being established) ──────────
+    - id: watchRgds
+      includeWhen:
+        - ${rgdCrd.?status.?conditions.orValue([]).exists(c, c.type == 'Established' && c.status == 'True')}
+      watch:
+        apiVersion: kro.run/v1alpha1
+        kind: ResourceGraphDefinition
+        selector: {}
+
+    # ─── L0 → L1: One sub-Graph per RGD ─────────────────────────────────────
+    - id: rgds
+      forEach:
+        - rgd: ${watchRgds}
+      template:
+        apiVersion: kro.run/v1alpha1
+        kind: Graph
+        metadata:
+          name: rgd.${rgd.metadata.name}
+          namespace: kro-system
+          labels:
+            kro.run/instance-name: ${rgd.metadata.name}
+          ownerReferences:
+            - apiVersion: kro.run/v1alpha1
+              kind: ResourceGraphDefinition
+              name: ${rgd.metadata.name}
+              uid: ${rgd.metadata.uid}
+              controller: true
+              blockOwnerDeletion: true
+        spec:
+          nodes:
+            # ─── L1: Read the specific RGD ───────────────────────────────────
+            - id: schema
+              ref:
+                apiVersion: kro.run/v1alpha1
+                kind: ResourceGraphDefinition
+                metadata:
+                  name: ${rgd.metadata.name}
+
+            # ─── L1: Validation (def: node, see KREP-011) ────────────────────
+            - id: checks
+              def:
+                resources: "${${schema.?spec.?resources.orValue([])}}"
+                reserved: '${${["apiVersion","context","dependency","dependencies","each","externalRef","externalReference","externalRefs","externalReferences","graph","instance","item","items","kind","kro","metadata","namespace","object","resource","resourcegraphdefinition","resourceGraphDefinition","resources","root","runtime","schema","self","serviceAccountName","spec","status","this","variables","vars","version"]}}'
+                allIDs: "${${schema.?spec.?resources.orValue([]).map(r, r.id)}}"
+
+            - id: validation
+              def:
+                result: >-
+                  ${${
+                    checks.resources.exists(r, checks.reserved.exists(w, r.id == w))
+                    ? {"valid": false, "message": "naming convention violation: id " + checks.resources.filter(r, checks.reserved.exists(w, r.id == w))[0].id + " is a reserved keyword in KRO"}
+                    : checks.resources.exists(r, !r.id.matches("^[a-z][a-zA-Z0-9]*$"))
+                    ? {"valid": false, "message": "naming convention violation: id " + checks.resources.filter(r, !r.id.matches("^[a-z][a-zA-Z0-9]*$"))[0].id + " is not a valid KRO resource id: must be lower camelCase"}
+                    : checks.resources.exists(r, checks.resources.filter(s, s.id == r.id).size() > 1)
+                    ? {"valid": false, "message": "found duplicate resource IDs \"" + checks.resources.filter(r, checks.resources.filter(s, s.id == r.id).size() > 1)[0].id + "\""}
+                    : checks.resources.exists(r, has(r.forEach) && r.forEach.size() > 0 && r.forEach.exists(d, d.exists(k, checks.reserved.exists(w, k == w))))
+                    ? {"valid": false, "message": "forEach iterator is a reserved keyword"}
+                    : checks.resources.exists(r, has(r.forEach) && r.forEach.size() > 0 && r.forEach.exists(d, d.exists(k, checks.allIDs.exists(id, id == k))))
+                    ? {"valid": false, "message": "forEach iterator conflicts with resource ID"}
+                    : schema.?spec.?schema.?status.orValue({}).size() > 0 && schema.spec.schema.status.exists(k, !string(schema.spec.schema.status[k]).contains("${"))
+                    ? {"valid": false, "message": "failed to build instance status schema: status fields without expressions are not supported"}
+                    : checks.resources.exists(r, !has(r.externalRef) && has(r.template) && (!has(r.template.apiVersion) || !has(r.template.kind) || !has(r.template.metadata)))
+                    ? {"valid": false, "message": "resource " + checks.resources.filter(r, !has(r.externalRef) && has(r.template) && (!has(r.template.apiVersion) || !has(r.template.kind) || !has(r.template.metadata)))[0].id + " is not a valid Kubernetes object: missing apiVersion, kind, or metadata"}
+                    : checks.resources.exists(r, !has(r.externalRef) && has(r.template) && has(r.template.apiVersion) && !string(r.template.apiVersion).contains("${") && !string(r.template.apiVersion).matches("^([a-zA-Z0-9][a-zA-Z0-9.-]*/)?v[0-9]+((?:alpha|beta)[0-9]+)?$"))
+                    ? {"valid": false, "message": "resource " + checks.resources.filter(r, !has(r.externalRef) && has(r.template) && has(r.template.apiVersion) && !string(r.template.apiVersion).contains("${") && !string(r.template.apiVersion).matches("^([a-zA-Z0-9][a-zA-Z0-9.-]*/)?v[0-9]+((?:alpha|beta)[0-9]+)?$"))[0].id + " has invalid apiVersion format"}
+                    : {"valid": true, "message": ""}
+                  }}
+
+            # ─── L1: Create the user's Kind CRD ──────────────────────────────
+            - id: crd
+              includeWhen:
+                - ${${validation.result.valid}}
+              template:
+                apiVersion: apiextensions.k8s.io/v1
+                kind: CustomResourceDefinition
+                metadata:
+                  name: ${${plural(schema.spec.schema.kind).lowerAscii()}}.${${schema.spec.schema.group}}
+                  labels: "${${schema.?spec.?schema.?metadata.?labels.orValue({})}}"
+                  annotations: "${${schema.?spec.?schema.?metadata.?annotations.orValue({})}}"
+                spec:
+                  group: ${${schema.spec.schema.group}}
+                  names:
+                    kind: ${${schema.spec.schema.kind}}
+                    plural: ${${plural(schema.spec.schema.kind).lowerAscii()}}
+                  scope: ${${schema.spec.schema.scope}}
+                  versions:
+                    - name: ${${schema.spec.schema.apiVersion}}
+                      served: true
+                      storage: true
+                      subresources:
+                        status: {}
+                      schema:
+                        openAPIV3Schema: "${${simpleSchema.toOpenAPI(schema.spec.schema, has(schema.spec.resources) ? schema.spec.resources : [])}}"
+                      additionalPrinterColumns: "${${schema.?spec.?schema.?additionalPrinterColumns.orValue([])}}"
+
+            # ─── L1: Watch all instances of the user's Kind ──────────────────
+            - id: watchInstances
+              includeWhen:
+                - ${${crd.?status.?conditions.orValue([]).exists(c, c.type == 'Established' && c.status == 'True')}}
+              watch:
+                apiVersion: ${${schema.spec.schema.group}}/${${schema.spec.schema.apiVersion}}
+                kind: ${${schema.spec.schema.kind}}
+                metadata:
+                  selector: {}
+
+            # ─── L1 → L2: One sub-Graph per instance ─────────────────────────
+            #
+            # The node list is constructed via CEL list concatenation:
+            #   [schema ref] + externalRefs-as-ref/watch + resources + [status patch]
+            #
+            # Expressions inside rgd.spec.resources (like ${schema.spec.image})
+            # survive as opaque string data — they are evaluated by L2's controller.
+            - id: instances
+              forEach:
+                - instance: ${${watchInstances}}
+              template:
+                apiVersion: kro.run/v1alpha1
+                kind: Graph
+                metadata:
+                  name: ${${"rgd." + schema.metadata.name + "." + instance.metadata.name}}
+                  namespace: '${${has(instance.metadata.namespace) && instance.metadata.namespace != "" ? instance.metadata.namespace : "kro-system"}}'
+                  ownerReferences:
+                    - apiVersion: '${${schema.spec.schema.group + "/" + schema.spec.schema.apiVersion}}'
+                      kind: "${${schema.spec.schema.kind}}"
+                      name: "${${instance.metadata.name}}"
+                      uid: "${${instance.metadata.uid}}"
+                      controller: true
+                      blockOwnerDeletion: true
+                spec:
+                  nodes: >-
+                    ${${
+                      [{"id": "schema", "ref": {
+                        "apiVersion": schema.spec.schema.group + "/" + schema.spec.schema.apiVersion,
+                        "kind": schema.spec.schema.kind,
+                        "metadata": {
+                          "name": instance.metadata.name,
+                          "namespace": instance.metadata.namespace
+                        }
+                      }}]
+                      + schema.spec.resources.filter(r, has(r.externalRef) && !has(r.externalRef.metadata.selector)).map(r,
+                        {"id": r.id, "ref": {
+                          "apiVersion": r.externalRef.apiVersion,
+                          "kind": r.externalRef.kind,
+                          "metadata": {"name": r.externalRef.metadata.name}.merge(
+                            has(r.externalRef.metadata.namespace) && r.externalRef.metadata.namespace != ""
+                              ? {"namespace": r.externalRef.metadata.namespace}
+                              : {}
+                          )
+                        }})
+                      + schema.spec.resources.filter(r, has(r.externalRef) && has(r.externalRef.metadata.selector)).map(r,
+                        {"id": r.id, "watch": {
+                          "apiVersion": r.externalRef.apiVersion,
+                          "kind": r.externalRef.kind,
+                          "selector": r.externalRef.metadata.selector
+                        }.merge(
+                          has(r.externalRef.metadata.namespace) && r.externalRef.metadata.namespace != ""
+                            ? {"metadata": {"namespace": r.externalRef.metadata.namespace}}
+                            : {}
+                        )})
+                      + schema.spec.resources.filter(r, !has(r.externalRef)).map(r, r.merge({
+                        "readyWhen": r.?readyWhen.orValue([]).map(expr, expr.replace('each.', r.id + '.')),
+                        "propagateWhen": r.?propagateWhen.orValue(r.?forEach.orValue([]).size() > 0 ? [] : ["${" + r.id + ".dependencies().all(d, d.ready())}"]),
+                        "lifecycle": {"apply": "Force"},
+                        "template": r.template.merge({
+                          "metadata": (has(r.template.metadata) ? r.template.metadata : {}).merge({
+                            "labels": (has(r.template.metadata) && has(r.template.metadata.labels) ? r.template.metadata.labels : {}).merge({
+                              "kro.run/instance-id": string(instance.metadata.uid),
+                              "kro.run/instance-name": instance.metadata.name,
+                              "kro.run/instance-namespace": instance.metadata.namespace,
+                              "kro.run/instance-group": schema.spec.schema.group,
+                              "kro.run/instance-version": schema.spec.schema.apiVersion,
+                              "kro.run/instance-kind": schema.spec.schema.kind
+                            })
+                          })
+                        })
+                      }))
+                      + [{"id": "rgdInstancePatch",
+                         "patch": {
+                        "apiVersion": schema.spec.schema.group + "/" + schema.spec.schema.apiVersion,
+                        "kind": schema.spec.schema.kind,
+                        "metadata": {
+                          "name": instance.metadata.name,
+                          "namespace": instance.metadata.namespace,
+                          "finalizers": ["experimental.kro.run/graph"]
+                        },
+                        "status": {
+                          "state": "${" + (schema.spec.resources.size() == 0 ? "true" : schema.spec.resources.map(r, r.id + ".ready().orValue(false)").join(" && ")) + " ? 'ACTIVE' : 'IN_PROGRESS'}",
+                          "conditions": [
+                            {
+                              "type": "Ready",
+                              "status": "${" + (schema.spec.resources.size() == 0 ? "true" : schema.spec.resources.map(r, r.id + ".ready().orValue(false)").join(" && ")) + " ? 'True' : 'False'}",
+                              "reason": "Ready",
+                              "observedGeneration": instance.metadata.generation,
+                              "lastTransitionTime": instance.metadata.creationTimestamp
+                            }
+                          ]
+                        }.merge(schema.?spec.?schema.?status.orValue({}))
+                      }}]
+                    }}
+
+            # ─── L1: Write status back to the RGD ────────────────────────────
+            - id: rgdStatus
+              propagateWhen:
+                - "${${!validation.result.valid || crd.ready().orValue(false)}}"
+              lifecycle:
+                apply: Force
+              patch:
+                apiVersion: kro.run/v1alpha1
+                kind: ResourceGraphDefinition
+                metadata:
+                  name: ${${schema.metadata.name}}
+                status:
+                  state: '${${validation.result.valid && crd.ready().orValue(false) ? "Active" : "Inactive"}}'
+                  topologicalOrder: "${${checks.allIDs}}"
+                  conditions:
+                    - type: Ready
+                      status: '${${validation.result.valid && crd.ready().orValue(false) ? "True" : "False"}}'
+                      reason: '${${validation.result.valid && crd.ready().orValue(false) ? "Ready" : "Invalid"}}'
+                      message: '${${validation.result.valid ? "" : validation.result.message}}'
+                      observedGeneration: ${${schema.metadata.generation}}
+                      lastTransitionTime: ${${schema.metadata.creationTimestamp}}
+                    - type: GraphAccepted
+                      status: '${${validation.result.valid ? "True" : "False"}}'
+                      reason: '${${validation.result.valid ? "Valid" : "Invalid"}}'
+                      message: '${${validation.result.valid ? "resource graph and schema are valid" : validation.result.message}}'
+                      observedGeneration: ${${schema.metadata.generation}}
+                      lastTransitionTime: ${${schema.metadata.creationTimestamp}}
+                    - type: KindReady
+                      status: '${${validation.result.valid && crd.ready().orValue(false) ? "True" : "False"}}'
+                      reason: '${${validation.result.valid && crd.ready().orValue(false) ? "Ready" : "Invalid"}}'
+                      message: '${${validation.result.valid ? "" : validation.result.message}}'
+                      observedGeneration: ${${schema.metadata.generation}}
+                      lastTransitionTime: ${${schema.metadata.creationTimestamp}}
+                    - type: ControllerReady
+                      status: "True"
+                      reason: Running
+                      message: controller is running
+                      observedGeneration: ${${schema.metadata.generation}}
+                      lastTransitionTime: ${${schema.metadata.creationTimestamp}}
+
+    # ─── L0: Mirror compilation status to RGDs ───────────────────────────────
+    #
+    # When a sub-Graph fails compilation, rgdStatus (inside L1) can't fire
+    # because the sub-Graph is inert. This node mirrors the Compiled condition
+    # from outside, also claiming Ready/state=Inactive when compilation fails.
+    # When compilation succeeds, it claims only Compiled — SSA relinquishes
+    # Ready and state for rgdStatus to own.
+    - id: compilationStatus
+      forEach:
+        - graph: ${rgds}
+      lifecycle:
+        apply: Force
+      patch: >-
+        ${
+          graph.?status.?conditions.orValue([]).exists(c, c.type == "Compiled" && c.status == "False")
+          ? {
+              "apiVersion": "kro.run/v1alpha1",
+              "kind": "ResourceGraphDefinition",
+              "metadata": {"name": graph.metadata.labels["kro.run/instance-name"]},
+              "status": {
+                "state": "Inactive",
+                "conditions": [
+                  {
+                    "type": "Compiled",
+                    "status": "False",
+                    "reason": graph.status.conditions.filter(c, c.type == "Compiled")[0].reason,
+                    "message": graph.status.conditions.filter(c, c.type == "Compiled")[0].message
+                  },
+                  {
+                    "type": "Ready",
+                    "status": "False",
+                    "reason": "CompilationFailed",
+                    "message": graph.status.conditions.filter(c, c.type == "Compiled")[0].message
+                  }
+                ]
+              }
+            }
+          : graph.?status.?conditions.orValue([]).exists(c, c.type == "Compiled" && c.status == "True")
+          ? {
+              "apiVersion": "kro.run/v1alpha1",
+              "kind": "ResourceGraphDefinition",
+              "metadata": {"name": graph.metadata.labels["kro.run/instance-name"]},
+              "status": {
+                "conditions": [
+                  {
+                    "type": "Compiled",
+                    "status": "True",
+                    "reason": "Compiled",
+                    "message": "Spec is valid"
+                  }
+                ]
+              }
+            }
+          : {
+              "apiVersion": "kro.run/v1alpha1",
+              "kind": "ResourceGraphDefinition",
+              "metadata": {"name": graph.metadata.labels["kro.run/instance-name"]},
+              "status": {
+                "conditions": [
+                  {
+                    "type": "Compiled",
+                    "status": "Unknown",
+                    "reason": "Reconciling",
+                    "message": "Waiting for graph compilation"
+                  }
+                ]
+              }
+            }
+        }

--- a/examples/graph/singleton.yaml
+++ b/examples/graph/singleton.yaml
@@ -1,0 +1,185 @@
+# KREP-024 Example: Singleton
+#
+# Demonstrates Graph's flexibility beyond the RGD pattern. A Singleton
+# declares a resource that should exist exactly once, with priority-based
+# resolution when multiple actors claim the same target.
+#
+# This is not an RGD — there is no schema, no CRD, no instances. It is
+# two Graphs that each want to own the same ConfigMap. The Singleton
+# controller (itself a Graph) resolves which one wins based on priority.
+#
+# When multiple Singletons target the same resource (same GVK + namespace
+# + name), the highest priority wins. Ties broken by name (lowest wins).
+# If the winner is deleted, the next-highest claimant takes over with zero
+# downtime — the resource UID never changes.
+# ---------------------------------------------------------------------------
+
+# Team A claims webapp-dashboard with priority 100
+---
+apiVersion: kro.run/v1alpha1
+kind: Singleton
+metadata:
+  name: team-a-dashboard
+spec:
+  priority: 100
+  template:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: webapp-dashboard
+      namespace: monitoring
+    data:
+      dashboard.json: '{ "title": "Team A Dashboard" }'
+
+# Team B claims the same resource with priority 200 — wins
+---
+apiVersion: kro.run/v1alpha1
+kind: Singleton
+metadata:
+  name: team-b-dashboard
+spec:
+  priority: 200
+  template:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: webapp-dashboard
+      namespace: monitoring
+    data:
+      dashboard.json: '{ "title": "Team B Dashboard" }'
+
+# Result:
+#   ConfigMap/monitoring/webapp-dashboard exists with Team B's content.
+#   If team-b-dashboard is deleted, Team A immediately becomes the winner.
+#   The ConfigMap is force-applied with Team A's template. No delete/recreate.
+#
+# Why this requires Graph (not RGD):
+#   RGD creates one Graph per instance — each Singleton would own its target
+#   independently, racing on delete. The Singleton controller is a fan-in
+#   Graph: all claimants are watched in a single Graph, which picks one
+#   winner and applies the target. Handoff is atomic.
+
+# ---------------------------------------------------------------------------
+# Singleton Controller — the Graph that implements the Singleton Kind.
+#
+# Fan-in pattern: a single long-lived Graph watches all Singleton CRs,
+# groups them by target identity (GVK + namespace + name), picks one
+# winner per identity by priority, and owns the target resource directly
+# via a forEach template. Status is written back to each Singleton CR.
+# ---------------------------------------------------------------------------
+---
+apiVersion: kro.run/v1alpha1
+kind: Graph
+metadata:
+  name: singleton
+  namespace: kro-system
+spec:
+  nodes:
+    # The Singleton CRD — created by this Graph using simpleSchema.
+    - id: crd
+      template:
+        apiVersion: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        metadata:
+          name: singletons.kro.run
+        spec:
+          group: kro.run
+          names:
+            plural: singletons
+            singular: singleton
+            kind: Singleton
+            listKind: SingletonList
+          scope: Namespaced
+          versions:
+            - name: v1alpha1
+              served: true
+              storage: true
+              subresources:
+                status: {}
+              schema:
+                openAPIV3Schema: >-
+                  ${simpleSchema.toOpenAPI({
+                    "apiVersion": "kro.run/v1alpha1",
+                    "kind": "Singleton",
+                    "spec": {
+                      "priority": "integer | default=0",
+                      "template": "object"
+                    },
+                    "status": {
+                      "active": "boolean",
+                      "claim": "string"
+                    }
+                  }, [])}
+              additionalPrinterColumns:
+                - name: Claim
+                  type: string
+                  jsonPath: .status.claim
+                - name: Priority
+                  type: integer
+                  jsonPath: .spec.priority
+                - name: Active
+                  type: boolean
+                  jsonPath: .status.active
+                - name: Age
+                  type: date
+                  jsonPath: .metadata.creationTimestamp
+
+    # Watch all Singleton CRs.
+    - id: singletons
+      includeWhen:
+        - ${has(crd.status) && has(crd.status.conditions) && crd.status.conditions.exists(c, c.type == 'Established' && c.status == 'True')}
+      watch:
+        apiVersion: kro.run/v1alpha1
+        kind: Singleton
+        selector: {}
+
+    # Flatten each singleton into {key, name, namespace, priority, creationTimestamp, identity, template}.
+    # key = namespace/name composite for cross-namespace uniqueness.
+    - id: claims
+      forEach:
+        - s: ${singletons}
+      def:
+        key: ${s.metadata.namespace + "/" + s.metadata.name}
+        name: ${s.metadata.name}
+        namespace: ${s.metadata.namespace}
+        priority: ${s.spec.priority}
+        creationTimestamp: ${s.metadata.creationTimestamp}
+        template: ${s.spec.template}
+        identity: >-
+          ${s.spec.template.apiVersion
+            + (has(s.spec.template.metadata.namespace)
+               ? "/namespaces/" + s.spec.template.metadata.namespace
+               : "")
+            + "/" + s.spec.template.kind
+            + "/" + s.spec.template.metadata.name}
+
+    # Apply one target resource per unique identity, using the winner's template.
+    # A claim is the winner if its key matches the first entry after sorting
+    # by priority desc, creationTimestamp asc.
+    - id: targets
+      forEach:
+        - c: >-
+            ${claims.filter(c,
+              c.key == claims.filter(x, x.identity == c.identity)
+                .sortBy(x, x.creationTimestamp)
+                .sortBy(x, -x.priority)[0].key)}
+      lifecycle:
+        apply: Force
+      template: "${c.template}"
+
+    # Status writeback — patch each Singleton CR with active + claim.
+    - id: status
+      forEach:
+        - c: ${claims}
+      patch:
+        apiVersion: kro.run/v1alpha1
+        kind: Singleton
+        metadata:
+          name: ${c.name}
+          namespace: ${c.namespace}
+        status:
+          active: >-
+            ${c.key == claims.filter(x, x.identity == c.identity)
+              .sortBy(x, x.creationTimestamp)
+              .sortBy(x, -x.priority)[0].key}
+          claim: "${c.identity}"


### PR DESCRIPTION
## Summary

Proposes Graph as a new `kro.run/v1alpha1` Kind — the atomic runtime primitive for composing
Kubernetes resources. Graph provides resource composition alone, separable from Kind definition
and instance management. Higher-level abstractions (RGD, Kind) rebuild from Graph via recursive
nested composition.

Validated by implementing the full RGD system as three levels of nested Graphs (L0 controller →
L1 per-RGD → L2 per-instance), passing 23/36 upstream compatibility tests with remaining gaps
due to prototype immaturity.

## Contents

- `docs/design/proposals/graph.md` — the KREP
- `examples/graph/rgd.yaml` — RGD implemented as nested Graphs
- `examples/graph/singleton.yaml` — fan-in pattern (usage + controller)

## Context

This formalizes work from the [krocodile](https://github.com/ellistarn/kro/tree/krocodile) prototype branch.