### PR TITLE
Compute condition duration metric at scrape time via a Collector

### DIFF
--- a/pkg/metrics/duration_collector.go
+++ b/pkg/metrics/duration_collector.go
@@ -1,0 +1,154 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// conditionKey identifies a condition on a single instance. It deliberately
+// excludes status and reason so there is at most one cache entry (one emitted
+// series) per condition type per instance: caching a new status/reason
+// overwrites the previous one instead of leaving a stale series behind.
+type conditionKey struct {
+	gvr           string
+	namespace     string
+	name          string
+	conditionType string
+}
+
+// conditionValue is the mutable part of a cache entry: the condition's current
+// status and reason (emitted as labels) and the LastTransitionTime the
+// duration is measured from.
+type conditionValue struct {
+	status string
+	reason string
+	ts     time.Time
+}
+
+func (k conditionKey) labelValues(v conditionValue) []string {
+	return []string{k.gvr, k.namespace, k.name, k.conditionType, v.status, v.reason}
+}
+
+// durationCollector computes instance_condition_current_status_seconds at
+// scrape time. It caches each condition's LastTransitionTime and returns
+// time-since on Collect, so the value stays accurate while the controller
+// is idle — unlike a GaugeVec set at reconcile time, which would freeze.
+type durationCollector struct {
+	desc *prometheus.Desc
+
+	mu      sync.RWMutex
+	now     func() time.Time // injectable for tests
+	entries map[conditionKey]conditionValue
+}
+
+func newDurationCollector(fqName, help string) *durationCollector {
+	labelNames := []string{
+		labelGVR,
+		labelNamespace,
+		labelName,
+		labelConditionType,
+		labelConditionStatus,
+		labelReason,
+	}
+	return &durationCollector{
+		desc:    prometheus.NewDesc(fqName, help, labelNames, nil),
+		now:     time.Now,
+		entries: make(map[conditionKey]conditionValue),
+	}
+}
+
+func (c *durationCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.desc
+}
+
+func (c *durationCollector) Collect(ch chan<- prometheus.Metric) {
+	// Snapshot under the lock, then emit unlocked: channel sends can block
+	// on a slow scrape consumer and must not stall Cache/Evict.
+	c.mu.RLock()
+	snapshot := make([]struct {
+		key conditionKey
+		val conditionValue
+	}, 0, len(c.entries))
+	for k, v := range c.entries {
+		snapshot = append(snapshot, struct {
+			key conditionKey
+			val conditionValue
+		}{k, v})
+	}
+	c.mu.RUnlock()
+
+	now := c.now()
+	for _, e := range snapshot {
+		seconds := now.Sub(e.val.ts).Seconds()
+		if seconds < 0 {
+			seconds = 0 // clamp clock skew / future timestamps
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.desc,
+			prometheus.GaugeValue,
+			seconds,
+			e.key.labelValues(e.val)...,
+		)
+	}
+}
+
+// Cache records the current status, reason, and transition time for a
+// condition, replacing any previous entry for the same condition type so only
+// the current series is emitted. A real (non-zero) ts always overwrites. A
+// zero ts anchors the series to now on first sighting and is preserved on
+// later re-caches of the same (status, reason), so a condition without a
+// LastTransitionTime grows steadily rather than resetting each reconcile.
+func (c *durationCollector) Cache(key conditionKey, status, reason string, ts time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if ts.IsZero() {
+		if prev, exists := c.entries[key]; exists && prev.status == status && prev.reason == reason {
+			return
+		}
+		ts = c.now()
+	}
+	c.entries[key] = conditionValue{status: status, reason: reason, ts: ts}
+}
+
+// EvictKey removes the entry for a single condition type on an instance.
+func (c *durationCollector) EvictKey(key conditionKey) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, key)
+}
+
+func (c *durationCollector) EvictInstance(gvr, namespace, name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k := range c.entries {
+		if k.gvr == gvr && k.namespace == namespace && k.name == name {
+			delete(c.entries, k)
+		}
+	}
+}
+
+func (c *durationCollector) EvictGVR(gvr string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k := range c.entries {
+		if k.gvr == gvr {
+			delete(c.entries, k)
+		}
+	}
+}

