### PR TITLE
fix: recover panics in dynamic controller instance reconcile

### DIFF
--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -59,6 +59,7 @@ package dynamiccontroller
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -288,7 +289,7 @@ func (dc *DynamicController) processNextWorkItem(ctx context.Context) bool {
 	return true
 }
 
-func (dc *DynamicController) syncFunc(ctx context.Context, oi ObjectIdentifiers, handler Handler) error {
+func (dc *DynamicController) syncFunc(ctx context.Context, oi ObjectIdentifiers, handler Handler) (err error) {
 	gvrKey := keyFromGVR(oi.GVR)
 	dc.log.V(1).Info("Syncing object", "gvr", gvrKey, "key", oi.NamespacedName)
 
@@ -301,7 +302,22 @@ func (dc *DynamicController) syncFunc(ctx context.Context, oi ObjectIdentifiers,
 			"gvr", gvrKey, "key", oi.NamespacedName, "duration", duration)
 	}()
 
-	err := handler(ctx, ctrl.Request{NamespacedName: oi.NamespacedName})
+	// Recover handler panics so one bad instance can't crash the worker; convert
+	// to an error for the normal requeue path. Also count as a handler error.
+	defer func() {
+		if r := recover(); r != nil {
+			metrics.DynReconcilePanicsTotal.WithLabelValues(gvrKey).Inc()
+			metrics.DynHandlerErrorsTotal.WithLabelValues(gvrKey).Inc()
+			err = fmt.Errorf("recovered from panic in reconcile: %v", r)
+			dc.log.Error(err, "Recovered from panic in instance reconcile",
+				"gvr", gvrKey, "key", oi.NamespacedName)
+			// Stack at V(1) to avoid log spam when a panic repeats every requeue.
+			dc.log.V(1).Info("Panic stack trace",
+				"gvr", gvrKey, "key", oi.NamespacedName, "stack", string(debug.Stack()))
+		}
+	}()
+
+	err = handler(ctx, ctrl.Request{NamespacedName: oi.NamespacedName})
 	// Do not count expected outcomes as handler errors: instance deleted (NotFound)
 	// and requeue signals (RequeueNeeded/RequeueNeededAfter) are normal control flow.
 	if err != nil && !apierrors.IsNotFound(err) && !requeue.IsRequeueError(err) {

--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/metrics"
 	"github.com/kubernetes-sigs/kro/pkg/requeue"
 )
 
@@ -476,6 +478,51 @@ func TestProcessNextWorkItem_RequeueBehaviors(t *testing.T) {
 		result := dc.processNextWorkItem(t.Context())
 		assert.False(t, result)
 	})
+}
+
+// TestProcessNextWorkItem_RecoversPanic verifies a panicking handler is
+// recovered per item and rate-limit requeued instead of crashing the process.
+func TestProcessNextWorkItem_RecoversPanic(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1.AddMetaToScheme(scheme))
+	client := fake.NewSimpleMetadataClient(scheme)
+	mapper := meta.NewDefaultRESTMapper(scheme.PreferredVersionAllGroups())
+
+	parentGVR := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
+	oi := ObjectIdentifiers{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+		GVR:            parentGVR,
+	}
+
+	cfg := testConfig()
+	cfg.MinRetryDelay = 1 * time.Millisecond
+	cfg.MaxRetryDelay = 5 * time.Millisecond
+	cfg.RateLimit = 1000
+	dc := NewDynamicController(noopLogger(), cfg, client, mapper)
+	dc.handlers.Store(parentGVR, Handler(func(ctx context.Context, req controllerruntime.Request) error {
+		panic("boom")
+	}))
+
+	// DynReconcilePanicsTotal is a never-reset global, so assert on the delta.
+	// Relies on parentGVR being unique here; do not run with t.Parallel().
+	gvrKey := keyFromGVR(parentGVR)
+	before := testutil.ToFloat64(metrics.DynReconcilePanicsTotal.WithLabelValues(gvrKey))
+
+	dc.queue.Add(oi)
+
+	// The panic must be recovered: processNextWorkItem returns normally (true)
+	// instead of crashing the process.
+	result := dc.processNextWorkItem(t.Context())
+	assert.True(t, result)
+
+	// The recovered panic is treated as a generic error and rate-limit requeued.
+	require.Eventually(t, func() bool {
+		return dc.queue.Len() == 1
+	}, 100*time.Millisecond, 1*time.Millisecond, "item should be requeued after a recovered panic")
+
+	// The panic counter for this GVR was incremented.
+	after := testutil.ToFloat64(metrics.DynReconcilePanicsTotal.WithLabelValues(gvrKey))
+	assert.Equal(t, before+1, after, "reconcile panic metric should increment")
 }
 
 func TestGracefulShutdown_Timeout(t *testing.T) {

--- a/pkg/metrics/dynamiccontroller.go
+++ b/pkg/metrics/dynamiccontroller.go
@@ -70,6 +70,13 @@ var (
 		},
 		[]string{"gvr"},
 	)
