### PR TITLE
docs: Helm does not update CRDs when upgrading to latest

### DIFF
--- a/website/versioned_docs/version-0.9.2/docs/getting-started/01-Installation.md
+++ b/website/versioned_docs/version-0.9.2/docs/getting-started/01-Installation.md
@@ -146,6 +146,9 @@ helm upgrade kro oci://registry.k8s.io/kro/charts/kro \
   --namespace kro-system
 ```
 
+:::info
+Helm does not update CRDs automatically. If a new version includes CRD changes, you may need to manually apply them. Check the release notes for CRD updates.
+:::
   </TabItem>
   <TabItem value="specific" label="Specific Version">
 


### PR DESCRIPTION
In #1054, an issue was reported that was caused by upgrading Kro via Helm, but not installing the corresponding CRDs. Unlike instructions for upgrading to a specific version, those for upgrading to the latest do not mention that CRDs must be upgraded separately.