### PR TITLE
pkg/graph: expose options for NewBuilder()

### DIFF
--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -49,23 +49,32 @@ import (
 	"github.com/kubernetes-sigs/kro/pkg/simpleschema"
 )
 
-// NewBuilder creates a new GraphBuilder instance.
-func NewBuilder(clientConfig *rest.Config, httpClient *http.Client) (*Builder, error) {
-	schemaResolver, err := schemaresolver.NewCombinedResolver(clientConfig, httpClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create schema resolver: %w", err)
+// NewBuilder creates a new Builder. By default it uses CombinedResolver for
+// schema resolution and DynamicRESTMapper for resource discovery. Both can be
+// overridden with BuilderOptions.
+func NewBuilder(clientConfig *rest.Config, httpClient *http.Client, opts ...BuilderOption) (*Builder, error) {
+	b := &Builder{}
+	for _, opt := range opts {
+		opt(b)
 	}
 
-	rm, err := apiutil.NewDynamicRESTMapper(clientConfig, httpClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create dynamic REST mapper: %w", err)
+	if b.schemaResolver == nil {
+		sr, err := schemaresolver.NewCombinedResolver(clientConfig, httpClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create schema resolver: %w", err)
+		}
+		b.schemaResolver = sr
 	}
 
-	rgBuilder := &Builder{
-		schemaResolver: schemaResolver,
-		restMapper:     rm,
+	if b.restMapper == nil {
+		rm, err := apiutil.NewDynamicRESTMapper(clientConfig, httpClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create dynamic REST mapper: %w", err)
+		}
+		b.restMapper = rm
 	}
-	return rgBuilder, nil
+
+	return b, nil
 }
 
 // Builder is an object that is responsible for constructing and managing
@@ -95,6 +104,19 @@ type Builder struct {
 	// schemaResolver is used to resolve the OpenAPI schema for the resources.
 	schemaResolver resolver.SchemaResolver
 	restMapper     meta.RESTMapper
+}
+
+// BuilderOption is an option for configuring a Builder.
+type BuilderOption func(*Builder)
+
+// WithSchemaResolver allows configuring a custom SchemaResolver for a Builder.
+func WithSchemaResolver(r resolver.SchemaResolver) BuilderOption {
+	return func(b *Builder) { b.schemaResolver = r }
+}
+
+// WithRESTMapper allows configuring a custom RESTMapper for a Builder.
+func WithRESTMapper(rm meta.RESTMapper) BuilderOption {
+	return func(b *Builder) { b.restMapper = rm }
 }
 
 // RGDConfig holds RGD runtime configuration parameters.

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -2235,20 +2235,57 @@ func TestGraphBuilder_CELTypeChecking(t *testing.T) {
 }
 
 func TestNewBuilder(t *testing.T) {
+	fakeResolver, fakeDiscovery := k8s.NewFakeResolver()
+	fakeRESTMapper := restmapper.NewDeferredDiscoveryRESTMapper(memory2.NewMemCacheClient(fakeDiscovery))
+
 	tests := []struct {
 		name    string
 		config  *rest.Config
 		client  *http.Client
+		opts    []BuilderOption
 		wantErr string
 	}{
-		{name: "success", config: &rest.Config{}, client: &http.Client{}},
-		{name: "schema resolver creation failure", config: &rest.Config{Host: "://bad"}, client: &http.Client{}, wantErr: "failed to create schema resolver"},
-		{name: "rest mapper creation failure", config: &rest.Config{}, client: nil, wantErr: "failed to create dynamic REST mapper"},
+		{
+			name:   "success with defaults",
+			config: &rest.Config{},
+			client: &http.Client{},
+		},
+		{
+			name:   "success with WithSchemaResolver",
+			config: &rest.Config{},
+			client: &http.Client{},
+			opts:   []BuilderOption{WithSchemaResolver(fakeResolver)},
+		},
+		{
+			name:   "success with WithRESTMapper",
+			config: &rest.Config{},
+			client: &http.Client{},
+			opts:   []BuilderOption{WithRESTMapper(fakeRESTMapper)},
+		},
+		{
+			name:   "success with both options overridden skips defaults",
+			config: &rest.Config{Host: "://bad"}, // would fail default resolver creation
+			client: nil,                          // would fail default REST mapper creation
+			opts:   []BuilderOption{WithSchemaResolver(fakeResolver), WithRESTMapper(fakeRESTMapper)},
+		},
+		{
+			name:    "schema resolver creation failure",
+			config:  &rest.Config{Host: "://bad"},
+			client:  &http.Client{},
+			wantErr: "failed to create schema resolver",
+		},
+		{
+			name:    "rest mapper creation failure",
+			config:  &rest.Config{},
+			client:  nil,
+			opts:    []BuilderOption{WithSchemaResolver(fakeResolver)},
+			wantErr: "failed to create dynamic REST mapper",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			builder, err := NewBuilder(tt.config, tt.client)
+			builder, err := NewBuilder(tt.config, tt.client, tt.opts...)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)


### PR DESCRIPTION
i am building a "kro aware" controller that works with [kcp](https://github.com/kcp-dev/kcp), but i faced a blocker where the function NewBuilder() had to be forked to work with this setup. instead of forking it to support kcp and aggregated api servers, i propose this minimal backwards compatible change to NewBuilder().

(copied from the commit message)

```
Expose the resolver and rest mapper of NewBuilder()
as options following a 'builder' pattern.

In NewBuilder(), NewCombinedResolver() returns
a resolver which is entirely /openapi based.
Passing a custom schema resolver is useful
when the API types being referenced
in the RGD are not served from the cluster's standard
/openapi discovery endpoint e.g. types served
through kcp virtual workspaces or aggregated API servers.

A custom rest mapper is useful when resource discovery
should not use the host cluster's standard discovery
endpoint (e.g. vs a kcp virtual workspaces) or in tests
where a fake mapper is preferred over a live
API server call.

Add minimal UT updates too.
```
