### PR TITLE
docs(website): fix broken relative links in overview and resource-basics

### DIFF
--- a/website/docs/docs/concepts/rgd/02-resource-definitions/01-resource-basics.md
+++ b/website/docs/docs/concepts/rgd/02-resource-definitions/01-resource-basics.md
@@ -90,7 +90,7 @@ CEL expressions in resource templates can reference three things:
 3. **Other resources** - Any field from other resources in your RGD, including their `spec`, `metadata`, and `status`
 
 :::important
-When you reference another resource in a CEL expression, it automatically creates a dependency. This is an implicit way of declaring that one resource depends on another. kro uses these references to determine the correct creation order - ensuring the referenced resource exists before the one referencing it. Learn more about [Dependencies and Ordering](../dependencies-ordering).
+When you reference another resource in a CEL expression, it automatically creates a dependency. This is an implicit way of declaring that one resource depends on another. kro uses these references to determine the correct creation order - ensuring the referenced resource exists before the one referencing it. Learn more about [Dependencies and Ordering](../04-dependencies-ordering.md).
 :::
 :::important
 If a resource references a field, like `schema.spec.myfield` or `resourceid.spec.field`, or `resourceid.status.field`, it creates a hard dependency on the field being present in the instance. You are declaring that the field must exist. Any instance that does not specify that field will fail reconciliation. However, fields that have schema defaults can be safely omitted. Alternatively, you can declare a soft dependency by using the `?` operator, or using the `.orValue("value")` expression. Some examples would be `${resour.status.?vpcID}` or `${vpc.status.?vpcID.orValue("fallback")}`. For more information, see [The Optional Operator](./03-readiness.md#the-optional-operator-)
@@ -151,7 +151,7 @@ In this example:
 - `deployment` references `schema.spec` (name, replicas, image), `schema.metadata.namespace`, `database.metadata.annotations`, `database.spec.version`, and `database.status.endpoint`
 
 :::important
-kro automatically determines that `database` must be created before `deployment`. The deployment waits for the database's endpoint to be available before it can be created. Learn more about [Dependencies and Ordering](../dependencies-ordering).
+kro automatically determines that `database` must be created before `deployment`. The deployment waits for the database's endpoint to be available before it can be created. Learn more about [Dependencies and Ordering](../04-dependencies-ordering.md).
 :::
 
 ## CEL Property Verification
@@ -307,7 +307,7 @@ resources:
 </Tabs>
 </div>
 
-For more details, see [Static Type Checking](../static-type-checking).
+For more details, see [Static Type Checking](../05-static-type-checking.md).
 
 ## How kro Processes Templates
 
@@ -412,7 +412,7 @@ resources:
 </Tabs>
 </div>
 
-For more details, see [Static Type Checking](../static-type-checking).
+For more details, see [Static Type Checking](../05-static-type-checking.md).
 
 ## Validation Errors
 
@@ -510,7 +510,7 @@ status:
       message: "type mismatch in resource \"deployment\" at path \"spec.replicas\": expression \"schema.spec.name\" returns type \"string\" but expected \"integer\""
 ```
 
-For more information about validation errors and type checking, see [Static Type Checking](../static-type-checking).
+For more information about validation errors and type checking, see [Static Type Checking](../05-static-type-checking.md).
 
 ## Next Steps
 

--- a/website/docs/docs/overview.mdx
+++ b/website/docs/docs/overview.mdx
@@ -24,10 +24,10 @@ runtime failures.
 
 ## How it works
 
-A ResourceGraphDefinition has two parts: a [**schema**](./concepts/rgd/schema) that defines your API
-surface (the fields users fill in), and [**resource templates**](./concepts/rgd/resource-definitions/resource-basics) that reference
-those fields with [CEL expressions](./concepts/rgd/cel-expressions). kro parses the expressions, infers the
-[dependency graph](./concepts/rgd/dependencies-ordering), generates a CRD, and stands up a controller - all at runtime.
+A ResourceGraphDefinition has two parts: a [**schema**](./concepts/rgd/01-schema.md) that defines your API
+surface (the fields users fill in), and [**resource templates**](./concepts/rgd/02-resource-definitions/01-resource-basics.md) that reference
+those fields with [CEL expressions](./concepts/rgd/03-cel-expressions.md). kro parses the expressions, infers the
+[dependency graph](./concepts/rgd/04-dependencies-ordering.md), generates a CRD, and stands up a controller - all at runtime.
 
 <IntroFlow />
 
@@ -71,7 +71,7 @@ object.
 
 ### The definition behind it
 
-A **ResourceGraphDefinition** defines the API under `spec.schema` (see [Simple Schema](./concepts/rgd/schema)) and the
+A **ResourceGraphDefinition** defines the API under `spec.schema` (see [Simple Schema](./concepts/rgd/01-schema.md)) and the
 backing resources under `spec.resources`. CEL expressions (`${}`) are what tie
 those two parts together (this example uses S3 via
 [ACK](https://aws-controllers-k8s.github.io/docs/), but kro works with any
@@ -162,8 +162,8 @@ in custom controller code.
 
 ## Get started
 
-- [Install kro](./getting-started/Installation) to run the controller in your cluster
-- [Deploy your first RGD](./getting-started/deploy-a-resource-graph-definition) to create a new API end to end
-- [Browse examples](../../examples/) to see more patterns
+- [Install kro](./getting-started/01-Installation.md) to run the controller in your cluster
+- [Deploy your first RGD](./getting-started/02-deploy-a-resource-graph-definition.md) to create a new API end to end
+- [Browse examples](../examples/examples.md) to see more patterns
 
 Need help or want to contribute? Join [#kro on Kubernetes Slack](https://kubernetes.slack.com/archives/C081TMY9D6Y), browse [GitHub](https://github.com/kubernetes-sigs/kro), or read [Contributing](https://github.com/kubernetes-sigs/kro/blob/main/CONTRIBUTING.md).

--- a/website/versioned_docs/version-0.9.2/docs/concepts/rgd/02-resource-definitions/01-resource-basics.md
+++ b/website/versioned_docs/version-0.9.2/docs/concepts/rgd/02-resource-definitions/01-resource-basics.md
@@ -90,7 +90,7 @@ CEL expressions in resource templates can reference three things:
 3. **Other resources** - Any field from other resources in your RGD, including their `spec`, `metadata`, and `status`
 
 :::important
-When you reference another resource in a CEL expression, it automatically creates a dependency. This is an implicit way of declaring that one resource depends on another. kro uses these references to determine the correct creation order - ensuring the referenced resource exists before the one referencing it. Learn more about [Dependencies and Ordering](../dependencies-ordering).
+When you reference another resource in a CEL expression, it automatically creates a dependency. This is an implicit way of declaring that one resource depends on another. kro uses these references to determine the correct creation order - ensuring the referenced resource exists before the one referencing it. Learn more about [Dependencies and Ordering](../04-dependencies-ordering.md).
 :::
 :::important
 If a resource references a field, like `schema.spec.myfield` or `resourceid.spec.field`, or `resourceid.status.field`, it creates a hard dependency on the field being present in the instance. You are declaring that the field must exist. Any instance that does not specify that field will fail reconciliation. However, fields that have schema defaults can be safely omitted. Alternatively, you can declare a soft dependency by using the `?` operator, or using the `.orValue("value")` expression. Some examples would be `${resour.status.?vpcID}` or `${vpc.status.?vpcID.orValue("fallback")}`. For more information, see [The Optional Operator](./03-readiness.md#the-optional-operator-)
@@ -151,7 +151,7 @@ In this example:
 - `deployment` references `schema.spec` (name, replicas, image), `schema.metadata.namespace`, `database.metadata.annotations`, `database.spec.version`, and `database.status.endpoint`
 
 :::important
-kro automatically determines that `database` must be created before `deployment`. The deployment waits for the database's endpoint to be available before it can be created. Learn more about [Dependencies and Ordering](../dependencies-ordering).
+kro automatically determines that `database` must be created before `deployment`. The deployment waits for the database's endpoint to be available before it can be created. Learn more about [Dependencies and Ordering](../04-dependencies-ordering.md).
 :::
 
 ## CEL Property Verification
@@ -307,7 +307,7 @@ resources:
 </Tabs>
 </div>
 
-For more details, see [Static Type Checking](../static-type-checking).
+For more details, see [Static Type Checking](../05-static-type-checking.md).
 
 ## How kro Processes Templates
 
@@ -412,7 +412,7 @@ resources:
 </Tabs>
 </div>
 
-For more details, see [Static Type Checking](../static-type-checking).
+For more details, see [Static Type Checking](../05-static-type-checking.md).
 
 ## Validation Errors
 
@@ -510,7 +510,7 @@ status:
       message: "type mismatch in resource \"deployment\" at path \"spec.replicas\": expression \"schema.spec.name\" returns type \"string\" but expected \"integer\""
 ```
 
-For more information about validation errors and type checking, see [Static Type Checking](../static-type-checking).
+For more information about validation errors and type checking, see [Static Type Checking](../05-static-type-checking.md).
 
 ## Next Steps
 

--- a/website/versioned_docs/version-0.9.2/docs/overview.mdx
+++ b/website/versioned_docs/version-0.9.2/docs/overview.mdx
@@ -24,10 +24,10 @@ runtime failures.
 
 ## How it works
 
-A ResourceGraphDefinition has two parts: a [**schema**](./concepts/rgd/schema) that defines your API
-surface (the fields users fill in), and [**resource templates**](./concepts/rgd/resource-definitions/resource-basics) that reference
-those fields with [CEL expressions](./concepts/rgd/cel-expressions). kro parses the expressions, infers the
-[dependency graph](./concepts/rgd/dependencies-ordering), generates a CRD, and stands up a controller - all at runtime.
+A ResourceGraphDefinition has two parts: a [**schema**](./concepts/rgd/01-schema.md) that defines your API
+surface (the fields users fill in), and [**resource templates**](./concepts/rgd/02-resource-definitions/01-resource-basics.md) that reference
+those fields with [CEL expressions](./concepts/rgd/03-cel-expressions.md). kro parses the expressions, infers the
+[dependency graph](./concepts/rgd/04-dependencies-ordering.md), generates a CRD, and stands up a controller - all at runtime.
 
 <IntroFlow />
 
@@ -71,7 +71,7 @@ object.
 
 ### The definition behind it
 
-A **ResourceGraphDefinition** defines the API under `spec.schema` (see [Simple Schema](./concepts/rgd/schema)) and the
+A **ResourceGraphDefinition** defines the API under `spec.schema` (see [Simple Schema](./concepts/rgd/01-schema.md)) and the
 backing resources under `spec.resources`. CEL expressions (`${}`) are what tie
 those two parts together (this example uses S3 via
 [ACK](https://aws-controllers-k8s.github.io/docs/), but kro works with any
@@ -162,8 +162,8 @@ in custom controller code.
 
 ## Get started
 
-- [Install kro](./getting-started/Installation) to run the controller in your cluster
-- [Deploy your first RGD](./getting-started/deploy-a-resource-graph-definition) to create a new API end to end
-- [Browse examples](../../examples/) to see more patterns
+- [Install kro](./getting-started/01-Installation.md) to run the controller in your cluster
+- [Deploy your first RGD](./getting-started/02-deploy-a-resource-graph-definition.md) to create a new API end to end
+- [Browse examples](../examples/examples.md) to see more patterns
 
 Need help or want to contribute? Join [#kro on Kubernetes Slack](https://kubernetes.slack.com/archives/C081TMY9D6Y), browse [GitHub](https://github.com/kubernetes-sigs/kro), or read [Contributing](https://github.com/kubernetes-sigs/kro/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
Internal links are broken on https://kro.run/docs/overview.

## Reproduction Steps

- Open https://kro.run/docs/overview
- Click the link labeled `schema` under the `How it works` section
- Attempt to navigate to https://kro.run/docs/overview/concepts/rgd/schema, resulting in a 404 error
    - The intended destination should be https://kro.run/docs/concepts/rgd/schema/

## Fix

Specifying the filename as the link destination will correctly link to the intended page.
The same fix is applied to both the current docs and the version-0.9.2 snapshot.
I verified this by building locally.
