### PR TITLE
Update 02-conditional-creation.md

### DIFF
--- a/website/versioned_docs/version-0.9.2/docs/concepts/rgd/02-resource-definitions/02-conditional-creation.md
+++ b/website/versioned_docs/version-0.9.2/docs/concepts/rgd/02-resource-definitions/02-conditional-creation.md
@@ -13,6 +13,11 @@ kro provides the `includeWhen` field to make resources optional. When you add `i
 Here's a simple example where an Ingress resource is only created if the user enables it in their instance spec:
 
 ```kro
+spec:
+  name: string
+  ingress:
+    enabled: boolean | default=false
+# ... rest of spec configuration ...
 resources:
   - id: ingress
     includeWhen:


### PR DESCRIPTION
This pull request adds documentation to clarify how to use the `includeWhen` field in resource definitions, specifically showing how to conditionally create resources like an Ingress based on user input in the instance spec.

Documentation update:

* Added an example to `website/versioned_docs/version-0.9.2/docs/concepts/rgd/02-resource-definitions/02-conditional-creation.md` demonstrating how to use the `includeWhen` field to make the creation of an Ingress resource conditional on the `enabled` value in the spec.