### PR TITLE
fix: reject CEL bytes-typed expressions at RGD compile time

### DIFF
--- a/pkg/cel/conversion/conversions.go
+++ b/pkg/cel/conversion/conversions.go
@@ -176,3 +176,21 @@ func IsBoolOrOptionalBool(t *cel.Type) bool {
 	optionalBool := cel.OptionalType(cel.BoolType)
 	return optionalBool.IsAssignableType(t)
 }
+
+// IsBytesOrOptionalBytes checks if a CEL type is bytes or optional_type(bytes).
+// CEL `bytes` (e.g. the result of hash.sha256/hash.md5/hash.fnv64a) cannot be
+// represented in a Kubernetes unstructured object: it resolves to a Go []byte,
+// which is not a valid JSON value and panics ("cannot deep copy []uint8") in
+// apimachinery's runtime.DeepCopyJSONValue when the object is deep-copied or
+// persisted. kro therefore rejects bytes-typed field/status expressions at RGD
+// compile time instead of letting them crash the controller at runtime.
+func IsBytesOrOptionalBytes(t *cel.Type) bool {
+	// Note: A.IsAssignableType(B) means "A accepts B", so we check if bytes accepts t.
+	if cel.BytesType.IsAssignableType(t) {
+		return true
+	}
+
+	// Check if it's optional_type(bytes)
+	optionalBytes := cel.OptionalType(cel.BytesType)
+	return optionalBytes.IsAssignableType(t)
+}

--- a/pkg/cel/conversion/conversions_test.go
+++ b/pkg/cel/conversion/conversions_test.go
@@ -225,3 +225,25 @@ func TestGoNativeType_Timestamp(t *testing.T) {
 	assert.NoError(t, err, "Should be JSON marshallable")
 	assert.NotEmpty(t, marshalled)
 }
+
+func TestIsBytesOrOptionalBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		t    *cel.Type
+		want bool
+	}{
+		{name: "bytes", t: cel.BytesType, want: true},
+		{name: "optional bytes", t: cel.OptionalType(cel.BytesType), want: true},
+		{name: "string", t: cel.StringType, want: false},
+		{name: "optional string", t: cel.OptionalType(cel.StringType), want: false},
+		{name: "int", t: cel.IntType, want: false},
+		{name: "bool", t: cel.BoolType, want: false},
+		{name: "list of bytes", t: cel.ListType(cel.BytesType), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsBytesOrOptionalBytes(tt.t))
+		})
+	}
+}

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -835,7 +835,15 @@ func buildStatusSchema(
 			return nil, nil, nil, fmt.Errorf("failed to type-check status expression %q at path %q: %w", expression.UserExpression(), fieldDescriptor.Path, err)
 		}
 
-		statusTypeMap[fieldDescriptor.Path] = checkedAST.OutputType()
+		outputType := checkedAST.OutputType()
+		if conversion.IsBytesOrOptionalBytes(outputType) {
+			return nil, nil, nil, fmt.Errorf(
+				"status expression %q at path %q returns type %q, which cannot be represented in a Kubernetes object; wrap it in base64.encode(...) or string(...)",
+				expression.UserExpression(), fieldDescriptor.Path, outputType.String(),
+			)
+		}
+
+		statusTypeMap[fieldDescriptor.Path] = outputType
 	}
 
 	// convert the CEL types to OpenAPI schema - best effort.