+	DynReconcilePanicsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "dynamic_controller_reconcile_panics_total",
+			Help: "Total number of panics recovered during reconciliation per GVR",
+		},
+		[]string{"gvr"},
+	)
 	DynInformerSyncDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "dynamic_controller_informer_sync_duration_seconds",

--- a/pkg/metrics/register.go
+++ b/pkg/metrics/register.go
@@ -49,6 +49,7 @@ func Register(registry prometheus.Registerer) {
 		DynHandlerAttachTotal,
 		DynHandlerDetachTotal,
 		DynHandlerErrorsTotal,
+		DynReconcilePanicsTotal,
 		DynInformerSyncDuration,
 		DynInformerEventsTotal,
 		DynWatchCount,

--- a/website/docs/docs/advanced/04-metrics.md
+++ b/website/docs/docs/advanced/04-metrics.md
@@ -34,6 +34,7 @@ metrics:
 | `dynamic_controller_reconcile_duration_seconds` | Histogram | Duration of reconciliations per GVR in seconds | ALPHA |
 | `dynamic_controller_requeue_total` | Counter | Total number of requeues per GVR and requeue type | ALPHA |
 | `dynamic_controller_handler_errors_total` | Counter | Total number of handler errors per GVR | ALPHA |
+| `dynamic_controller_reconcile_panics_total` | Counter | Total number of panics recovered during reconciliation per GVR | ALPHA |
 | `dynamic_controller_queue_length` | Gauge | Current length of the workqueue | ALPHA |
 | `dynamic_controller_gvr_count` | Gauge | Number of instance GVRs currently managed by the controller | ALPHA |
 | `dynamic_controller_handler_count_total` | Gauge | Number of active handlers by type (parent or child) | ALPHA |


### PR DESCRIPTION
Fixes #1310

## Problem

`DynamicController` runs each instance reconcile on a worker goroutine with no panic recovery, so a single panicking instance reconcile (for any RGD, any reason) unwinds the worker, crashes the whole kro process, and lands the pod in `CrashLoopBackOff`, halting reconciliation cluster-wide.

## Change

Add a per-item `recover()` in `syncFunc` so a panicking handler can no longer crash the worker goroutine (or the process). The panic is recovered and converted into a normal `error`, which flows through the existing requeue switch in `processNextWorkItem` onto the rate-limited path (requeue, then drop after `QueueMaxRetries`), the same treatment as any other unexpected reconcile error. A concise message is logged at `Error` level; the full stack is logged at `V(1)` to avoid log spam when a deterministic panic repeats on every requeue.

Each recovered panic increments a new `dynamic_controller_reconcile_panics_total{gvr}` counter (registered and documented), and also the existing `dynamic_controller_handler_errors_total{gvr}` so panics surface in the handler-error metric operators already watch.

## Testing

### Unit

Added `TestProcessNextWorkItem_RecoversPanic`: registers a handler that panics, drives it through `processNextWorkItem`, and asserts the call returns normally (no crash), the item is rate-limit requeued, and `DynReconcilePanicsTotal` increments. Without the fix this test crashes the test binary, so it is a genuine no-crash signal. `go build ./...`, `gofmt`, `golangci-lint` (pinned v2.11.4; `nakedret`/`unparam` enabled), and `go test ./pkg/dynamiccontroller/... ./pkg/metrics/...` all pass.

### End-to-end

Deployed the built image and applied the issue's reproduction (a deep-copy panic) alongside a healthy RGD/instance.

A recovered panic, with the full stack logged separately at `V(1)`:

```
2026-06-16T21:44:59Z	ERROR	dynamic-controller	Recovered from panic in instance reconcile	{"gvr": "kro.run/v1alpha1/panicreproes", "key": {"name":"panic-instance","namespace":"default"}, "error": "recovered from panic in reconcile: cannot deep copy []uint8"}
2026-06-16T21:44:59Z	DEBUG	dynamic-controller	Panic stack trace	{"gvr": "kro.run/v1alpha1/panicreproes", "key": {"name":"panic-instance","namespace":"default"}, "stack": "goroutine 197 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:26 +0x5e
github.com/kubernetes-sigs/kro/pkg/dynamiccontroller.(*DynamicController).syncFunc.func2()
	github.com/kubernetes-sigs/kro/pkg/dynamiccontroller/dynamic_controller.go:316 +0x2db
panic({0x208bdc0?, 0x19a248601c10?})
	runtime/panic.go:860 +0x13a
k8s.io/apimachinery/pkg/runtime.DeepCopyJSONValue({0x1f1db60?, 0x19a247dbb9e0?})
	k8s.io/apimachinery@v0.35.0/pkg/runtime/converter.go:646 +0x26e
k8s.io/apimachinery/pkg/runtime.DeepCopyJSONValue({0x2129c00?, 0x19a24857b980})
	k8s.io/apimachinery@v0.35.0/pkg/runtime/converter.go:630 +0x2e5
k8s.io/apimachinery/pkg/runtime.DeepCopyJSON(...)
	k8s.io/apimachinery@v0.35.0/pkg/runtime/converter.go:615
k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.NestedMap(...)
	k8s.io/apimachinery@v0.35.0/pkg/apis/meta/v1/unstructured/helpers.go:235 +0x3d
github.com/kubernetes-sigs/kro/pkg/controller/instance.(*Controller).updateStatus(...)
	github.com/kubernetes-sigs/kro/pkg/controller/instance/status.go:176 +0x38f
github.com/kubernetes-sigs/kro/pkg/controller/instance.(*Controller).Reconcile(...)
	github.com/kubernetes-sigs/kro/pkg/controller/instance/controller.go:292 +0xf34
github.com/kubernetes-sigs/kro/pkg/dynamiccontroller.(*DynamicController).syncFunc(...)
	github.com/kubernetes-sigs/kro/pkg/dynamiccontroller/dynamic_controller.go:320 +0x395
github.com/kubernetes-sigs/kro/pkg/dynamiccontroller.(*DynamicController).processNextWorkItem(...)
	github.com/kubernetes-sigs/kro/pkg/dynamiccontroller/dynamic_controller.go:251 +0x2c9
github.com/kubernetes-sigs/kro/pkg/dynamiccontroller.(*DynamicController).worker(...)
	github.com/kubernetes-sigs/kro/pkg/dynamiccontroller/dynamic_controller.go:229
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1(...)
	k8s.io/apimachinery@v0.35.0/pkg/util/wait/backoff.go:255 +0x51
...
created by github.com/kubernetes-sigs/kro/pkg/dynamiccontroller.(*DynamicController).Start in goroutine 195
	github.com/kubernetes-sigs/kro/pkg/dynamiccontroller/dynamic_controller.go:210 +0x1a5
"}
2026-06-16T21:44:59Z	ERROR	dynamic-controller	Error syncing item, requeuing with rate limit	{"item": {"name":"panic-instance","namespace":"default"}, "error": "recovered from panic in reconcile: cannot deep copy []uint8"}
```

The panic instance keeps recovering and requeuing with growing rate-limited backoff, while the healthy instance reconciles successfully in the middle of that loop and the process never crashes:

```
2026-06-16T21:45:24Z	DEBUG	dynamic-controller	Syncing object	{"gvr": "kro.run/v1alpha1/panicreproes", "key": {"name":"panic-instance","namespace":"default"}}
2026-06-16T21:45:25Z	ERROR	dynamic-controller	Recovered from panic in instance reconcile	{"gvr": "kro.run/v1alpha1/panicreproes", "key": {"name":"panic-instance","namespace":"default"}, "error": "recovered from panic in reconcile: cannot deep copy []uint8"}
2026-06-16T21:45:25Z	ERROR	dynamic-controller	Error syncing item, requeuing with rate limit	{"item": {"name":"panic-instance","namespace":"default"}, "error": "recovered from panic in reconcile: cannot deep copy []uint8"}
2026-06-16T21:45:27Z	DEBUG	dynamic-controller	Syncing object	{"gvr": "kro.run/v1alpha1/healthycms", "key": {"name":"healthy-instance","namespace":"default"}}
2026-06-16T21:45:27Z	DEBUG	dynamic-controller	Finished syncing object	{"gvr": "kro.run/v1alpha1/healthycms", "key": {"name":"healthy-instance","namespace":"default"}, "duration": "57.422272ms"}
```

The pod stayed `Running` with 0 restarts throughout, and the metrics confirm the healthy GVR reconciled cleanly while the panicking one was rate-limited:

```
dynamic_controller_reconcile_panics_total{gvr="kro.run/v1alpha1/panicreproes"} 9
dynamic_controller_handler_errors_total{gvr="kro.run/v1alpha1/panicreproes"} 9
dynamic_controller_requeue_total{gvr="kro.run/v1alpha1/panicreproes",type="rate_limited"} 9
dynamic_controller_reconcile_total{gvr="kro.run/v1alpha1/healthycms"} 5
```

## Notes

- Improving RGD type checking (#1308) addresses one trigger of reconcile-time panics, but compile-time validation cannot enumerate every possible panic. This change is the defense-in-depth recovery so that no single instance can take down the shared process.
- This recovers panics on the reconcile (worker) goroutine. Panics in goroutines a handler spawns itself remain fatal, an inherent Go limitation; the reconcile path is single-goroutine today.