### PR TITLE
fix(cel): accept whole-valued float64 for integer-typed schema fields

### DIFF
--- a/pkg/cel/unstructured/valunstructured.go
+++ b/pkg/cel/unstructured/valunstructured.go
@@ -21,6 +21,7 @@ package unstructured
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"sync"
 	"time"
@@ -180,6 +181,14 @@ func UnstructuredToVal(unstructured interface{}, schema common.Schema) ref.Val {
 			return types.Int(v)
 		case int64:
 			return types.Int(v)
+		case float64:
+			// encoding/json decodes every JSON number as float64; accept whole
+			// values that fit in int64 so integer-typed CRD fields work end-to-end.
+			// Reject non-integer floats explicitly rather than silently truncating.
+			if !math.IsNaN(v) && !math.IsInf(v, 0) && v == math.Trunc(v) && v >= math.MinInt64 && v <= math.MaxInt64 {
+				return types.Int(int64(v))
+			}
+			return types.NewErr("invalid data, expected int, got non-integer float %v", v)
 		default:
 			return types.NewErr("invalid data, expected int, got %T", unstructured)
 		}

--- a/pkg/cel/unstructured/valunstructured_test.go
+++ b/pkg/cel/unstructured/valunstructured_test.go
@@ -18,6 +18,7 @@ package unstructured
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -202,11 +203,32 @@ func TestUnstructuredToVal_Integer(t *testing.T) {
 		{"int", int(42)},
 		{"int32", int32(42)},
 		{"int64", int64(42)},
+		{"float64 whole", float64(42)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			val := UnstructuredToVal(tt.input, schema("integer"))
 			assert.Equal(t, types.Int(42), val)
+		})
+	}
+}
+
+func TestUnstructuredToVal_Integer_RejectsNonInteger(t *testing.T) {
+	tests := []struct {
+		name  string
+		input interface{}
+	}{
+		{"float64 fractional", float64(1.5)},
+		{"float64 NaN", math.NaN()},
+		{"float64 +Inf", math.Inf(1)},
+		{"float64 -Inf", math.Inf(-1)},
+		{"string", "1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val := UnstructuredToVal(tt.input, schema("integer"))
+			_, isErr := val.(*types.Err)
+			assert.True(t, isErr, "expected *types.Err for input %v, got %T", tt.input, val)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #1303.

UnstructuredToVal rejected every value arriving as float64 when the destination OpenAPI schema declared type: integer. The integer switch only handled Go int / int32 / int64 - but every JSON number decoded by encoding/json (the default behind unstructured.Unstructured) is float64. So any integer-typed CRD field that flowed through this adapter triggered:

` invalid data, expected int, got float64`

This is asymmetric with the number branch immediately above, which accepts both ints and floats.

This completes the work of #1080, whose stated goal was to make "integers as ints rather than floats" - by handling the case where the incoming value is already a float64 from JSON decoding.

Accept float64 if and only if it is a whole number that fits in int64; reject NaN, infinities, and non-integer floats explicitly so no silent truncation can occur.

Tests: `TestUnstructuredToVal_Integer` extended with a `float64 whole` case; new `TestUnstructuredToVal_Integer_RejectsNonInteger` for fractional / NaN / ±Inf / string. No change for existing `int / int32 / int64` callers.
