### PR TITLE
Fix RGD CRD description examples to match parser behavior

### DIFF
--- a/api/v1alpha1/resourcegraphdefinition_types.go
+++ b/api/v1alpha1/resourcegraphdefinition_types.go
@@ -72,7 +72,8 @@ type Schema struct {
 	// Spec defines the schema for the instance's spec section using SimpleSchema syntax.
 	// This becomes the OpenAPI schema for instances of the generated CRD.
 	// Use SimpleSchema's concise syntax to define fields, types, defaults, and validations.
-	// Example: {"replicas": "integer | default=1 | min=1 | max=10"}
+	// Markers are space-separated after a single "|" separator.
+	// Example: {"replicas": "integer | default=1 minimum=1 maximum=10"}
 	Spec runtime.RawExtension `json:"spec,omitempty"`
 
 	// Types is a map of custom type definitions that can be referenced in the Spec.
@@ -199,9 +200,10 @@ type Resource struct {
 	// ReadyWhen is a list of CEL expressions that determine when this resource is considered ready.
 	// All expressions must evaluate to true for the resource to be ready.
 	// If not specified, the resource is considered ready when it exists.
+	// Each entry must be a single standalone CEL expression wrapped in ${...}.
 	// Examples:
-	// - Single resource: ["database.status.phase == 'Running'", "database.status.readyReplicas > 0"]
-	// - Collection: ["each.status.phase == 'Running'"]
+	// - Single resource: ["${database.status.phase == 'Running'}", "${database.status.readyReplicas > 0}"]
+	// - Collection: ["${each.status.phase == 'Running'}"]
 	//
 	// +kubebuilder:validation:Optional
 	ReadyWhen []string `json:"readyWhen,omitempty"`
@@ -211,7 +213,8 @@ type Resource struct {
 	// Expressions may reference schema fields and/or fields in other resources in the RGD. They are
 	// re-evaluated during reconciliation, so resources may be created later or
 	// pruned later as conditions change.
-	// Example: ["schema.spec.enableMonitoring == true", "network.status.ready == true"]
+	// Each entry must be a single standalone CEL expression wrapped in ${...}.
+	// Example: ["${schema.spec.enableMonitoring == true}", "${network.status.ready == true}"]
 	//
 	// +kubebuilder:validation:Optional
 	IncludeWhen []string `json:"includeWhen,omitempty"`

--- a/helm/crds/internal.kro.run_graphrevisions.yaml
+++ b/helm/crds/internal.kro.run_graphrevisions.yaml
@@ -227,7 +227,8 @@ spec:
                                 Expressions may reference schema fields and/or fields in other resources in the RGD. They are
                                 re-evaluated during reconciliation, so resources may be created later or
                                 pruned later as conditions change.
-                                Example: ["schema.spec.enableMonitoring == true", "network.status.ready == true"]
+                                Each entry must be a single standalone CEL expression wrapped in ${...}.
+                                Example: ["${schema.spec.enableMonitoring == true}", "${network.status.ready == true}"]
                               items:
                                 type: string
                               type: array
@@ -236,9 +237,10 @@ spec:
                                 ReadyWhen is a list of CEL expressions that determine when this resource is considered ready.
                                 All expressions must evaluate to true for the resource to be ready.
                                 If not specified, the resource is considered ready when it exists.
+                                Each entry must be a single standalone CEL expression wrapped in ${...}.
                                 Examples:
-                                - Single resource: ["database.status.phase == 'Running'", "database.status.readyReplicas > 0"]
-                                - Collection: ["each.status.phase == 'Running'"]
+                                - Single resource: ["${database.status.phase == 'Running'}", "${database.status.readyReplicas > 0}"]
+                                - Collection: ["${each.status.phase == 'Running'}"]
                               items:
                                 type: string
                               type: array
@@ -377,7 +379,8 @@ spec:
                               Spec defines the schema for the instance's spec section using SimpleSchema syntax.
                               This becomes the OpenAPI schema for instances of the generated CRD.
                               Use SimpleSchema's concise syntax to define fields, types, defaults, and validations.
-                              Example: {"replicas": "integer | default=1 | min=1 | max=10"}
+                              Markers are space-separated after a single "|" separator.
+                              Example: {"replicas": "integer | default=1 minimum=1 maximum=10"}
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           status:

--- a/helm/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/helm/crds/kro.run_resourcegraphdefinitions.yaml
@@ -205,7 +205,8 @@ spec:
                         Expressions may reference schema fields and/or fields in other resources in the RGD. They are
                         re-evaluated during reconciliation, so resources may be created later or
                         pruned later as conditions change.
-                        Example: ["schema.spec.enableMonitoring == true", "network.status.ready == true"]
+                        Each entry must be a single standalone CEL expression wrapped in ${...}.
+                        Example: ["${schema.spec.enableMonitoring == true}", "${network.status.ready == true}"]
                       items:
                         type: string
                       type: array
@@ -214,9 +215,10 @@ spec:
                         ReadyWhen is a list of CEL expressions that determine when this resource is considered ready.
                         All expressions must evaluate to true for the resource to be ready.
                         If not specified, the resource is considered ready when it exists.
+                        Each entry must be a single standalone CEL expression wrapped in ${...}.
                         Examples:
-                        - Single resource: ["database.status.phase == 'Running'", "database.status.readyReplicas > 0"]
-                        - Collection: ["each.status.phase == 'Running'"]
+                        - Single resource: ["${database.status.phase == 'Running'}", "${database.status.readyReplicas > 0}"]
+                        - Collection: ["${each.status.phase == 'Running'}"]
                       items:
                         type: string
                       type: array
@@ -352,7 +354,8 @@ spec:
                       Spec defines the schema for the instance's spec section using SimpleSchema syntax.
                       This becomes the OpenAPI schema for instances of the generated CRD.
                       Use SimpleSchema's concise syntax to define fields, types, defaults, and validations.
-                      Example: {"replicas": "integer | default=1 | min=1 | max=10"}
+                      Markers are space-separated after a single "|" separator.
+                      Example: {"replicas": "integer | default=1 minimum=1 maximum=10"}
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   status:

--- a/website/docs/api/crds/internal.kro.run_graphrevisions.yaml
+++ b/website/docs/api/crds/internal.kro.run_graphrevisions.yaml
@@ -227,7 +227,8 @@ spec:
                                 Expressions may reference schema fields and/or fields in other resources in the RGD. They are
                                 re-evaluated during reconciliation, so resources may be created later or
                                 pruned later as conditions change.
-                                Example: ["schema.spec.enableMonitoring == true", "network.status.ready == true"]
+                                Each entry must be a single standalone CEL expression wrapped in ${...}.
+                                Example: ["${schema.spec.enableMonitoring == true}", "${network.status.ready == true}"]
                               items:
                                 type: string
                               type: array
@@ -236,9 +237,10 @@ spec:
                                 ReadyWhen is a list of CEL expressions that determine when this resource is considered ready.
                                 All expressions must evaluate to true for the resource to be ready.
                                 If not specified, the resource is considered ready when it exists.
+                                Each entry must be a single standalone CEL expression wrapped in ${...}.
                                 Examples:
-                                - Single resource: ["database.status.phase == 'Running'", "database.status.readyReplicas > 0"]
-                                - Collection: ["each.status.phase == 'Running'"]
+                                - Single resource: ["${database.status.phase == 'Running'}", "${database.status.readyReplicas > 0}"]
+                                - Collection: ["${each.status.phase == 'Running'}"]
                               items:
                                 type: string
                               type: array
@@ -377,7 +379,8 @@ spec:
                               Spec defines the schema for the instance's spec section using SimpleSchema syntax.
                               This becomes the OpenAPI schema for instances of the generated CRD.
                               Use SimpleSchema's concise syntax to define fields, types, defaults, and validations.
-                              Example: {"replicas": "integer | default=1 | min=1 | max=10"}
+                              Markers are space-separated after a single "|" separator.
+                              Example: {"replicas": "integer | default=1 minimum=1 maximum=10"}
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           status:

--- a/website/docs/api/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/website/docs/api/crds/kro.run_resourcegraphdefinitions.yaml
@@ -205,7 +205,8 @@ spec:
                         Expressions may reference schema fields and/or fields in other resources in the RGD. They are
                         re-evaluated during reconciliation, so resources may be created later or
                         pruned later as conditions change.
-                        Example: ["schema.spec.enableMonitoring == true", "network.status.ready == true"]
+                        Each entry must be a single standalone CEL expression wrapped in ${...}.
+                        Example: ["${schema.spec.enableMonitoring == true}", "${network.status.ready == true}"]
                       items:
                         type: string
                       type: array
@@ -214,9 +215,10 @@ spec:
                         ReadyWhen is a list of CEL expressions that determine when this resource is considered ready.
                         All expressions must evaluate to true for the resource to be ready.
                         If not specified, the resource is considered ready when it exists.
+                        Each entry must be a single standalone CEL expression wrapped in ${...}.
                         Examples:
-                        - Single resource: ["database.status.phase == 'Running'", "database.status.readyReplicas > 0"]
-                        - Collection: ["each.status.phase == 'Running'"]
+                        - Single resource: ["${database.status.phase == 'Running'}", "${database.status.readyReplicas > 0}"]
+                        - Collection: ["${each.status.phase == 'Running'}"]
                       items:
                         type: string
                       type: array
@@ -352,7 +354,8 @@ spec:
                       Spec defines the schema for the instance's spec section using SimpleSchema syntax.
                       This becomes the OpenAPI schema for instances of the generated CRD.
                       Use SimpleSchema's concise syntax to define fields, types, defaults, and validations.
-                      Example: {"replicas": "integer | default=1 | min=1 | max=10"}
+                      Markers are space-separated after a single "|" separator.
+                      Example: {"replicas": "integer | default=1 minimum=1 maximum=10"}
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   status:


### PR DESCRIPTION
**What this PR does / why we need it:**

The RGD CRD field descriptions show examples that the parsers actually reject, which misleads users (and LLMs) consuming the schema:

- `schema.spec` shows pipe-separated markers with `min=`/`max=` (`"integer | default=1 | min=1 | max=10"`), but `pkg/simpleschema` splits on the first pipe only, markers are space-separated, and the valid marker names are `minimum`/`maximum`. Corrected example: `"integer | default=1 minimum=1 maximum=10"`.
- `readyWhen` and `includeWhen` show bare expressions (e.g. `["database.status.phase == 'Running'"]`), but `ParseConditionExpressions` in `pkg/graph/parser/conditions.go` requires each entry to be a standalone `${...}` expression and rejects the documented form with "only standalone expressions are allowed".

This updates the Go doc comments in `api/v1alpha1/resourcegraphdefinition_types.go` and regenerates the CRDs with `make manifests` (which also refreshes the `website/docs/api/crds` copies).

Doc-only change, no behavior change.