--- a/pkg/metrics/duration_collector_test.go
+++ b/pkg/metrics/duration_collector_test.go
@@ -1,0 +1,248 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCollector(now time.Time) *durationCollector {
+	c := newDurationCollector("test_metric", "test help")
+	c.now = func() time.Time { return now }
+	return c
+}
+
+func (c *durationCollector) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = make(map[conditionKey]conditionValue)
+}
+
+func (c *durationCollector) size() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}
+
+func keyFor(name string) conditionKey {
+	return conditionKey{
+		gvr:           "kro.run/v1alpha1, Resource=tests",
+		namespace:     "default",
+		name:          name,
+		conditionType: "Ready",
+	}
+}
+
+func TestDurationCollector_CacheAndCollect(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 30, 0, time.UTC)
+	c := newTestCollector(now)
+
+	ts := now.Add(-10 * time.Second)
+	c.Cache(keyFor("a"), "True", "AllReady", ts)
+
+	got := collectorEntries(t, c)
+	require.Len(t, got, 1)
+	assert.InDelta(t, 10.0, got[0].value, 0.001,
+		"value should be (now - cachedTimestamp) in seconds")
+	assert.Equal(t, "True", got[0].labels["condition_status"])
+	assert.Equal(t, "AllReady", got[0].labels["reason"])
+}
+
+func TestDurationCollector_ZeroTimestampTreatedAsNow(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	c := newTestCollector(now)
+
+	c.Cache(keyFor("a"), "True", "AllReady", time.Time{})
+
+	got := collectorEntries(t, c)
+	require.Len(t, got, 1)
+	assert.Equal(t, 0.0, got[0].value,
+		"zero timestamp must produce a zero-second initial duration")
+}
+
+func TestDurationCollector_ZeroTimestampDoesNotResetOnRecache(t *testing.T) {
+	clock := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	c := newDurationCollector("test_metric", "test help")
+	c.now = func() time.Time { return clock }
+
+	c.Cache(keyFor("a"), "True", "AllReady", time.Time{})
+
+	clock = clock.Add(30 * time.Second)
+	c.Cache(keyFor("a"), "True", "AllReady", time.Time{})
+
+	got := collectorEntries(t, c)
+	require.Len(t, got, 1)
+	assert.Equal(t, 30.0, got[0].value,
+		"a re-cached zero timestamp must keep growing, not reset the anchor")
+}
+
+func TestDurationCollector_NegativeDurationClamped(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	c := newTestCollector(now)
+
+	future := now.Add(5 * time.Second)
+	c.Cache(keyFor("a"), "True", "AllReady", future)
+
+	got := collectorEntries(t, c)
+	require.Len(t, got, 1)
+	assert.Equal(t, 0.0, got[0].value, "future timestamps must clamp to 0, not emit negative durations")
+}
+
+func TestDurationCollector_CacheOverwritesStatusAndReason(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	c := newTestCollector(now)
+
+	c.Cache(keyFor("a"), "False", "NotReady", now.Add(-100*time.Second))
+	c.Cache(keyFor("a"), "True", "AllReady", now.Add(-5*time.Second))
+
+	got := collectorEntries(t, c)
+	require.Len(t, got, 1, "a transition must overwrite, not leave a stale series")
+	assert.Equal(t, "True", got[0].labels["condition_status"])
+	assert.Equal(t, "AllReady", got[0].labels["reason"])
+	assert.InDelta(t, 5.0, got[0].value, 0.001)
+}
+
+func TestDurationCollector_EvictKey(t *testing.T) {
+	c := newTestCollector(time.Now())
+	c.Cache(keyFor("a"), "True", "AllReady", time.Now())
+	c.Cache(keyFor("b"), "True", "AllReady", time.Now())
+
+	c.EvictKey(keyFor("a"))
+
+	got := collectorEntries(t, c)
+	require.Len(t, got, 1, "only key 'b' should remain")
+}
+
+func TestDurationCollector_EvictInstance(t *testing.T) {
+	c := newTestCollector(time.Now())
+	now := time.Now()
+
+	c.Cache(keyFor("a"), "True", "AllReady", now)
+	c.Cache(keyFor("b"), "True", "AllReady", now)
+
+	c.EvictInstance("kro.run/v1alpha1, Resource=tests", "default", "a")
+
+	got := collectorEntries(t, c)
+	require.Len(t, got, 1)
+	for _, e := range got {
+		assert.Equal(t, "b", e.labels["name"])
+	}
+}
+
+func TestDurationCollector_EvictGVR(t *testing.T) {
+	c := newTestCollector(time.Now())
+	now := time.Now()
+
+	c.Cache(keyFor("a"), "True", "AllReady", now)
+	c.Cache(keyFor("b"), "True", "AllReady", now)
+
+	other := keyFor("c")
+	other.gvr = "different.group/v1, Resource=others"
+	c.Cache(other, "True", "AllReady", now)
+
+	c.EvictGVR("kro.run/v1alpha1, Resource=tests")
+
+	got := collectorEntries(t, c)
+	require.Len(t, got, 1)
+	assert.Equal(t, "different.group/v1, Resource=others", got[0].labels["gvr"])
+}
+
+func TestDurationCollector_DescribeEmitsDescriptor(t *testing.T) {
+	c := newTestCollector(time.Now())
+
+	ch := make(chan *prometheus.Desc, 4)
+	c.Describe(ch)
+	close(ch)
+
+	descs := []*prometheus.Desc{}
+	for d := range ch {
+		descs = append(descs, d)
+	}
+	require.Len(t, descs, 1, "Describe must emit exactly one descriptor")
+}
+
+func TestDurationCollector_ScrapeIsConcurrencySafe(t *testing.T) {
+	c := newTestCollector(time.Now())
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				status := []string{"True", "False", "Unknown"}[i%3]
+				c.Cache(keyFor("name"), status, "reason", time.Now())
+				i++
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = collectorEntries(t, c)
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+type emittedEntry struct {
+	value  float64
+	labels map[string]string
+}
+
+func collectorEntries(t *testing.T, c prometheus.Collector) []emittedEntry {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 100)
+	c.Collect(ch)
+	close(ch)
+
+	out := []emittedEntry{}
+	for m := range ch {
+		var dto io_prometheus_client.Metric
+		require.NoError(t, m.Write(&dto))
+		labels := make(map[string]string, len(dto.Label))
+		for _, lp := range dto.Label {
+			labels[lp.GetName()] = lp.GetValue()
+		}
+		out = append(out, emittedEntry{
+			value:  dto.GetGauge().GetValue(),
+			labels: labels,
+		})
+	}
+	return out
+}

