### PR TITLE
Update condition telemetry to reflect author conditions

### DIFF
--- a/pkg/controller/instance/status.go
+++ b/pkg/controller/instance/status.go
@@ -160,6 +160,9 @@ func (c *Controller) updateConditionsStatus(ctx context.Context, inst *unstructu
 		}
 		status["state"] = string(v1alpha1.InstanceStateError)
 		cur.Object["status"] = status
+		// Mirror persisted status onto the instance so the deferred
+		// emitters read what's on the wire, not the marker's built-ins.
+		inst.Object["status"] = status
 		if c.namespaced {
 			_, err = ri.Namespace(inst.GetNamespace()).UpdateStatus(ctx, cur, metav1.UpdateOptions{})
 		} else {
@@ -234,15 +237,17 @@ func (c *Controller) updateStatus(rcx *ReconcileContext) error {
 	// resourceVersion, which triggers a watch event, which re-enqueues the
 	// instance, which reconciles again.
 	oldStatus, _, _ := unstructured.NestedMap(rcx.Instance.Object, "status")
+
+	// Mirror persisted status onto the instance so the deferred
+	// emitters read what's on the wire, not the marker's built-ins.
+	rcx.Instance.Object["status"] = status
+
 	if equality.Semantic.DeepEqual(oldStatus, status) {
 		return nil
 	}
 
-	inst := rcx.Instance.DeepCopy()
-	inst.Object["status"] = status
-
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		cur, err := rcx.InstanceClient().Get(rcx.Ctx, inst.GetName(), metav1.GetOptions{})
+		cur, err := rcx.InstanceClient().Get(rcx.Ctx, rcx.Instance.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/instance/status_test.go
+++ b/pkg/controller/instance/status_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 	"github.com/kubernetes-sigs/kro/pkg/cel/library"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
@@ -155,6 +156,88 @@ func TestUpdateStatusPaths(t *testing.T) {
 			assert.NotEqual(t, []interface{}{"bad"}, conditions)
 		})
 	}
+}
+
+func TestUpdateStatusMirrorsPersistedConditionsOntoInstance(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+
+	instanceNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         graph.InstanceNodeID,
+			Type:       graph.NodeTypeInstance,
+			GVR:        controllerTestParentGVR,
+			Namespaced: true,
+		},
+		Template: &unstructured.Unstructured{
+			Object: map[string]interface{}{"status": map[string]interface{}{}},
+		},
+		Conditions: []*krocel.Expression{
+			mustCompileControllerExpr(t,
+				`runtime.newCondition({type: 'PrimaryReady', status: 'True', reason: 'Healthy', message: 'all good'})`,
+				library.RuntimeVarName,
+			),
+		},
+	}
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraphWithInstance(instanceNode))
+	rcx.StateManager.State = v1alpha1.InstanceStateActive
+
+	rcx.Mark.InstanceManaged()
+	rcx.Mark.GraphResolved()
+	rcx.Mark.ResourcesReady()
+
+	require.NoError(t, controller.updateStatus(rcx))
+
+	instanceConditions := conditionsFromInstance(rcx.Instance)
+	require.Len(t, instanceConditions, 1,
+		"only the author condition should be on rcx.Instance; built-ins are suppressed from the wire")
+	assert.Equal(t, v1alpha1.ConditionType("PrimaryReady"), instanceConditions[0].Type,
+		"rcx.Instance must carry the author condition the emitter reports")
+	assert.Equal(t, metav1.ConditionTrue, instanceConditions[0].Status)
+
+	stored := getStoredParentObject(t, raw)
+	assert.Equal(t,
+		conditionsFromInstance(stored),
+		instanceConditions,
+		"rcx.Instance conditions must match the persisted wire conditions")
+}
+
+func TestUpdateStatusKeepsBuiltinConditionsWhenNoAuthorConditions(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+
+	instanceNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         graph.InstanceNodeID,
+			Type:       graph.NodeTypeInstance,
+			GVR:        controllerTestParentGVR,
+			Namespaced: true,
+		},
+		Template: &unstructured.Unstructured{
+			Object: map[string]interface{}{"status": map[string]interface{}{}},
+		},
+	}
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraphWithInstance(instanceNode))
+	rcx.StateManager.State = v1alpha1.InstanceStateActive
+
+	rcx.Mark.InstanceManaged()
+	rcx.Mark.GraphResolved()
+	rcx.Mark.ResourcesReady()
+
+	require.NoError(t, controller.updateStatus(rcx))
+
+	instanceConditions := conditionsFromInstance(rcx.Instance)
+	types := make(map[v1alpha1.ConditionType]struct{}, len(instanceConditions))
+	for _, c := range instanceConditions {
+		types[c.Type] = struct{}{}
+	}
+	for _, builtin := range []string{InstanceManaged, GraphResolved, ResourcesReady, Ready} {
+		assert.Contains(t, types, v1alpha1.ConditionType(builtin),
+			"built-in %q should remain on rcx.Instance when no author conditions are declared", builtin)
+	}
+
+	assert.Equal(t, conditionsFromInstance(getStoredParentObject(t, raw)), instanceConditions,
+		"rcx.Instance conditions must match the persisted wire conditions")
 }
 
 func TestStampAuthorConditionsNewWire(t *testing.T) {

--- a/test/integration/suites/core/instance_custom_conditions_test.go
+++ b/test/integration/suites/core/instance_custom_conditions_test.go
@@ -336,6 +336,9 @@ var _ = Describe("Instance Custom Conditions", func() {
 			}, nil, nil),
 		)
 		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			_ = env.Client.Delete(ctx, rgd)
+		})
 
 		Eventually(func(g Gomega) {
 			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)).To(Succeed())


### PR DESCRIPTION
[#1301](https://github.com/kubernetes-sigs/kro/pull/1301) added author-defined custom status conditions. However, the instance condition telemetry (metrics and events) doesn't reflect them.

The emitter reads conditions from the in-memory instance object, which the marker populates with kro's built-in conditions. When an RGD declares author conditions, updateStatus writes only the author's conditions to the wire (built-ins are suppressed), so the in-memory object no longer matches what's persisted. As a result the emitter reports built-in conditions that never reach etcd and misses the author conditions entirely.

This PR mirrors the persisted status onto the in-memory object before the API write, so the emitter reports the conditions kro actually persists — the author's conditions when declared, built-ins otherwise.