@@ -1227,6 +1235,17 @@ func validateAndCompileTemplates(
 // validateExpressionType verifies that the CEL expression output type matches
 // the expected type. Returns an error if there is a type mismatch.
 func validateExpressionType(outputType, expectedType *cel.Type, expression, resourceID, path string, typeProvider *krocel.DeclTypeProvider) error {
+	// CEL `bytes` cannot be represented in a Kubernetes object: it resolves to a
+	// Go []byte and panics ("cannot deep copy []uint8") in apimachinery's
+	// DeepCopyJSONValue when the resolved object is deep-copied or persisted.
+	// Reject it here rather than letting it crash the controller at runtime.
+	if conversion.IsBytesOrOptionalBytes(outputType) {
+		return fmt.Errorf(
+			"expression %q at path %q in resource %q returns type %q, which cannot be represented in a Kubernetes object; wrap it in base64.encode(...) or string(...)",
+			expression, path, resourceID, outputType.String(),
+		)
+	}
+
 	// Try CEL's built-in nominal type checking first
 	if expectedType.IsAssignableType(outputType) {
 		return nil

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -2217,6 +2217,81 @@ func TestGraphBuilder_CELTypeChecking(t *testing.T) {
 			wantErr: true,
 			errMsg:  "type mismatch",
 		},
+		{
+			name: "status field returning bytes is rejected",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					map[string]interface{}{
+						"digest": "${hash.sha256(configmap.metadata.name)}",
+					},
+				),
+				generator.WithResource("configmap", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "${schema.spec.name}",
+					},
+					"data": map[string]interface{}{
+						"key": "value",
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "cannot be represented in a Kubernetes object",
+		},
+		{
+			name: "resource field returning bytes is rejected",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("configmap", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "test-config",
+					},
+					"data": map[string]interface{}{
+						"digest": "${hash.sha256(schema.spec.name)}",
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "cannot be represented in a Kubernetes object",
+		},
+		{
+			name: "status field with base64-encoded hash is accepted",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					map[string]interface{}{
+						"digest": "${base64.encode(hash.sha256(configmap.metadata.name))}",
+					},
+				),
+				generator.WithResource("configmap", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "${schema.spec.name}",
+					},
+					"data": map[string]interface{}{
+						"key": "value",
+					},
+				}, nil, nil),
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/integration/suites/core/status_test.go
+++ b/test/integration/suites/core/status_test.go
@@ -136,6 +136,62 @@ var _ = Describe("Status", func() {
 		}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 	})
 
+	It("should reject a status field whose expression returns bytes", func(ctx SpecContext) {
+		// Regression test for the "cannot deep copy []uint8" controller panic:
+		// a status field returning CEL bytes (e.g. hash.sha256) resolves to a Go
+		// []byte, which is not representable in a Kubernetes object. Such RGDs
+		// must be rejected at build time so they never reach the instance
+		// controller and crash it.
+		rgd := generator.NewResourceGraphDefinition("test-status-bytes",
+			generator.WithSchema(
+				"StatusBytes", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+				},
+				map[string]interface{}{
+					"digest": "${hash.sha256(configmap.metadata.name)}",
+				},
+			),
+			generator.WithResource("configmap", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}",
+				},
+				"data": map[string]interface{}{
+					"key": "value",
+				},
+			}, nil, nil),
+		)
+
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+
+		//nolint:dupl // we have many test cases checking for inactivity but with different conditions
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name: rgd.Name,
+			}, rgd)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
+
+			var crdCondition *krov1alpha1.Condition
+			for _, cond := range rgd.Status.Conditions {
+				if cond.Type == resourcegraphdefinition.Ready {
+					crdCondition = &cond
+					break
+				}
+			}
+
+			g.Expect(crdCondition).ToNot(BeNil())
+			g.Expect(crdCondition.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(*crdCondition.Message).To(ContainSubstring("cannot be represented in a Kubernetes object"))
+		}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+
 	It("should interpolate string templates in instance status", func(ctx SpecContext) {
 		// This test verifies that status fields with string templates like
 		// "${configmap.metadata.name}-${configmap.metadata.namespace}" are properly


### PR DESCRIPTION
Fixes #1308

## Problem

An RGD whose status (or resource template) field uses a CEL expression that evaluates to the CEL **`bytes`** type (e.g. an unwrapped `hash.sha256(...)`/`hash.md5(...)`/`hash.fnv64a(...)`) is accepted and installs its CRD, but the first instance reconcile panics with `cannot deep copy []uint8` and crashloops the controller. Since the panic is in the shared dynamic-controller worker, a single malformed RGD takes down the controller for every RGD it serves. Full repro, panic stack, and root-cause walkthrough are in #1308.

In short: `bytes` resolves to a Go `[]byte`, which is not a valid JSON/unstructured value and panics in apimachinery's `DeepCopyJSONValue` when the resolved status is deep-copied during `updateStatus`.

## Fix

Reject `bytes`-typed expressions at **RGD compile/validation time**, mirroring the existing `validateConditionExpression` (bool) precedent, instead of letting the value reach the runtime and crash the controller. The error surfaces as `GraphAccepted=False` on the RGD (no controller changes needed), so a malformed RGD is rejected cleanly and never produces an installable CRD or instance.

We deliberately do **not** change `GoNativeType`: it is a shared conversion helper used on multiple paths, and silently re-encoding bytes (e.g. to base64) there would mask the user error and change behavior for other callers. Validation belongs at the type-checking layer.

Changes:

- **`pkg/cel/conversion/conversions.go`**: add `IsBytesOrOptionalBytes(t *cel.Type) bool`, mirroring `IsBoolOrOptionalBool`.
- **`pkg/graph/builder.go`**: reject bytes at the two output-type chokepoints:
  - `buildStatusSchema` (status fields are type-*inferred*, so they aren't caught by the expected-type check).
  - `validateExpressionType` (covers all resource template fields).

  Both return a clear, actionable error:

  ```
  ... returns type "bytes", which cannot be represented in a Kubernetes object;
  wrap it in base64.encode(...) or string(...)
  ```

Well-formed RGDs are unaffected; the idiomatic `${base64.encode(hash.sha256(...))}` (which returns `string`) continues to work.

## Behavior change

Using the repro from #1308 (`status.digest: ${hash.sha256(configmap.metadata.name)}`):

**Before:** the RGD is accepted, the CRD is installed, and the first instance reconcile panics and crashloops the controller.

**After:** the RGD is rejected at build time and never installs a CRD or touches the controller:

```console
$ kubectl get rgd hashbug -o jsonpath='{.status.state}'
Inactive

$ kubectl get rgd hashbug \
    -o jsonpath='{range .status.conditions[*]}{.type}={.status}: {.message}{"\n"}{end}'
GraphAccepted=False: failed to build instance status schema: status expression \
  "hash.sha256(configmap.metadata.name)" at path "digest" returns type "bytes", \
  which cannot be represented in a Kubernetes object; wrap it in \
  base64.encode(...) or string(...)
Ready=False: failed to build instance status schema: ...
```

Wrapping the expression so it returns a `string` (`${base64.encode(hash.sha256(configmap.metadata.name))}`) makes the RGD `Active` and the instance reconciles with a populated status:

```console
$ kubectl get hashok demo -o jsonpath='{.status.digest}{"  "}{.status.state}'
MnFaN4sAFC2DRpyox4IxI6gl9UB7bt6OlUuUq2fb67o=  ACTIVE
```

## Tests

- **`pkg/cel/conversion/conversions_test.go`**: `TestIsBytesOrOptionalBytes` (bytes / optional(bytes) -> true; string/int/bool/list-of-bytes -> false).
- **`pkg/graph/builder_test.go`**: added to the CEL type-checking table:
  - status field returning bytes -> rejected;
  - resource field returning bytes -> rejected;
  - status field with `base64.encode(hash.sha256(...))` -> accepted (positive control).
- **`test/integration/suites/core/status_test.go`** (envtest): an RGD with a bytes status field becomes `Inactive` with `Ready=False` carrying the "cannot be represented in a Kubernetes object" message.

Confirmed before the fix: a controller-level test driving a `${hash.sha256(...)}` status field through `updateStatus` panics with `cannot deep copy []uint8`. After the fix the RGD is rejected at build time and the controller is never handed the bytes value.

```
make test WHAT=unit            # pass
make test WHAT=integration     # pass (Ran 1 of 139, new spec included)
make lint                      # 0 issues
```

## Live validation (real EKS cluster)

Built the patched image with `ko`, pushed to ECR, deployed via the Helm chart to an EKS 1.34 cluster, and exercised both paths:

- **Negative (the bug):** the bytes-status RGD produced `Inactive`/`GraphAccepted=False` with the expected message; **no CRD created; controller pod stayed `Running` with 0 restarts and no panic in logs.**
- **Positive:** the `base64.encode(...)` RGD produced `Active`/`GraphAccepted=True`; an instance reconciled to `ACTIVE` with `status.digest` populated as the correct base64 SHA-256 string, verified against an independent computation.