--- a/pkg/metrics/instance.go
+++ b/pkg/metrics/instance.go
@@ -94,22 +94,20 @@ var (
 		[]string{"gvr"},
 	)
 
-	// InstanceConditionCurrentStatusSeconds tracks the duration an instance condition
-	// has been in its current state. The value is computed at reconcile time
-	// as time.Since(lastTransitionTime). To get fresher gauge values, consider
-	// lowering --dynamic-controller-default-resync-period.
-	InstanceConditionCurrentStatusSeconds = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "instance_condition_current_status_seconds",
-			Help: "The current amount of time in seconds that an instance status condition has been in a specific state.",
-		},
-		[]string{labelGVR, labelNamespace, labelName, labelConditionType, labelConditionStatus, labelReason},
+	// InstanceConditionCurrentStatusSeconds is computed at scrape time by a
+	// Collector so it stays accurate for non-PromQL consumers (CloudWatch,
+	// Datadog) even while the controller is idle. The cache rebuilds from
+	// etcd as instances reconcile after a restart.
+	InstanceConditionCurrentStatusSeconds = newDurationCollector(
+		"instance_condition_current_status_seconds",
+		"The current amount of time in seconds that an instance status condition has been in a specific state.",
 	)
 )
 
-// emitConditionMetrics computes the diff between initial and final conditions,
-// emits gauge metrics for all current conditions, emits structured logs for
-// changed conditions, and cleans up gauges for disappeared conditions.
+// EmitConditionMetrics syncs the duration cache with an instance's
+// conditions. For each final condition it caches the LastTransitionTime
+// keyed by condition type, and evicts conditions that no longer appear.
+// It also logs status transitions.
 func EmitConditionMetrics(
 	log logr.Logger,
 	gvr schema.GroupVersionResource,
@@ -129,29 +127,27 @@ func EmitConditionMetrics(
 		finalTypes[cond.Type] = struct{}{}
 		reason := ptr.Deref(cond.Reason, "")
 
-		var durationSeconds float64
+		var lastTransition time.Time
 		if cond.LastTransitionTime != nil {
-			durationSeconds = time.Since(cond.LastTransitionTime.Time).Seconds()
+			lastTransition = cond.LastTransitionTime.Time
 		}
+
+		// Cache overwrites any previous status/reason for this condition
+		// type, so a transition replaces the old series without a separate
+		// eviction step.
+		InstanceConditionCurrentStatusSeconds.Cache(
+			conditionKey{
+				gvr:           gvrKey,
+				namespace:     ns,
+				name:          name,
+				conditionType: string(cond.Type),
+			},
+			string(cond.Status),
+			reason,
+			lastTransition,
+		)
 
 		oldCond, existed := initialByType[cond.Type]
-
-		// Delete the old series when status or reason changed to avoid stale gauges.
-		if existed {
-			oldReason := ptr.Deref(oldCond.Reason, "")
-			if oldCond.Status != cond.Status || oldReason != reason {
-				InstanceConditionCurrentStatusSeconds.DeleteLabelValues(
-					gvrKey, ns, name,
-					string(oldCond.Type), string(oldCond.Status), oldReason,
-				)
-			}
-		}
-
-		InstanceConditionCurrentStatusSeconds.WithLabelValues(
-			gvrKey, ns, name,
-			string(cond.Type), string(cond.Status), reason,
-		).Set(durationSeconds)
-
 		if !existed || oldCond.Status != cond.Status {
 			oldStatus := "none"
 			if existed {
@@ -169,35 +165,28 @@ func EmitConditionMetrics(
 		}
 	}
 
-	// Clean up gauges for conditions that disappeared.
 	for _, oldCond := range initialConditions {
 		if _, stillPresent := finalTypes[oldCond.Type]; !stillPresent {
-			InstanceConditionCurrentStatusSeconds.DeletePartialMatch(prometheus.Labels{
-				labelGVR:           gvrKey,
-				labelNamespace:     ns,
-				labelName:          name,
-				labelConditionType: string(oldCond.Type),
+			InstanceConditionCurrentStatusSeconds.EvictKey(conditionKey{
+				gvr:           gvrKey,
+				namespace:     ns,
+				name:          name,
+				conditionType: string(oldCond.Type),
 			})
 		}
 	}
 }
 
-// deleteInstanceMetrics removes all gauge metrics for a specific instance.
+// DeleteInstanceMetrics removes all metrics for a specific instance.
 // Called when an instance is deleted (not found).
 func DeleteInstanceMetrics(gvr schema.GroupVersionResource, namespace, name string) {
-	InstanceConditionCurrentStatusSeconds.DeletePartialMatch(prometheus.Labels{
-		labelGVR:       gvr.String(),
-		labelNamespace: namespace,
-		labelName:      name,
-	})
+	InstanceConditionCurrentStatusSeconds.EvictInstance(gvr.String(), namespace, name)
 }
 
-// DeleteGVRMetrics removes all gauge metrics for all instances of a GVR.
+// DeleteGVRMetrics removes all metrics for all instances of a GVR.
 // Called when an RGD is deregistered (deleted).
 func DeleteGVRMetrics(gvr schema.GroupVersionResource) {
-	InstanceConditionCurrentStatusSeconds.DeletePartialMatch(prometheus.Labels{
-		labelGVR: gvr.String(),
-	})
+	InstanceConditionCurrentStatusSeconds.EvictGVR(gvr.String())
 }
 
 // indexConditionsByType builds a lookup map from condition type to condition.

--- a/pkg/metrics/instance_test.go
+++ b/pkg/metrics/instance_test.go
@@ -31,8 +31,7 @@ import (
 )
 
 func TestEmitConditionMetrics_NewCondition(t *testing.T) {
-	// Reset metrics for test isolation.
-	InstanceConditionCurrentStatusSeconds.Reset()
+	InstanceConditionCurrentStatusSeconds.reset()
 
 	log := zap.New(zap.UseDevMode(true))
 	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
@@ -53,13 +52,12 @@ func TestEmitConditionMetrics_NewCondition(t *testing.T) {
 
 	EmitConditionMetrics(log, gvr, inst, initial, final)
 
-	// Gauge should have one series.
-	gaugeCount := testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds)
-	assert.Equal(t, 1, gaugeCount)
+	assert.Equal(t, 1, InstanceConditionCurrentStatusSeconds.size())
+	assert.Equal(t, 1, testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds))
 }
 
 func TestEmitConditionMetrics_NoTransition(t *testing.T) {
-	InstanceConditionCurrentStatusSeconds.Reset()
+	InstanceConditionCurrentStatusSeconds.reset()
 
 	log := zap.New(zap.UseDevMode(true))
 	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
@@ -79,13 +77,12 @@ func TestEmitConditionMetrics_NoTransition(t *testing.T) {
 
 	EmitConditionMetrics(log, gvr, inst, conds, conds)
 
-	// Gauge should still be set (updated duration).
-	gaugeCount := testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds)
-	assert.Equal(t, 1, gaugeCount)
+	assert.Equal(t, 1, InstanceConditionCurrentStatusSeconds.size())
+	assert.Equal(t, 1, testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds))
 }
 
 func TestEmitConditionMetrics_StatusTransition(t *testing.T) {
-	InstanceConditionCurrentStatusSeconds.Reset()
+	InstanceConditionCurrentStatusSeconds.reset()
 
 	log := zap.New(zap.UseDevMode(true))
 	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
@@ -110,22 +107,26 @@ func TestEmitConditionMetrics_StatusTransition(t *testing.T) {
 			LastTransitionTime: &now,
 		},
 	}
-
-	// Pre-populate the old series to verify it gets cleaned up.
-	InstanceConditionCurrentStatusSeconds.WithLabelValues(
-		gvr.String(), "default", "my-app", "ResourcesReady", "False", "NotReady",
-	).Set(42)
-	assert.Equal(t, 1, testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds))
+	InstanceConditionCurrentStatusSeconds.Cache(conditionKey{
+		gvr:           gvr.String(),
+		namespace:     "default",
+		name:          "my-app",
+		conditionType: "ResourcesReady",
+	}, "False", "NotReady", now.Time)
+	assert.Equal(t, 1, InstanceConditionCurrentStatusSeconds.size())
 
 	EmitConditionMetrics(log, gvr, inst, initial, final)
 
-	// Only the new series should remain; the old False/NotReady series must be deleted.
-	gaugeCount := testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds)
-	assert.Equal(t, 1, gaugeCount)
+	assert.Equal(t, 1, InstanceConditionCurrentStatusSeconds.size())
+	got := collectorEntries(t, InstanceConditionCurrentStatusSeconds)
+	require.Len(t, got, 1, "the transition must leave exactly one series")
+	assert.Equal(t, "True", got[0].labels["condition_status"],
+		"the remaining series must reflect the new status, not the pre-seeded False")
+	assert.Equal(t, "AllResourcesReady", got[0].labels["reason"])
 }
 
