### PR TITLE
set KRO version to 0.9.3

### DIFF
--- a/website/docs/docs/advanced/03-controller-tuning.md
+++ b/website/docs/docs/advanced/03-controller-tuning.md
@@ -158,8 +158,8 @@ This switches the chart to the `-debug` image tag and configures the controller 
 Use the dedicated Make targets when building or publishing the pprof-enabled image:
 
 ```bash
-make build-debug-image RELEASE_VERSION=v0.9.2
-make publish-debug-image RELEASE_VERSION=v0.9.2
+make build-debug-image RELEASE_VERSION=v0.9.3
+make publish-debug-image RELEASE_VERSION=v0.9.3
 ```
 
 If you deploy with `image.ko=true` or use `ko apply` directly, build with `GOFLAGS="-tags=pprof"` so the pprof handlers are compiled into the controller binary.

--- a/website/docs/docs/getting-started/01-Installation.md
+++ b/website/docs/docs/getting-started/01-Installation.md
@@ -36,7 +36,7 @@ Install a specific version for reproducible deployments:
 
 ```bash
 # Set the version you want to install
-export KRO_VERSION=0.9.2
+export KRO_VERSION=0.9.3
 
 # Install kro
 helm install kro oci://registry.k8s.io/kro/charts/kro \
@@ -150,7 +150,7 @@ helm upgrade kro oci://registry.k8s.io/kro/charts/kro \
   <TabItem value="specific" label="Specific Version">
 
 ```bash
-export KRO_VERSION=0.9.2
+export KRO_VERSION=0.9.3
 
 helm upgrade kro oci://registry.k8s.io/kro/charts/kro \
   --namespace kro-system \

--- a/website/versioned_docs/version-0.9.3/docs/advanced/03-controller-tuning.md
+++ b/website/versioned_docs/version-0.9.3/docs/advanced/03-controller-tuning.md
@@ -158,8 +158,8 @@ This switches the chart to the `-debug` image tag and configures the controller 
 Use the dedicated Make targets when building or publishing the pprof-enabled image:
 
 ```bash
-make build-debug-image RELEASE_VERSION=v0.9.2
-make publish-debug-image RELEASE_VERSION=v0.9.2
+make build-debug-image RELEASE_VERSION=v0.9.3
+make publish-debug-image RELEASE_VERSION=v0.9.3
 ```
 
 If you deploy with `image.ko=true` or use `ko apply` directly, build with `GOFLAGS="-tags=pprof"` so the pprof handlers are compiled into the controller binary.

--- a/website/versioned_docs/version-0.9.3/docs/getting-started/01-Installation.md
+++ b/website/versioned_docs/version-0.9.3/docs/getting-started/01-Installation.md
@@ -36,7 +36,7 @@ Install a specific version for reproducible deployments:
 
 ```bash
 # Set the version you want to install
-export KRO_VERSION=0.9.2
+export KRO_VERSION=0.9.3
 
 # Install kro
 helm install kro oci://registry.k8s.io/kro/charts/kro \
@@ -150,7 +150,7 @@ helm upgrade kro oci://registry.k8s.io/kro/charts/kro \
   <TabItem value="specific" label="Specific Version">
 
 ```bash
-export KRO_VERSION=0.9.2
+export KRO_VERSION=0.9.3
 
 helm upgrade kro oci://registry.k8s.io/kro/charts/kro \
   --namespace kro-system \


### PR DESCRIPTION
Bump KRO_VERSION 0.9.2 → 0.9.3 in live and 0.9.3 versioned docs.

Stacked on #1333 (cut docs v0.9.3) — rebase to main after that merges.