### PR TITLE
fix: build package paths instead of single files in Makefile and CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,11 +186,11 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 
 .PHONY: build
 build: manifests generate fmt vet ## Build controller binary.
-	go build -ldflags=${LDFLAGS} -o bin/controller ./cmd/controller/main.go
+	go build -ldflags=${LDFLAGS} -o bin/controller ./cmd/controller
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/controller/main.go
+	go run ./cmd/controller
 
 ##@ Build Dependencies
 
@@ -361,7 +361,7 @@ ko-apply: ko
 ## CLI
 .PHONY: cli
 cli:
-	go build -o bin/kro cmd/kro/main.go
+	go build -C cmd/kro -o $(LOCALBIN)/kro .
 	sudo mv bin/kro /usr/local/bin
 	@echo "CLI built successfully"
 

--- a/scripts/ci/presubmits/build-image
+++ b/scripts/ci/presubmits/build-image
@@ -8,6 +8,6 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
 # Build
-go build cmd
+go build ./cmd/...
 
 make build-image KO_LOCAL=false

--- a/scripts/ci/presubmits/e2e-raw-manifests-tests
+++ b/scripts/ci/presubmits/e2e-raw-manifests-tests
@@ -8,7 +8,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
 # Build
-go build cmd
+go build ./cmd/...
 
 mkdir -p ./bin
 curl -Lo ./bin/kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64

--- a/scripts/ci/presubmits/e2e-tests
+++ b/scripts/ci/presubmits/e2e-tests
@@ -8,7 +8,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
 # Build
-go build cmd
+go build ./cmd/...
 
 mkdir -p ./bin
 curl -Lo ./bin/kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64

--- a/scripts/ci/presubmits/integration-tests
+++ b/scripts/ci/presubmits/integration-tests
@@ -8,6 +8,6 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
 # Build
-go build cmd
+go build ./cmd/...
 
 make test WHAT=integration

--- a/scripts/ci/presubmits/unit-tests
+++ b/scripts/ci/presubmits/unit-tests
@@ -8,7 +8,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
 # Build
-go build cmd
+go build ./cmd/...
 
 # Run unit tests
 make test WHAT=unit


### PR DESCRIPTION
## Summary

`make build` and `make run` have been broken since #922 introduced build-tagged files (`pprof.go` / `pprof_disabled.go`) in `cmd/controller`. Passing an explicit file (`./cmd/controller/main.go`) to `go build` makes Go compile only the listed files and skip the tagged siblings, which fails with:

```
cmd/controller/main.go:192:5: undefined: pprofEnabled
cmd/controller/main.go:194:3: undefined: startPprof
```

This PR builds the package path (`./cmd/controller`) instead, which selects the correct tagged file automatically and also works with `-tags pprof`.

CI never caught this because the presubmit scripts run `go build cmd`, which Go resolves as the GOROOT import path `cmd` (the Go toolchain's own commands) rather than the repo's `./cmd` directory, so it exits 0 without compiling any kro code. This PR changes those scripts to `go build ./cmd/...`, matching what the `e2e-upgrade-tests` presubmit already does; this would have caught the original regression.

The `cli` target had the same class of bug: `go build -o bin/kro cmd/kro/main.go` fails because `cmd/kro` is a separate Go module, so its imports cannot be resolved from the root module in file mode (`no required module provides package .../cmd/kro/commands`). It is now built from within its own module via `go build -C cmd/kro -o $(LOCALBIN)/kro .`; the output still lands in `bin/kro` so the subsequent install step is unchanged.

## Testing

Validation performed:

- `make build` passes
- `go build -tags pprof ./cmd/controller` (debug variant) passes
- `go build ./cmd/...` (new presubmit build line) passes
- `make cli` build step produces a working `bin/kro` (`kro --help` runs)
- `make test WHAT=unit` passes