-func TestEmitConditionMetrics_DisappearedCondition(t *testing.T) {
-	InstanceConditionCurrentStatusSeconds.Reset()
+func TestEmitConditionMetrics_NoPhantomWhenCacheDivergesFromEtcd(t *testing.T) {
+	InstanceConditionCurrentStatusSeconds.reset()
 
 	log := zap.New(zap.UseDevMode(true))
 	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
@@ -135,10 +136,38 @@ func TestEmitConditionMetrics_DisappearedCondition(t *testing.T) {
 
 	now := metav1.Now()
 
-	// Pre-populate the gauge for the condition that will disappear.
-	InstanceConditionCurrentStatusSeconds.WithLabelValues(
-		gvr.String(), "default", "my-app", "ResourcesReady", "True", "AllResourcesReady",
-	).Set(10)
+	// Simulates a cache/etcd divergence (e.g. a failed status write): reconcile 1's
+	// condition is cached but absent from reconcile 2's initialConditions.
+	EmitConditionMetrics(log, gvr, inst, nil, []v1alpha1.Condition{
+		{Type: "Ready", Status: metav1.ConditionFalse, Reason: strPtr("ReasonA"), LastTransitionTime: &now},
+	})
+
+	EmitConditionMetrics(log, gvr, inst, nil, []v1alpha1.Condition{
+		{Type: "Ready", Status: metav1.ConditionFalse, Reason: strPtr("ReasonB"), LastTransitionTime: &now},
+	})
+
+	got := collectorEntries(t, InstanceConditionCurrentStatusSeconds)
+	require.Len(t, got, 1, "must not strand a phantom series when the cache diverges from etcd")
+	assert.Equal(t, "ReasonB", got[0].labels["reason"], "only the latest series should remain")
+}
+
+func TestEmitConditionMetrics_DisappearedCondition(t *testing.T) {
+	InstanceConditionCurrentStatusSeconds.reset()
+
+	log := zap.New(zap.UseDevMode(true))
+	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
+	inst := &unstructured.Unstructured{}
+	inst.SetNamespace("default")
+	inst.SetName("my-app")
+
+	now := metav1.Now()
+
+	InstanceConditionCurrentStatusSeconds.Cache(conditionKey{
+		gvr:           gvr.String(),
+		namespace:     "default",
+		name:          "my-app",
+		conditionType: "ResourcesReady",
+	}, "True", "AllResourcesReady", now.Time)
 
 	initial := []v1alpha1.Condition{
 		{
@@ -152,49 +181,54 @@ func TestEmitConditionMetrics_DisappearedCondition(t *testing.T) {
 
 	EmitConditionMetrics(log, gvr, inst, initial, final)
 
-	// Gauge should be cleaned up (no series left).
-	gaugeCount := testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds)
-	assert.Equal(t, 0, gaugeCount)
-}
-
-func TestDeleteInstanceMetrics(t *testing.T) {
-	InstanceConditionCurrentStatusSeconds.Reset()
-
-	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
-	gvrKey := gvr.String()
-
-	// Populate metrics for two instances.
-	InstanceConditionCurrentStatusSeconds.WithLabelValues(gvrKey, "default", "app-1", "Ready", "True", "AllReady").Set(5)
-	InstanceConditionCurrentStatusSeconds.WithLabelValues(gvrKey, "default", "app-2", "Ready", "True", "AllReady").Set(10)
-
-	assert.Equal(t, 2, testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds))
-
-	DeleteInstanceMetrics(gvr, "default", "app-1")
-
-	// Only app-2 should remain.
-	assert.Equal(t, 1, testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds))
-}
-
-func TestDeleteGVRMetrics(t *testing.T) {
-	InstanceConditionCurrentStatusSeconds.Reset()
-
-	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
-	gvrKey := gvr.String()
-
-	// Populate metrics for two instances.
-	InstanceConditionCurrentStatusSeconds.WithLabelValues(gvrKey, "default", "app-1", "Ready", "True", "AllReady").Set(5)
-	InstanceConditionCurrentStatusSeconds.WithLabelValues(gvrKey, "default", "app-2", "Ready", "True", "AllReady").Set(10)
-
-	assert.Equal(t, 2, testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds))
-
-	DeleteGVRMetrics(gvr)
-
-	// All metrics for this GVR should be gone.
+	assert.Equal(t, 0, InstanceConditionCurrentStatusSeconds.size())
 	assert.Equal(t, 0, testutilCountMetrics(t, InstanceConditionCurrentStatusSeconds))
 }
 
+func TestDeleteInstanceMetrics(t *testing.T) {
+	InstanceConditionCurrentStatusSeconds.reset()
+
+	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
+	gvrKey := gvr.String()
+	now := time.Now()
+
+	InstanceConditionCurrentStatusSeconds.Cache(conditionKey{
+		gvr: gvrKey, namespace: "default", name: "app-1", conditionType: "Ready",
+	}, "True", "AllReady", now)
+	InstanceConditionCurrentStatusSeconds.Cache(conditionKey{
+		gvr: gvrKey, namespace: "default", name: "app-2", conditionType: "Ready",
+	}, "True", "AllReady", now)
+
+	assert.Equal(t, 2, InstanceConditionCurrentStatusSeconds.size())
+
+	DeleteInstanceMetrics(gvr, "default", "app-1")
+
+	assert.Equal(t, 1, InstanceConditionCurrentStatusSeconds.size())
+}
+
+func TestDeleteGVRMetrics(t *testing.T) {
+	InstanceConditionCurrentStatusSeconds.reset()
+
+	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
+	gvrKey := gvr.String()
+	now := time.Now()
+
+	InstanceConditionCurrentStatusSeconds.Cache(conditionKey{
+		gvr: gvrKey, namespace: "default", name: "app-1", conditionType: "Ready",
+	}, "True", "AllReady", now)
+	InstanceConditionCurrentStatusSeconds.Cache(conditionKey{
+		gvr: gvrKey, namespace: "default", name: "app-2", conditionType: "Ready",
+	}, "True", "AllReady", now)
+
+	assert.Equal(t, 2, InstanceConditionCurrentStatusSeconds.size())
+
+	DeleteGVRMetrics(gvr)
+
+	assert.Equal(t, 0, InstanceConditionCurrentStatusSeconds.size())
+}
+
 func TestEmitConditionMetrics_DurationIsPositive(t *testing.T) {
-	InstanceConditionCurrentStatusSeconds.Reset()
+	InstanceConditionCurrentStatusSeconds.reset()
 
 	log := zap.New(zap.UseDevMode(true))
 	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
@@ -215,16 +249,49 @@ func TestEmitConditionMetrics_DurationIsPositive(t *testing.T) {
 
 	EmitConditionMetrics(log, gvr, inst, initial, final)
 
-	// The gauge value should be >= 30 seconds.
-	val := testutilGetGaugeValue(t, InstanceConditionCurrentStatusSeconds, gvr.String(), "default", "my-app", "Ready", "True", "AllReady")
+	val := testutilGetCollectorValue(t, InstanceConditionCurrentStatusSeconds,
+		gvr.String(), "default", "my-app", "Ready", "True", "AllReady")
 	assert.GreaterOrEqual(t, val, 30.0)
+}
+
+func TestEmitConditionMetrics_DurationStaysAccurateBetweenReconciles(t *testing.T) {
+	InstanceConditionCurrentStatusSeconds.reset()
+
+	log := zap.New(zap.UseDevMode(true))
+	gvr := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
+	inst := &unstructured.Unstructured{}
+	inst.SetNamespace("default")
+	inst.SetName("my-app")
+
+	past := metav1.NewTime(time.Now().Add(-10 * time.Second))
+	final := []v1alpha1.Condition{
+		{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			Reason:             strPtr("AllReady"),
+			LastTransitionTime: &past,
+		},
+	}
+
+	EmitConditionMetrics(log, gvr, inst, nil, final)
+
+	val1 := testutilGetCollectorValue(t, InstanceConditionCurrentStatusSeconds,
+		gvr.String(), "default", "my-app", "Ready", "True", "AllReady")
+
+	time.Sleep(150 * time.Millisecond)
+
+	val2 := testutilGetCollectorValue(t, InstanceConditionCurrentStatusSeconds,
+		gvr.String(), "default", "my-app", "Ready", "True", "AllReady")
+
+	assert.Greater(t, val2, val1, "scrape-time duration must advance even without a reconcile")
 }
 
 func strPtr(s string) *string {
 	return &s
 }
 
-// testutilCountMetrics returns the number of active metric series in a collector.
+// testutilCountMetrics returns the number of active metric series a
+// collector emits.
 func testutilCountMetrics(t *testing.T, c prometheus.Collector) int {
 	t.Helper()
 	ch := make(chan prometheus.Metric, 100)
@@ -237,18 +304,35 @@ func testutilCountMetrics(t *testing.T, c prometheus.Collector) int {
 	return count
 }
 
-// testutilGetGaugeValue retrieves the value of a specific gauge series.
-func testutilGetGaugeValue(t *testing.T, gv *prometheus.GaugeVec, labels ...string) float64 {
+// testutilGetCollectorValue retrieves the value of a specific gauge series.
+func testutilGetCollectorValue(t *testing.T, c prometheus.Collector,
+	gvr, namespace, name, conditionType, conditionStatus, reason string) float64 {
 	t.Helper()
-	gauge, err := gv.GetMetricWithLabelValues(labels...)
-	require.NoError(t, err)
-
-	ch := make(chan prometheus.Metric, 1)
-	gauge.Collect(ch)
+	want := map[string]string{
+		labelGVR:             gvr,
+		labelNamespace:       namespace,
+		labelName:            name,
+		labelConditionType:   conditionType,
+		labelConditionStatus: conditionStatus,
+		labelReason:          reason,
+	}
+	ch := make(chan prometheus.Metric, 100)
+	c.Collect(ch)
 	close(ch)
 
-	m := <-ch
-	var dto io_prometheus_client.Metric
-	require.NoError(t, m.Write(&dto))
-	return dto.GetGauge().GetValue()
+	for m := range ch {
+		var dto io_prometheus_client.Metric
+		require.NoError(t, m.Write(&dto))
+		match := true
+		for _, lp := range dto.Label {
+			if v, ok := want[lp.GetName()]; !ok || v != lp.GetValue() {
+				match = false
+				break
+			}
+		}
+		if match && len(dto.Label) == len(want) {
+			return dto.GetGauge().GetValue()
+		}
+	}
+	return 0
 }

--- a/test/integration/suites/core/instance_custom_conditions_test.go
+++ b/test/integration/suites/core/instance_custom_conditions_test.go
@@ -272,6 +272,9 @@ var _ = Describe("Instance Custom Conditions", func() {
 			}, nil, nil),
 		)
 		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			_ = env.Client.Delete(ctx, rgd)
+		})
 
 		Eventually(func(g Gomega) {
 			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)).To(Succeed())
@@ -308,6 +311,9 @@ var _ = Describe("Instance Custom Conditions", func() {
 			}, nil, nil),
 		)
 		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			_ = env.Client.Delete(ctx, rgd)
+		})
 
 		Eventually(func(g Gomega) {
 			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)).To(Succeed())


### PR DESCRIPTION
Compute `instance_condition_current_status_seconds` at scrape time so it stays accurate while the controller is idle.

## Background

`instance_condition_current_status_seconds` was a `GaugeVec` whose value was computed at reconcile time as `time.Since(lastTransitionTime)` and stored. Since kro only runs code during reconciles, once an instance reaches steady state the stored value stops updating. It keeps reporting the duration as of the last reconcile, not the actual elapsed time:

```
T=30s   last reconcile → gauge = 30
T=630s  scrape → still reads 30   (reality: 630s in this state)
```

Metric agents like CloudWatch and Datadog read the gauge as-is, so the value must be correct when scraped. Shortening the resync period would keep it fresh but wastes API-server calls at scale, and the metric shouldn't drive reconciliation.

## Change

Back the metric with a custom `prometheus.Collector` (`durationCollector`) instead of a `GaugeVec`:

- **At reconcile time:** cache each condition's `LastTransitionTime`, keyed by `(gvr, namespace, name, condition_type)` with status and reason stored as the value. Keying by condition type keeps at most one series per condition type per instance: a status/reason change overwrites the previous entry, and a condition that disappears from the wire is evicted.
- **At scrape time:** `Collect()` computes `time.Now() - cachedTimestamp` per entry and emits it as a gauge.

The key deliberately excludes status and reason so the cache holds at most one series per condition type per instance, avoiding stale/phantom series when the cache diverges from etcd (e.g. a failed status write).

The value is derived at scrape time, so it stays accurate with no forced reconciles and no added API-server load. Timestamps are cached as a side effect of reconciles that happen anyway. The cache is in-memory derived state: on controller restart it rebuilds from etcd as instances reconcile, so values self-heal within seconds.

The metric name, labels, and semantics are unchanged. Only the computation moves from reconcile-time-stored to scrape-time-computed. `EmitConditionMetrics` now feeds the collector's cache (cache/evict) rather than setting a gauge; the GaugeVec calls (`WithLabelValues`, `DeleteLabelValues`, `DeletePartialMatch`) are replaced by `Cache`/`EvictKey`/`EvictInstance`/`EvictGVR`.

## Testing

- `duration_collector_test.go`: cache/collect, zero-timestamp handling, negative-duration clamping, the eviction paths, `Describe`, and a `-race` concurrency test (concurrent `Cache` vs `Collect`).
- A regression test asserts the value grows between two scrapes with no reconcile in between.
- A regression test asserts a status/reason change with diverged initial conditions leaves a single series (no phantom).
- `go build ./...` and `go test ./pkg/metrics/... ./pkg/controller/instance/...` pass.